### PR TITLE
tweak radio title and description

### DIFF
--- a/src/components/organisms/RadioModal/RadioModal.tsx
+++ b/src/components/organisms/RadioModal/RadioModal.tsx
@@ -22,10 +22,9 @@ export const RadioModal: React.FunctionComponent<PropsType> = ({
 
   return (
     <div className="radio-modal-container">
-      <div className="title-radio">Burning radio</div>
+      <div className="title-radio">Shouting Fire Radio</div>
       <div className="text-radio">
-        Listen to the official Burning Man Information Radio while you explore
-        the Playa!
+        The global burner radio station piped live onto the Playa.
       </div>
       <img
         className="img-radio"


### PR DESCRIPTION
Replaces the title and the description of the Radio popup with the ones provided in ticket 216 from trello.

![radio-tweak](https://user-images.githubusercontent.com/18435853/91844582-68f31c80-ec60-11ea-9b7e-849648d9c29e.jpg)
