### PR TITLE
fix event creation in admin

### DIFF
--- a/src/pages/Admin/AdminEventModal.tsx
+++ b/src/pages/Admin/AdminEventModal.tsx
@@ -104,6 +104,7 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
     },
     [event, onHide, venueId, template]
   );
+
   return (
     <Modal show={show} onHide={onHide}>
       <div className="form-container">
@@ -199,7 +200,7 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
                 className="input-block input-centered"
                 placeholder="Cuddle Puddle"
                 ref={register}
-                value={roomName && roomName}
+                value={roomName}
               />
               {errors.host && (
                 <span className="input-error">{errors.host.message}</span>
@@ -234,7 +235,7 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
 };
 
 AdminEventModal.defaultProps = {
-  roomName: "",
+  roomName: undefined,
 };
 
 export default AdminEventModal;


### PR DESCRIPTION
The default value was empty string and that was always being send to the firebase, now its undefined and the component can trigger onChange correctly when the user is typing