### PR TITLE
fix redirect after account creation

### DIFF
--- a/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
+++ b/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
@@ -2,12 +2,13 @@ import firebase from "firebase/app";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { CodeOfConductFormData } from "pages/Account/CodeOfConduct";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { CODE_CHECK_URL } from "secrets";
 import axios from "axios";
 import { updateUserPrivate } from "pages/Account/helpers";
 import { IS_BURN } from "secrets";
 import { TICKET_URL } from "settings";
+import { useKeyedSelector } from "hooks/useSelector";
 
 interface PropsType {
   displayLoginForm: () => void;
@@ -56,7 +57,14 @@ const RegisterForm: React.FunctionComponent<PropsType> = ({
   closeAuthenticationModal,
 }) => {
   const history = useHistory();
-  const { venueId } = useParams();
+  const { currentVenue } = useKeyedSelector(
+    (state) => ({
+      currentVenue: state.firestore.ordered.currentVenue ?? {},
+    }),
+    ["currentVenue"]
+  );
+
+  const venueName = currentVenue[0]?.name;
 
   const signUp = ({ email, password }: RegisterFormData) => {
     return firebase.auth().createUserWithEmailAndPassword(email, password);
@@ -84,11 +92,10 @@ const RegisterForm: React.FunctionComponent<PropsType> = ({
       }
       afterUserIsLoggedIn && afterUserIsLoggedIn();
       closeAuthenticationModal();
-      history.push(
-        IS_BURN
-          ? "/enter/step2"
-          : `/account/questions?venueId=${venueId}&returnUrl=${window.location.pathname}${window.location.search}`
-      );
+      const accountProfileUrl = `/account/profile${
+        venueName ? `?venueId=${venueName}` : ""
+      }`;
+      history.push(IS_BURN ? "/enter/step2" : accountProfileUrl);
     } catch (error) {
       if (error.response?.status === 404) {
         setError(

--- a/src/pages/Account/CodeOfConduct.tsx
+++ b/src/pages/Account/CodeOfConduct.tsx
@@ -67,13 +67,12 @@ const CodeOfConduct: React.FunctionComponent<PropsType> = ({ location }) => {
   });
 
   const proceed = () => {
-    history.push(
-      returnUrl
-        ? returnUrl.toString()
-        : venueId
-        ? venueInsideUrl(venueId.toString())
-        : ""
-    );
+    const nextUrl = venueId
+      ? venueInsideUrl(venueId.toString())
+      : returnUrl
+      ? returnUrl.toString()
+      : "";
+    history.push(nextUrl);
   };
 
   const onSubmit = async (data: CodeOfConductFormData) => {
@@ -105,33 +104,34 @@ const CodeOfConduct: React.FunctionComponent<PropsType> = ({ location }) => {
       <div className="login-container">
         <h2>Final step: agree to our code of conduct</h2>
         <form onSubmit={handleSubmit(onSubmit)} className="form">
-          {codeOfConductQuestions.map((q) => (
-            <div className="input-group" key={q.name}>
-              <label
-                htmlFor={q.name}
-                className={`checkbox ${watch(q.name) && "checkbox-checked"}`}
-              >
-                {q.link && (
-                  <a href={q.link} target="_blank" rel="noopener noreferrer">
-                    {q.text}
-                  </a>
+          {codeOfConductQuestions &&
+            codeOfConductQuestions.map((q) => (
+              <div className="input-group" key={q.name}>
+                <label
+                  htmlFor={q.name}
+                  className={`checkbox ${watch(q.name) && "checkbox-checked"}`}
+                >
+                  {q.link && (
+                    <a href={q.link} target="_blank" rel="noopener noreferrer">
+                      {q.text}
+                    </a>
+                  )}
+                  {!q.link && q.text}
+                </label>
+                <input
+                  type="checkbox"
+                  name={q.name}
+                  id={q.name}
+                  ref={register({
+                    required: true,
+                  })}
+                />
+                {/* @ts-ignore @debt questions should be typed if possible */}
+                {q.name in errors && errors[q.name].type === "required" && (
+                  <span className="input-error">Required</span>
                 )}
-                {!q.link && q.text}
-              </label>
-              <input
-                type="checkbox"
-                name={q.name}
-                id={q.name}
-                ref={register({
-                  required: true,
-                })}
-              />
-              {/* @ts-ignore @debt questions should be typed if possible */}
-              {q.name in errors && errors[q.name].type === "required" && (
-                <span className="input-error">Required</span>
-              )}
-            </div>
-          ))}
+              </div>
+            ))}
 
           <input
             className="btn btn-primary btn-block btn-centered"

--- a/src/pages/Account/Profile.tsx
+++ b/src/pages/Account/Profile.tsx
@@ -8,9 +8,9 @@ import ProfilePictureInput from "components/molecules/ProfilePictureInput";
 import { RouterLocation } from "types/RouterLocation";
 import { useUser } from "hooks/useUser";
 import { IS_BURN } from "secrets";
-import { venueInsideUrl } from "utils/url";
 import getQueryParameters from "utils/getQueryParameters";
 import { DEFAULT_VENUE, PLAYA_VENUE_NAME } from "settings";
+import { useVenueId } from "hooks/useVenueId";
 
 export interface ProfileFormData {
   partyName: string;
@@ -24,12 +24,11 @@ interface PropsType {
 const Profile: React.FunctionComponent<PropsType> = ({ location }) => {
   const history = useHistory();
   const { user } = useUser();
+  const venueName = useVenueId();
   const venueId =
+    venueName ??
     getQueryParameters(window.location.search)?.venueId?.toString() ??
     DEFAULT_VENUE;
-  const returnUrl = getQueryParameters(
-    window.location.search
-  )?.returnUrl?.toString();
 
   const {
     register,
@@ -45,9 +44,9 @@ const Profile: React.FunctionComponent<PropsType> = ({ location }) => {
   const onSubmit = async (data: ProfileFormData) => {
     if (!user) return;
     await updateUserProfile(user.uid, data);
-    history.push(
-      IS_BURN ? `/enter/step3` : returnUrl ? returnUrl : venueInsideUrl(venueId)
-    );
+    const accountQuestionsUrl = `/account/questions?venueId=${venueId}&returnUrl=${window.location.pathname}${window.location.search}`;
+    const nextUrl = venueId ? accountQuestionsUrl : `/${DEFAULT_VENUE}`;
+    history.push(IS_BURN ? `/enter/step3` : nextUrl);
   };
 
   const pictureUrl = watch("pictureUrl");

--- a/src/pages/VenueLandingPage/VenueLandingPage.tsx
+++ b/src/pages/VenueLandingPage/VenueLandingPage.tsx
@@ -24,7 +24,7 @@ import { WithId } from "utils/id";
 import { isUserAMember } from "utils/isUserAMember";
 import { ONE_MINUTE_IN_SECONDS } from "utils/time";
 import "./VenueLandingPage.scss";
-import { venueEntranceUrl } from "utils/url";
+import { venueEntranceUrl, venueInsideUrl } from "utils/url";
 
 export interface VenueLandingPageProps {
   venue: Firestore["data"]["currentVenue"];
@@ -112,6 +112,14 @@ export const VenueLandingPage: React.FunctionComponent<VenueLandingPageProps> = 
     setIsAuthenticationModalOpen(false);
   };
 
+  const onJoinClick = () => {
+    const venueEntrance = venue.entrance && venue.entrance.length;
+    window.location.href =
+      user && !venueEntrance
+        ? venueInsideUrl(venueId)
+        : venueEntranceUrl(venueId);
+  };
+
   return (
     <WithNavigationBar>
       <div className="container venue-entrance-experience-container">
@@ -149,7 +157,7 @@ export const VenueLandingPage: React.FunctionComponent<VenueLandingPageProps> = 
             futureOrOngoingVenueEvents.length === 0) && (
             <button
               className="btn btn-primary btn-block btn-centered"
-              onClick={() => (window.location.href = venueEntranceUrl(venueId))}
+              onClick={onJoinClick}
             >
               Join the event
             </button>


### PR DESCRIPTION
- Move returnUrl logic one step deeper to avoid the direct back to the first step
- Make join event button redirect directly to /in/ instead of entrance page
- Add account profile page to the registration flow because it was missing in some of the cases