### PR TITLE
Fix: iframe URL updates when the venues iframeUrl changes either via …

### DIFF
--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -147,7 +147,9 @@ export const Audience: React.FunctionComponent = () => {
       .firestore()
       .collection("venues")
       .doc(venueId as string)
-      .onSnapshot((doc) => setIframeUrl(ConvertToEmbeddableUrl(doc.data()?.iframeUrl || "", true)));
+      .onSnapshot((doc) =>
+        setIframeUrl(ConvertToEmbeddableUrl(doc.data()?.iframeUrl || "", true))
+      );
   }, [venueId]);
 
   const experienceContext = useContext(ExperienceContext);
@@ -436,17 +438,18 @@ export const Audience: React.FunctionComponent = () => {
   }, [
     auditoriumSize,
     venue,
-    selectedUserProfile,
-    user,
     profile,
     venueId,
+    iframeUrl,
+    isAudioEffectDisabled,
+    handleSubmit,
+    register,
+    isShoutSent,
+    selectedUserProfile,
+    user,
+    experienceContext,
+    reset,
     reactionClicked,
     partygoersBySeat,
-    handleSubmit,
-    isShoutSent,
-    isAudioEffectDisabled,
-    experienceContext,
-    register,
-    reset,
   ]);
 };

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -140,6 +140,16 @@ export const Audience: React.FunctionComponent = () => {
   >();
   const [isAudioEffectDisabled, setIsAudioEffectDisabled] = useState(false);
 
+  const [iframeUrl, setIframeUrl] = useState<string>("");
+
+  useEffect(() => {
+    firebase
+      .firestore()
+      .collection("venues")
+      .doc(venueId as string)
+      .onSnapshot((doc) => setIframeUrl(ConvertToEmbeddableUrl(doc.data()?.iframeUrl || "", true)));
+  }, [venueId]);
+
   const experienceContext = useContext(ExperienceContext);
   const createReaction = (reaction: ReactionType, user: UserInfo) => ({
     created_at: new Date().getTime(),
@@ -273,8 +283,6 @@ export const Audience: React.FunctionComponent = () => {
     const userSeated =
       typeof profile.data?.[venueId]?.row === "number" &&
       typeof profile.data?.[venueId]?.row === "number";
-
-    const iframeUrl = ConvertToEmbeddableUrl(venue.iframeUrl, true);
 
     return (
       <>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "dom.iterable",
       "esnext"
     ],
+    "types": [],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Using Firestores _onSnapshot_, audiance `iframeUrl` property updates automatically when the venue.iframeUrl changes.

Tested by changing URL in _/admin_ panel of the venue and by direct change in _firestore_