### PR TITLE
Fixes for the playa and venue chat

### DIFF
--- a/src/components/molecules/Message/Message.tsx
+++ b/src/components/molecules/Message/Message.tsx
@@ -4,6 +4,7 @@ import { RestrictedChatMessage } from "components/context/ChatContext";
 import { DEFAULT_PROFILE_IMAGE } from "settings";
 import { WithId } from "utils/id";
 import { getLinkFromText } from "../../../utils/getLinkFromText";
+import { formatUtcSeconds } from "../../../utils/time";
 
 interface MessageProps {
   sender: WithId<User>;
@@ -16,19 +17,28 @@ export const Message: React.FC<MessageProps> = ({
   message,
   onClick,
 }) => {
-  const profileImageSize = 40;
+  const profileImageSize = 30;
   return (
-    <div className="message" key={`${message.from}-${message.ts_utc}`}>
-      <img
-        onClick={onClick}
-        key={`${message.from}-messaging-the-band`}
-        className="profile-icon"
-        src={sender.pictureUrl || DEFAULT_PROFILE_IMAGE}
-        title={sender.partyName}
-        alt={`${sender.partyName} profile`}
-        width={profileImageSize}
-        height={profileImageSize}
-      />
+    <div
+      className="message chat-message"
+      key={`${message.from}-${message.ts_utc}`}
+    >
+      <div className="sender-info">
+        <img
+          onClick={onClick}
+          key={`${message.from}-messaging-the-band`}
+          className="profile-icon"
+          src={sender.pictureUrl || DEFAULT_PROFILE_IMAGE}
+          title={sender.partyName}
+          alt={`${sender.partyName} profile`}
+          width={profileImageSize}
+          height={profileImageSize}
+        />
+        <div>
+          {sender.partyName}{" "}
+          <span className="timestamp">{formatUtcSeconds(message.ts_utc)}</span>
+        </div>
+      </div>
       <div className="message-bubble split-words">
         {getLinkFromText(message.text)}
       </div>

--- a/src/components/organisms/ChatDrawer/ChatDrawer.scss
+++ b/src/components/organisms/ChatDrawer/ChatDrawer.scss
@@ -51,4 +51,21 @@
     color: $primaryColor;
     font-size: 30px;
   }
+
+  .band-reaction-container {
+    &::-webkit-scrollbar-track {
+      border-radius: 3px;
+      background-color: rgba(0, 0, 0, 0);
+    }
+
+    &::-webkit-scrollbar {
+      width: 6px;
+      background-color: rgba($white, 0);
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 2px;
+      background-color: rgba($white, 0.4);
+    }
+  }
 }

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -695,12 +695,29 @@ span.link {
     padding: 10px 20px;
     border-radius: 22px;
     width: 100%;
+    word-wrap: break-word;
   }
   .message {
     display: flex;
-
     img {
       margin-right: 20px;
+    }
+    .timestamp {
+      color: $concrete;
+    }
+    &.chat-message {
+      flex-direction: column;
+      .sender-info {
+        display: flex;
+        align-items: center;
+        margin-bottom: 3px;
+        img {
+          margin-right: 10px;
+        }
+        .timestamp {
+          margin-left: 10px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes for the playa and venue chat - https://trello.com/c/M4QW5YVS
1. Show author and time of the message above the bubble next to profile pic
2. Long bubble text are displayed on multiple lines, and shared URL are broken to not bust out of the container
3. Restyled chat scrolling bar