### PR TITLE
Fix/revert basic party modal 

### DIFF
--- a/src/components/templates/Camp/components/Map.scss
+++ b/src/components/templates/Camp/components/Map.scss
@@ -42,7 +42,7 @@ $border-radius: 28px;
   cursor: pointer;
   &:hover {
     .playa-venue-text {
-      display: block;
+      // display: block;
     }
     .playa-venue-img {
       transform: scale(1.05);

--- a/src/components/templates/Camp/components/Map.scss
+++ b/src/components/templates/Camp/components/Map.scss
@@ -42,7 +42,7 @@ $border-radius: 28px;
   cursor: pointer;
   &:hover {
     .playa-venue-text {
-      // display: block;
+      display: block;
     }
     .playa-venue-img {
       transform: scale(1.05);

--- a/src/components/templates/Camp/components/Map.scss
+++ b/src/components/templates/Camp/components/Map.scss
@@ -104,7 +104,7 @@ $border-radius: 28px;
     width: 300px;
     height: auto;
     transition: height 400ms cubic-bezier(0.23, 1, 0.32, 1);
-    display: none;
+    display: block;
     .playa-venue-maininfo {
       display: flex;
       align-items: center;

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -90,7 +90,7 @@ export const Map: React.FC<PropsType> = ({
                     alt={room.title}
                   />
                 </div>
-                <div className={IS_BURN ? `playa-venue-text` : ``}>
+                <div className={`playa-venue-text`}>
                   <div className="playa-venue-maininfo">
                     <div className="playa-venue-title">{room.title}</div>
                     <div className="playa-venue-people">

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -4,7 +4,6 @@ import { CampRoomData } from "types/CampRoomData";
 import "./Map.scss";
 import { enterRoom } from "../../../../utils/useLocationUpdateEffect";
 import { useUser } from "../../../../hooks/useUser";
-import RoomCard from "./RoomCard";
 import { IS_BURN } from "secrets";
 
 interface PropsType {
@@ -76,6 +75,9 @@ export const Map: React.FC<PropsType> = ({
                     prevRoomClicked === room.title ? undefined : room.title
                   );
                 }
+              }}
+              onMouseEnter={() => {
+                IS_BURN && setRoomHovered(room.title);
               }}
             >
               <div

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -4,6 +4,7 @@ import { CampRoomData } from "types/CampRoomData";
 import "./Map.scss";
 import { enterRoom } from "../../../../utils/useLocationUpdateEffect";
 import { useUser } from "../../../../hooks/useUser";
+import RoomCard from "./RoomCard";
 import { IS_BURN } from "secrets";
 
 interface PropsType {
@@ -44,6 +45,10 @@ export const Map: React.FC<PropsType> = ({
   const roomEnter = (room: CampRoomData) => {
     room && user && enterRoom(user, room.title);
   };
+  const openModal = (room: CampRoomData) => {
+    setSelectedRoom(room);
+    setIsRoomModalOpen(true);
+  };
 
   return (
     <>
@@ -64,17 +69,13 @@ export const Map: React.FC<PropsType> = ({
               }}
               key={room.title}
               onClick={() => {
-                if (IS_BURN) {
-                  setSelectedRoom(room);
-                  setIsRoomModalOpen(true);
+                if (!IS_BURN) {
+                  openModal(room);
                 } else {
                   setRoomClicked((prevRoomClicked) =>
                     prevRoomClicked === room.title ? undefined : room.title
                   );
                 }
-              }}
-              onMouseEnter={() => {
-                IS_BURN && setRoomHovered(room.title);
               }}
             >
               <div

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -90,7 +90,7 @@ export const Map: React.FC<PropsType> = ({
                     alt={room.title}
                   />
                 </div>
-                <div className={`playa-venue-text`}>
+                <div className={IS_BURN ? `playa-venue-text` : ``}>
                   <div className="playa-venue-maininfo">
                     <div className="playa-venue-title">{room.title}</div>
                     <div className="playa-venue-people">

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -25,7 +25,7 @@ export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
 
   return (
     <div className="room-modal-ongoing-event-container">
-      {eventToDisplay && currentEvent && (
+      {eventToDisplay && (
         <>
           <div className="title-container">
             <img
@@ -34,25 +34,6 @@ export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
               alt="sparkle-icon"
             />
             {whatsOnText}
-          </div>
-          <div className="artist-ongoing-container">
-            <div className="event-title">{eventToDisplay.name}</div>
-            <div>
-              by <span className="artist-name">{eventToDisplay.host}</span>
-            </div>
-          </div>
-          <div className="event-description">{eventToDisplay.description}</div>
-        </>
-      )}
-      {eventToDisplay && !currentEvent && (
-        <>
-          <div className="title-container">
-            <img
-              src="/sparkle-icon.png"
-              className="sparkle-icon"
-              alt="sparkle-icon"
-            />
-            What's on next
           </div>
           <div className="artist-ongoing-container">
             <div className="event-title">{eventToDisplay.name}</div>

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -23,7 +23,7 @@ export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
     (currentEvent ? currentEvent : roomEvents[0]);
   return (
     <div className="room-modal-ongoing-event-container">
-      {eventToDisplay && (
+      {eventToDisplay && currentEvent && (
         <>
           <div className="title-container">
             <img
@@ -40,18 +40,49 @@ export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
             </div>
           </div>
           <div className="event-description">{eventToDisplay.description}</div>
-          <a
-            className="btn btn-primary room-entry-button"
-            onClick={() => enterRoom()}
-            id={`enter-room-in-ongoing-event-card-${room.title}`}
-            href={room.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Join the room
-          </a>
         </>
       )}
+      {eventToDisplay && !currentEvent && (
+        <>
+          <div className="title-container">
+            <img
+              src="/sparkle-icon.png"
+              className="sparkle-icon"
+              alt="sparkle-icon"
+            />
+            What's on next
+          </div>
+          <div className="artist-ongoing-container">
+            <div className="event-title">{eventToDisplay.name}</div>
+            <div>
+              by <span className="artist-name">{eventToDisplay.host}</span>
+            </div>
+          </div>
+          <div className="event-description">{eventToDisplay.description}</div>
+        </>
+      )}
+      {!eventToDisplay && (
+        <>
+          <div className="event-description">
+            <img
+              src="/sparkle-icon.png"
+              className="sparkle-icon"
+              alt="sparkle-icon"
+            />
+            No events scheduled
+          </div>
+        </>
+      )}
+      <a
+        className="btn btn-primary room-entry-button"
+        onClick={() => enterRoom()}
+        id={`enter-room-in-ongoing-event-card-${room.title}`}
+        href={room.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Join the room
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
https://trello.com/c/QoSq0lTJ/8-make-basic-party-map-modals-become-the-full-black-popup-as-before

Fix to make a onClick from map to show the same modal as room-list, whilst keeping IS_BURN logic the same.