### PR TITLE
Remove of Camp page message at the bottom "what's on now/ loading" 

### DIFF
--- a/src/components/templates/Camp/components/RoomList.tsx
+++ b/src/components/templates/Camp/components/RoomList.tsx
@@ -38,9 +38,9 @@ export const RoomList: React.FunctionComponent<PropsType> = ({
 
   return (
     <>
-      <div>
+      {/*<div>
         <h5>{`What's on now: ${currentRooms.length} rooms open`}</h5>
-      </div>
+      </div>*/}
       <div className="rooms-container">
         {currentRooms.map((room) => (
           <RoomCard

--- a/src/components/templates/Camp/components/RoomList.tsx
+++ b/src/components/templates/Camp/components/RoomList.tsx
@@ -2,9 +2,7 @@ import React from "react";
 
 import { CampRoomData } from "types/CampRoomData";
 import RoomCard from "./RoomCard";
-import { eventHappeningNow } from "utils/event";
 import useConnectCurrentVenue from "hooks/useConnectCurrentVenue";
-import { useSelector } from "hooks/useSelector";
 
 import "../../../templates/PartyMap/components/RoomList/RoomList.scss";
 
@@ -23,14 +21,6 @@ export const RoomList: React.FunctionComponent<PropsType> = ({
 }) => {
   useConnectCurrentVenue();
 
-  const { events } = useSelector((state) => ({
-    events: state.firestore.ordered.venueEvents,
-  }));
-
-  const currentRooms = rooms.filter((room) =>
-    eventHappeningNow(room.title, events)
-  );
-
   const openModal = (room: CampRoomData) => {
     setSelectedRoom(room);
     setIsRoomModalOpen(true);
@@ -38,11 +28,8 @@ export const RoomList: React.FunctionComponent<PropsType> = ({
 
   return (
     <>
-      {/*<div>
-        <h5>{`What's on now: ${currentRooms.length} rooms open`}</h5>
-      </div>*/}
       <div className="rooms-container">
-        {currentRooms.map((room) => (
+        {rooms.map((room) => (
           <RoomCard
             key={room.title}
             room={room}

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -27,7 +27,8 @@ export const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
   }));
 
   if (!room) {
-    return <>Loading...</>;
+    // return <>Loading...</>;
+    return <></>;
   }
 
   const usersToDisplay =

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -27,7 +27,6 @@ export const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
   }));
 
   if (!room) {
-    // return <>Loading...</>;
     return <></>;
   }
 


### PR DESCRIPTION
On the Camp page- this no longer has any function in this context, so complete removal (via commenting out)
Remove the whole message at the bottom "what's on now/ loading" (you can comment it out.