### PR TITLE
change chat hover color to make text visible

### DIFF
--- a/src/components/molecules/PrivateRecipientSearchInput/PrivateRecipientSearchInput.scss
+++ b/src/components/molecules/PrivateRecipientSearchInput/PrivateRecipientSearchInput.scss
@@ -5,7 +5,7 @@
     text-decoration: none;
 
     &:hover {
-      background: $primaryColor;
+      background: darken($dark, 10);
     }
   }
 


### PR DESCRIPTION
The hover color "$primary" was yellow and the text was white which was hard to read. Now it's $dark + darken because the background itself is $dark