### PR TITLE
fix first child ui bug when grid is missing

### DIFF
--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -387,8 +387,7 @@ export const Map: React.FC<PropsType> = ({
           gridTemplateRows: `repeat(${templateRows}, 1fr)`,
         }}
       >
-        {venue.showGrid &&
-          rows &&
+        {venue.showGrid && rows ? (
           Array.from(Array(columns)).map((_, colIndex) => {
             return (
               <div className="seat-column" key={`column${colIndex}`}>
@@ -466,7 +465,10 @@ export const Map: React.FC<PropsType> = ({
                   })}
               </div>
             );
-          })}
+          })
+        ) : (
+          <div />
+        )}
         {!!rooms.length &&
           rooms.map((room) => {
             const left = room.x_percent;


### PR DESCRIPTION
There is css which adds padding to the first child of the grid and when the grid is missing this breaks the first room UI in the array. This fixes the issue by conditionally rendering a div when the grid is missing.