### PR TITLE
add disable option to location update

### DIFF
--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -16,7 +16,10 @@ import { VenueTemplate } from "types/VenueTemplate";
 import { hasUserBoughtTicketForEvent } from "utils/hasUserBoughtTicket";
 import { isUserAMember } from "utils/isUserAMember";
 import { canUserJoinTheEvent, ONE_MINUTE_IN_SECONDS } from "utils/time";
-import { useLocationUpdateEffect } from "utils/useLocationUpdateEffect";
+import {
+  updateLocationData,
+  useLocationUpdateEffect,
+} from "utils/useLocationUpdateEffect";
 import { updateTheme } from "./helpers";
 import "./VenuePage.scss";
 import { PlayaRouter } from "components/templates/Playa/Router";
@@ -80,14 +83,21 @@ const VenuePage = () => {
   const venueName = venue && venue.name;
   // Camp and PartyMap needs to be able to modify this
   // Currently does not work with roome
-  useLocationUpdateEffect(
-    user,
-    venueName
-      ? venueName
-      : profile && profile.lastSeenIn
-      ? profile.lastSeenIn
-      : ""
-  );
+  const isVenueRoom = !!venue?.rooms?.filter(
+    (room) => room.title === profile?.room
+  ).length;
+  const profileRoom = profile?.room;
+  const location =
+    venueName === profileRoom
+      ? venueName ?? ""
+      : isVenueRoom
+      ? profileRoom ?? ""
+      : venueName ?? "";
+  useLocationUpdateEffect(user, location);
+
+  if (!profileRoom && user) {
+    updateLocationData(user, location);
+  }
 
   const venueIdFromParams = getQueryParameters(window.location.search)
     ?.venueId as string;

--- a/src/types/Venue.ts
+++ b/src/types/Venue.ts
@@ -68,6 +68,7 @@ export interface Venue {
   profileAvatars?: boolean;
   hideVideo?: boolean;
   showLiveSchedule?: boolean;
+  rooms?: any[];
 }
 
 export interface VenuePlacement {

--- a/src/utils/useLocationUpdateEffect.ts
+++ b/src/utils/useLocationUpdateEffect.ts
@@ -25,18 +25,6 @@ export const useLocationUpdateEffect = (
   roomName: string
 ) => {
   useEffect(() => {
-    if (!user || !roomName) return;
-
-    updateLocationData(user, roomName);
-    const intervalId = setInterval(
-      () => updateLocationData(user, roomName),
-      5 * 60 * 1000
-    );
-
-    return () => clearInterval(intervalId);
-  }, [user, roomName]);
-
-  useEffect(() => {
     // Time spent is currently counted multiple time if multiple tabs are open
     if (!user || !roomName) return;
 


### PR DESCRIPTION
- Remove updateLocationData from the hook because it was running on every tab
- Conditionally update the location of the profile only when it's not available in the firebase