### PR TITLE
Shouting Fire Radio fixes

### DIFF
--- a/src/components/organisms/RadioModal/RadioModal.tsx
+++ b/src/components/organisms/RadioModal/RadioModal.tsx
@@ -1,41 +1,15 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import "./RadioModal.scss";
 
 interface PropsType {
   volume: number;
   setVolume: Function;
-  sound: HTMLAudioElement | undefined;
 }
 
 export const RadioModal: React.FunctionComponent<PropsType> = ({
   volume,
   setVolume,
-  sound,
 }) => {
-  useEffect(() => {
-    sound?.play();
-  }, [sound]);
-
-  const loadedInitialState = useRef(false);
-  useEffect(() => {
-    const storageKey = "Radio";
-    if (!loadedInitialState.current) {
-      try {
-        const storedState = localStorage.getItem(storageKey);
-        if (storedState) {
-          const state = JSON.parse(storedState);
-          setVolume(state.volume);
-          loadedInitialState.current = true;
-        }
-      } catch {}
-    }
-    localStorage.setItem(storageKey, JSON.stringify({ volume }));
-  }, [volume, setVolume, sound]);
-
-  useEffect(() => {
-    if (sound) sound.volume = volume / 100;
-  }, [volume, sound]);
-
   return (
     <div className="radio-modal-container">
       <div className="title-radio">Shouting Fire Radio</div>

--- a/src/hooks/useRadio.ts
+++ b/src/hooks/useRadio.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useRadio = (audio?: HTMLAudioElement) => {
+  const [volume, setVolume] = useState<number>(10);
+
+  const loadedInitialState = useRef(false);
+  useEffect(() => {
+    const storageKey = "Radio";
+    if (!loadedInitialState.current) {
+      try {
+        const storedState = localStorage.getItem(storageKey);
+        if (storedState) {
+          const state = JSON.parse(storedState);
+          setVolume(state.volume);
+          loadedInitialState.current = true;
+        }
+      } catch {}
+    }
+    localStorage.setItem(storageKey, JSON.stringify({ volume }));
+  }, [volume]);
+
+  useEffect(() => {
+    if (audio) {
+      audio.volume = volume / 100;
+      audio?.play();
+    }
+  }, [volume, audio]);
+
+  useEffect(() => {
+    audio?.play();
+  }, [audio]);
+
+  return { volume, setVolume };
+};


### PR DESCRIPTION
https://trello.com/c/a5wZE7Y9 
1. Radio popup now opens only on first Playa visit,
2. Radio audio now starts to play upon visit the Playa with 10% volume (for the first time visitor)
3. Radio audio now resume upon subsequent visit the Playa with X% volume where X = last value set by the visitor