### PR TITLE
Fix: avatar being displayed as background image instead of as img tag…

### DIFF
--- a/src/components/molecules/UserList/UserList.tsx
+++ b/src/components/molecules/UserList/UserList.tsx
@@ -1,12 +1,22 @@
 import React, { useState } from "react";
+
+// Components
 import UserProfileModal from "components/organisms/UserProfileModal";
-import { User } from "types/User";
-import "./UserList.scss";
 import UserProfilePicture from "components/molecules/UserProfilePicture";
+
+// Hooks
 import { useSelector } from "hooks/useSelector";
+
+// Utils | Settings | Constants
 import { WithId } from "utils/id";
-import { DEFAULT_USER_LIST_LIMIT } from "../../../settings";
+import { DEFAULT_USER_LIST_LIMIT } from "settings";
 import { IS_BURN } from "secrets";
+
+// Typings
+import { User } from "types/User";
+
+// Styles
+import "./UserList.scss";
 
 interface PropsType {
   users: Array<WithId<User>>;
@@ -67,7 +77,6 @@ const UserList: React.FunctionComponent<PropsType> = ({
                 <UserProfilePicture
                   user={user}
                   setSelectedUserProfile={setSelectedUserProfile}
-                  imageSize={imageSize}
                   isAudioEffectDisabled={isAudioEffectDisabled}
                   key={`${user.id}-${activity}-${imageSize}`}
                 />

--- a/src/components/organisms/PrivateChatModal/PrivateChatModal.tsx
+++ b/src/components/organisms/PrivateChatModal/PrivateChatModal.tsx
@@ -1,18 +1,28 @@
 import React, { useState } from "react";
-import "./PrivateChatModal.scss";
-import { PrivateChatMessage } from "components/context/ChatContext";
-import UserProfilePicture from "components/molecules/UserProfilePicture";
-import Chatbox from "components/organisms/Chatbox";
-import { formatUtcSeconds } from "utils/time";
-import { User } from "types/User";
-import { setPrivateChatMessageIsRead } from "./helpers";
+
+// Components
 import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PrivateChatMessage } from "components/context/ChatContext";
+import Chatbox from "components/organisms/Chatbox";
 import PrivateRecipientSearchInput from "components/molecules/PrivateRecipientSearchInput";
-import { useUser } from "hooks/useUser";
+import UserProfilePicture from "components/molecules/UserProfilePicture";
+
+// Hooks
 import { useSelector } from "hooks/useSelector";
-import { WithId } from "utils/id";
+import { useUser } from "hooks/useUser";
+
+// Utils | Settings | Constants
 import { DEFAULT_PARTY_NAME } from "settings";
+import { formatUtcSeconds } from "utils/time";
+import { setPrivateChatMessageIsRead } from "./helpers";
+import { WithId } from "utils/id";
+
+// Typings
+import { User } from "types/User";
+
+// Styles
+import "./PrivateChatModal.scss";
 
 interface LastMessageByUser {
   [userId: string]: PrivateChatMessage;
@@ -104,7 +114,6 @@ const PrivateChatModal: React.FunctionComponent = () => {
                     <UserProfilePicture
                       user={sender}
                       setSelectedUserProfile={() => null}
-                      imageSize={50}
                     />
                     <div className="sender-info-container">
                       <div className="sender-party-name">

--- a/src/components/organisms/Room/Participant.tsx
+++ b/src/components/organisms/Room/Participant.tsx
@@ -1,17 +1,21 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
-import UserProfileModal from "components/organisms/UserProfileModal";
+
+// Components
 import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import UserProfileModal from "components/organisms/UserProfileModal";
 import UserProfilePicture from "components/molecules/UserProfilePicture";
 import Video from "twilio-video";
+
+// Typings
 import { User } from "types/User";
 
 export interface ParticipantProps {
+  bartender?: User;
+  defaultMute?: boolean;
   participant: Video.Participant;
   profileData: User;
   profileDataId: string;
-  bartender?: User;
-  defaultMute?: boolean;
 }
 
 type VideoTracks = Array<Video.LocalVideoTrack | Video.RemoteVideoTrack>;
@@ -129,7 +133,6 @@ const Participant: React.FC<React.PropsWithChildren<ParticipantProps>> = ({
         <UserProfilePicture
           user={{ ...profileData, id: participant.identity }}
           setSelectedUserProfile={() => setShowProfile(true)}
-          imageSize={40}
         />
       </div>
       <UserProfileModal

--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -200,8 +200,11 @@ $light: #ffffff;
   }
 
   .profile-avatar {
-    border-radius: 100%;
     width: 100%;
     height: 100%;
+
+    border-radius: 100%;
+    background-size: cover;
+    background-position: center;
   }
 }

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -385,7 +385,6 @@ export const Audience: React.FunctionComponent<PropsType> = () => {
                                   }
                                   miniAvatars={venue.miniAvatars}
                                   isAudioEffectDisabled={isAudioEffectDisabled}
-                                  imageSize={undefined}
                                 />
                               </div>
                             )}

--- a/src/components/templates/AvatarGrid/AvatarGrid.tsx
+++ b/src/components/templates/AvatarGrid/AvatarGrid.tsx
@@ -1,21 +1,27 @@
-import UserProfilePicture from "components/molecules/UserProfilePicture";
+import React, { useCallback, useEffect, useState } from "react";
 import firebase from "firebase/app";
+
+// Components
+import { RoomModal } from "./RoomModal";
+import Announcement from "./Announcement";
+import ChatDrawer from "components/organisms/ChatDrawer";
+import UserProfileModal from "components/organisms/UserProfileModal";
+import UserProfilePicture from "components/molecules/UserProfilePicture";
+
+// Hooks
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
-import React, { useCallback, useEffect, useState } from "react";
-import { WithId } from "utils/id";
-import { User } from "types/User";
-import "./AvatarGrid.scss";
-import UserProfileModal from "components/organisms/UserProfileModal";
-import { AvatarGridRoom } from "types/AvatarGrid";
-import Announcement from "./Announcement";
-import { RoomModal } from "./RoomModal";
-import ChatDrawer from "components/organisms/ChatDrawer";
 import { useVenueId } from "hooks/useVenueId";
 
-type Props = {
-  venueName: string;
-};
+// Utils | Settings | Constants
+import { WithId } from "utils/id";
+
+// Typings
+import { AvatarGridRoom } from "types/AvatarGrid";
+import { User } from "types/User";
+
+// Styles
+import "./AvatarGrid.scss";
 
 const DEFAULT_COLUMNS = 40;
 const DEFAULT_ROWS = 25;
@@ -327,7 +333,6 @@ const AvatarGrid = () => {
                             profileStyle={"profile-avatar"}
                             setSelectedUserProfile={setSelectedUserProfile}
                             miniAvatars={venue?.miniAvatars}
-                            imageSize={undefined}
                           />
                         </div>
                       )}

--- a/src/components/templates/AvatarGrid/RoomModal.tsx
+++ b/src/components/templates/AvatarGrid/RoomModal.tsx
@@ -1,21 +1,33 @@
 import React from "react";
-import { enterRoom } from "utils/useLocationUpdateEffect";
-import { useUser } from "hooks/useUser";
+
+// Components
 import { Modal } from "react-bootstrap";
-import { AvatarGridRoom } from "types/AvatarGrid";
-import "./RoomModal.scss";
-import "./AvatarGrid.scss";
 import UserProfilePicture from "components/molecules/UserProfilePicture";
+
+// Hooks
+import { useDispatch } from "hooks/useDispatch";
 import { useSelector } from "hooks/useSelector";
+import { useUser } from "hooks/useUser";
+
+// Utils | Settings | Constants
+import { isEventLive } from "utils/event";
 import {
   currentTimeInUnixEpoch,
   formatUtcSeconds,
   getCurrentTimeInUTCSeconds,
   ONE_MINUTE_IN_SECONDS,
 } from "utils/time";
-import { isEventLive } from "utils/event";
-import { useDispatch } from "hooks/useDispatch";
+import { enterRoom } from "utils/useLocationUpdateEffect";
+
+// Typings
+import { AvatarGridRoom } from "types/AvatarGrid";
+
+// Reducer | Actions
 import { retainAttendance } from "store/actions/Attendance";
+
+// Styles
+import "./RoomModal.scss";
+import "./AvatarGrid.scss";
 
 interface PropsType {
   show: boolean;
@@ -84,7 +96,6 @@ export const RoomModal: React.FC<PropsType> = ({
                     profileStyle={"profile-avatar"}
                     setSelectedUserProfile={() => {}}
                     miniAvatars={miniAvatars}
-                    imageSize={undefined}
                   />
                 </div>
               )


### PR DESCRIPTION
- [x] Avatar showing as background-image in _div_ instead of as a _img_
- [ ] Image not having its dimensions distorted

- Code cleanup
- Memoizing _UserProfilePicture_ component render, to reduce re-render amount
- _avatarSrc_ function wrapped in _useCallback_ to reduce re-render amount
