### PR TITLE
'Large Party Map' Performance - Part 1/x

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "eject": "react-scripts eject",
     "deploy": "npm run build && firebase deploy",
     "cy:install": "cypress install",
-    "cy:run": "cypress run"
+    "cy:run": "cypress run",
+    "firebase": "npx --no-install -- firebase",
+    "firebase:emulate-functions": "npm run firebase -- emulators:start --only functions"
   },
   "proxy": "http://localhost:3001",
   "browserslist": {

--- a/src/components/context/ChatContext.tsx
+++ b/src/components/context/ChatContext.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from "react";
 import { useFirestoreConnect } from "react-redux-firebase";
+
 import firebase from "firebase/app";
+
+import { currentVenueNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
 import { useSelector } from "hooks/useSelector";
 
 interface ChatContextType {
@@ -80,11 +83,7 @@ function buildMessage(data: MessageBuilderInput): ChatMessage {
 export const ChatContextWrapper: React.FC<React.PropsWithChildren<{}>> = ({
   children,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0],
-  }));
-
-  const chatCollectionName = `venues/${venue.id}/chats`;
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
 
   useFirestoreConnect({
     collection: "venues",
@@ -92,6 +91,8 @@ export const ChatContextWrapper: React.FC<React.PropsWithChildren<{}>> = ({
     subcollections: [{ collection: "chats" }],
     storeAs: "venueChats",
   });
+
+  const chatCollectionName = `venues/${venue.id}/chats`;
 
   const sendGlobalChat = useCallback(
     (from, text) => {

--- a/src/components/molecules/CountDown/CountDown.tsx
+++ b/src/components/molecules/CountDown/CountDown.tsx
@@ -6,7 +6,7 @@ interface PropsType {
   textBeforeCountdown?: string;
 }
 
-const CountDown: React.FunctionComponent<PropsType> = ({
+export const CountDown: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   textBeforeCountdown,
 }) => {
@@ -21,4 +21,7 @@ const CountDown: React.FunctionComponent<PropsType> = ({
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default CountDown;

--- a/src/components/molecules/CountDown/index.ts
+++ b/src/components/molecules/CountDown/index.ts
@@ -1,1 +1,6 @@
+export { CountDown } from "./CountDown";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./CountDown";

--- a/src/components/organisms/AuthenticationModal/AuthenticationModal.tsx
+++ b/src/components/organisms/AuthenticationModal/AuthenticationModal.tsx
@@ -12,7 +12,7 @@ interface PropsType {
   showAuth: "login" | "register" | "passwordReset";
 }
 
-const AuthenticationModal: React.FunctionComponent<PropsType> = ({
+export const AuthenticationModal: React.FunctionComponent<PropsType> = ({
   show,
   onHide,
   afterUserIsLoggedIn,
@@ -67,4 +67,7 @@ const AuthenticationModal: React.FunctionComponent<PropsType> = ({
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default AuthenticationModal;

--- a/src/components/organisms/AuthenticationModal/index.ts
+++ b/src/components/organisms/AuthenticationModal/index.ts
@@ -1,1 +1,6 @@
+export { AuthenticationModal } from "./AuthenticationModal";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./AuthenticationModal";

--- a/src/components/organisms/UserProfileModal/UserProfileModal.tsx
+++ b/src/components/organisms/UserProfileModal/UserProfileModal.tsx
@@ -19,6 +19,7 @@ import { useFirestoreConnect } from "react-redux-firebase";
 import { AnyVenue } from "types/Firestore";
 import { CampRoomData } from "types/CampRoomData";
 import { IS_BURN } from "secrets";
+import { venuesOrderedSelector } from "utils/selectors";
 
 type fullUserProfile =
   | { userProfile?: WithId<User> }
@@ -138,7 +139,7 @@ const Badges: React.FC<{ user: WithId<User> }> = ({ user }) => {
   const visits = useSelector(
     (state) => state.firestore.ordered.userModalVisits
   );
-  const venues = useSelector((state) => state.firestore.ordered.venues);
+  const venues = useSelector(venuesOrderedSelector);
 
   const playaTime = useMemo(() => {
     if (!visits) return undefined;

--- a/src/components/organisms/WithNavigationBar/WithNavigationBar.tsx
+++ b/src/components/organisms/WithNavigationBar/WithNavigationBar.tsx
@@ -8,7 +8,7 @@ interface PropsType {
   fullscreen?: boolean;
 }
 
-const WithNavigationBar: React.FunctionComponent<PropsType> = ({
+export const WithNavigationBar: React.FunctionComponent<PropsType> = ({
   redirectionUrl,
   fullscreen,
   children,
@@ -21,4 +21,7 @@ const WithNavigationBar: React.FunctionComponent<PropsType> = ({
   </>
 );
 
+/**
+ * @deprecated use named export instead
+ */
 export default WithNavigationBar;

--- a/src/components/organisms/WithNavigationBar/index.ts
+++ b/src/components/organisms/WithNavigationBar/index.ts
@@ -1,1 +1,6 @@
+export { WithNavigationBar } from "./WithNavigationBar";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./WithNavigationBar";

--- a/src/components/templates/ArtPiece/ArtPiece.tsx
+++ b/src/components/templates/ArtPiece/ArtPiece.tsx
@@ -13,7 +13,7 @@ import { IS_BURN } from "secrets";
 import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
 import BannerMessage from "components/molecules/BannerMessage";
 
-const ArtPiece = () => {
+export const ArtPiece = () => {
   const { venue } = useSelector((state) => ({
     venue: state.firestore.data.currentVenue,
   }));
@@ -89,4 +89,7 @@ const ArtPiece = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default ArtPiece;

--- a/src/components/templates/ArtPiece/index.ts
+++ b/src/components/templates/ArtPiece/index.ts
@@ -1,1 +1,6 @@
+export { ArtPiece } from "./ArtPiece";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./ArtPiece";

--- a/src/components/templates/Audience/AudienceRouter.tsx
+++ b/src/components/templates/Audience/AudienceRouter.tsx
@@ -6,7 +6,7 @@ import { Venue } from "types/Venue";
 import { ExperienceContextWrapper } from "components/context/ExperienceContext";
 import { Audience } from "./Audience";
 
-const AudienceRouter: React.FunctionComponent = () => {
+export const AudienceRouter: React.FunctionComponent = () => {
   const match = useRouteMatch();
 
   const { venue } = useSelector((state) => ({
@@ -28,4 +28,7 @@ const AudienceRouter: React.FunctionComponent = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default AudienceRouter;

--- a/src/components/templates/AvatarGrid/RoomModal.tsx
+++ b/src/components/templates/AvatarGrid/RoomModal.tsx
@@ -6,6 +6,10 @@ import UserProfilePicture from "components/molecules/UserProfilePicture";
 
 // Hooks
 import { useDispatch } from "hooks/useDispatch";
+import {
+  currentVenueEventsNGLegacyWorkaroundSelector,
+  currentVenueNGLegacyWorkaroundSelector,
+} from "hooks/useConnectCurrentVenueNG";
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 
@@ -18,6 +22,7 @@ import {
   ONE_MINUTE_IN_SECONDS,
 } from "utils/time";
 import { enterRoom } from "utils/useLocationUpdateEffect";
+import { partygoersSelector } from "utils/selectors";
 
 // Typings
 import { AvatarGridRoom } from "types/AvatarGrid";
@@ -45,11 +50,10 @@ export const RoomModal: React.FC<PropsType> = ({
   miniAvatars,
 }) => {
   const { user, profile } = useUser();
-  const { partygoers, venueEvents, venue } = useSelector((state) => ({
-    partygoers: state.firestore.ordered.partygoers,
-    venueEvents: state.firestore.ordered.venueEvents,
-    venue: state.firestore.ordered.currentVenue,
-  }));
+
+  const partygoers = useSelector(partygoersSelector);
+  const venueEvents = useSelector(currentVenueEventsNGLegacyWorkaroundSelector);
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
 
   const dispatch = useDispatch();
 
@@ -57,7 +61,7 @@ export const RoomModal: React.FC<PropsType> = ({
     return <></>;
   }
 
-  const venueName = venue[0].name;
+  const venueName = venue.name;
 
   const enter = () => {
     room &&

--- a/src/components/templates/Camp/Camp.tsx
+++ b/src/components/templates/Camp/Camp.tsx
@@ -20,6 +20,8 @@ import { createUrlSafeName } from "api/admin";
 
 import "./Camp.scss";
 import BannerMessage from "components/molecules/BannerMessage";
+import { currentVenueNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
+import { partygoersSelector } from "utils/selectors";
 
 const Camp: React.FC = () => {
   useConnectPartyGoers();
@@ -28,10 +30,10 @@ const Camp: React.FC = () => {
   const [showEventSchedule, setShowEventSchedule] = useState(false);
   const [nowMs, setNowMs] = useState(new Date().getTime());
 
-  const { partygoers, venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0] as CampVenue,
-    partygoers: state.firestore.ordered.partygoers,
-  }));
+  const venue = useSelector(
+    currentVenueNGLegacyWorkaroundSelector
+  ) as CampVenue;
+  const partygoers = useSelector(partygoersSelector);
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/src/components/templates/Camp/components/RoomCard.tsx
+++ b/src/components/templates/Camp/components/RoomCard.tsx
@@ -5,6 +5,7 @@ import { CampRoomData } from "types/CampRoomData";
 import { useSelector } from "hooks/useSelector";
 import { getCurrentEvent } from "utils/event";
 import "../../../templates/PartyMap/components/RoomCard/RoomCard.scss";
+import { currentVenueEventsNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
 
 interface PropsType {
   room: CampRoomData;
@@ -17,9 +18,7 @@ const RoomCard: React.FunctionComponent<PropsType> = ({
   attendance,
   onClick,
 }) => {
-  const venueEvents = useSelector(
-    (state) => state.firestore.ordered.venueEvents
-  );
+  const venueEvents = useSelector(currentVenueEventsNGLegacyWorkaroundSelector);
 
   if (!venueEvents) return <></>;
 

--- a/src/components/templates/Camp/components/RoomList.tsx
+++ b/src/components/templates/Camp/components/RoomList.tsx
@@ -5,6 +5,7 @@ import RoomCard from "./RoomCard";
 
 import "../../../templates/PartyMap/components/RoomList/RoomList.scss";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
 
 interface PropsType {
   rooms: CampRoomData[];
@@ -19,9 +20,7 @@ export const RoomList: React.FunctionComponent<PropsType> = ({
   setSelectedRoom,
   setIsRoomModalOpen,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0],
-  }));
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
 
   const openModal = (room: CampRoomData) => {
     setSelectedRoom(room);

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -12,6 +12,11 @@ import { CampRoomData } from "types/CampRoomData";
 import "../../../templates/PartyMap/RoomModal/RoomModal.scss";
 import { currentTimeInUnixEpoch, ONE_MINUTE_IN_SECONDS } from "utils/time";
 import { useFirestoreConnect } from "react-redux-firebase";
+import {
+  currentVenueEventsNGLegacyWorkaroundSelector,
+  currentVenueNGLegacyWorkaroundSelector,
+} from "hooks/useConnectCurrentVenueNG";
+import { partygoersSelector, venuesOrderedSelector } from "utils/selectors";
 
 interface PropsType {
   show: boolean;
@@ -28,12 +33,11 @@ export const RoomModal: React.FC<PropsType> = ({
 }) => {
   useFirestoreConnect("venues");
   const { user, profile } = useUser();
-  const { users, venueEvents, venues, venue } = useSelector((state) => ({
-    users: state.firestore.ordered.partygoers,
-    venueEvents: state.firestore.ordered.venueEvents,
-    venues: state.firestore.ordered.venues,
-    venue: state.firestore.ordered.currentVenue?.[0],
-  }));
+
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
+  const venueEvents = useSelector(currentVenueEventsNGLegacyWorkaroundSelector);
+  const venues = useSelector(venuesOrderedSelector);
+  const users = useSelector(partygoersSelector);
 
   if (!room) {
     return <></>;

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -12,7 +12,7 @@ import { LOC_UPDATE_FREQ_MS } from "settings";
 import { TABLES } from "./constants";
 import "./ConversationSpace.scss";
 
-const ConversationSpace: React.FunctionComponent = () => {
+export const ConversationSpace: React.FunctionComponent = () => {
   const { venue, users } = useSelector((state) => ({
     venue: state.firestore.data.currentVenue,
     users: state.firestore.ordered.partygoers,
@@ -124,4 +124,7 @@ const ConversationSpace: React.FunctionComponent = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default ConversationSpace;

--- a/src/components/templates/ConversationSpace/index.ts
+++ b/src/components/templates/ConversationSpace/index.ts
@@ -1,1 +1,6 @@
+export { ConversationSpace } from "./ConversationSpace";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./ConversationSpace";

--- a/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
+++ b/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
@@ -8,7 +8,7 @@ import { Venue } from "types/Venue";
 import { useSelector } from "hooks/useSelector";
 import VideoAdmin from "pages/VideoAdmin";
 
-const JazzbarRouter: React.FunctionComponent = () => {
+export const JazzbarRouter: React.FunctionComponent = () => {
   const match = useRouteMatch();
   useConnectPartyGoers();
 
@@ -27,4 +27,7 @@ const JazzbarRouter: React.FunctionComponent = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default JazzbarRouter;

--- a/src/components/templates/Jazzbar/JazzbarRouter/index.ts
+++ b/src/components/templates/Jazzbar/JazzbarRouter/index.ts
@@ -1,1 +1,6 @@
+export { JazzbarRouter } from "./JazzbarRouter";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./JazzbarRouter";

--- a/src/components/templates/PartyMap/PartyMapPage.tsx
+++ b/src/components/templates/PartyMap/PartyMapPage.tsx
@@ -23,6 +23,8 @@ import { updateTheme } from "pages/VenuePage/helpers";
 
 import { PartyTitle, RoomList, Map } from "./components";
 import { RoomModal } from "./RoomModal/RoomModal";
+import { partygoersSelector } from "utils/selectors";
+import { currentVenueNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
 
 export const PartyMap = () => {
   useConnectPartyGoers();
@@ -33,10 +35,9 @@ export const PartyMap = () => {
   const [nowMs, setNowMs] = useState(new Date().getTime());
 
   const { user, profile } = useUser();
-  const { partygoers, venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0],
-    partygoers: state.firestore.ordered.partygoers,
-  }));
+
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
+  const partygoers = useSelector(partygoersSelector);
 
   venue && updateTheme(venue);
 

--- a/src/components/templates/PartyMap/PartyMapPage.tsx
+++ b/src/components/templates/PartyMap/PartyMapPage.tsx
@@ -24,7 +24,7 @@ import { updateTheme } from "pages/VenuePage/helpers";
 import { PartyTitle, RoomList, Map } from "./components";
 import { RoomModal } from "./RoomModal/RoomModal";
 
-const PartyMap = () => {
+export const PartyMap = () => {
   useConnectPartyGoers();
   useConnectCurrentVenue();
 
@@ -161,4 +161,7 @@ const PartyMap = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default PartyMap;

--- a/src/components/templates/PartyMap/PartyMapPage.tsx
+++ b/src/components/templates/PartyMap/PartyMapPage.tsx
@@ -1,24 +1,28 @@
 import React, { useEffect, useState } from "react";
 
-import CountDown from "components/molecules/CountDown";
-import UserList from "components/molecules/UserList";
-import RoomList from "./components/RoomList";
-import WithNavigationBar from "components/organisms/WithNavigationBar";
-import { updateTheme } from "pages/VenuePage/helpers";
-import { updateLocationData } from "utils/useLocationUpdateEffect";
-import useConnectPartyGoers from "hooks/useConnectPartyGoers";
-import useConnectCurrentVenue from "hooks/useConnectCurrentVenue";
+import { LOC_UPDATE_FREQ_MS } from "settings";
 
-import { PartyTitle } from "./components";
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
+import { currentTimeInUnixEpoch } from "utils/time";
+import { updateLocationData } from "utils/useLocationUpdateEffect";
+import { venueLandingUrl } from "utils/url";
+
 import { isPartyMapVenue } from "types/PartyMapVenue";
 import { RoomData } from "types/RoomData";
-import RoomModal from "./RoomModal";
-import { venueLandingUrl } from "utils/url";
-import { Map } from "./components/Map/Map";
-import { currentTimeInUnixEpoch } from "utils/time";
-import { LOC_UPDATE_FREQ_MS } from "settings";
+
+import useConnectCurrentVenue from "hooks/useConnectCurrentVenue";
+import useConnectPartyGoers from "hooks/useConnectPartyGoers";
+import { useSelector } from "hooks/useSelector";
+import { useUser } from "hooks/useUser";
+
+import WithNavigationBar from "components/organisms/WithNavigationBar";
+
+import CountDown from "components/molecules/CountDown";
+import UserList from "components/molecules/UserList";
+
+import { updateTheme } from "pages/VenuePage/helpers";
+
+import { PartyTitle, RoomList, Map } from "./components";
+import { RoomModal } from "./RoomModal/RoomModal";
 
 const PartyMap = () => {
   useConnectPartyGoers();

--- a/src/components/templates/PartyMap/RoomModal/RoomModal.tsx
+++ b/src/components/templates/PartyMap/RoomModal/RoomModal.tsx
@@ -16,6 +16,8 @@ import { RoomModalOngoingEvent } from "../components";
 import { ScheduleItem } from "../components";
 
 import "./RoomModal.scss";
+import { partygoersSelector } from "utils/selectors";
+import { currentVenueNGLegacyWorkaroundSelector } from "hooks/useConnectCurrentVenueNG";
 
 interface PropsType {
   show: boolean;
@@ -25,10 +27,9 @@ interface PropsType {
 
 export const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
   const { user, profile } = useUser();
-  const { users, venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0],
-    users: state.firestore.ordered.partygoers,
-  }));
+
+  const venue = useSelector(currentVenueNGLegacyWorkaroundSelector);
+  const users = useSelector(partygoersSelector);
 
   if (!isPartyMapVenue(venue)) {
     return <></>;

--- a/src/components/templates/PartyMap/RoomModal/RoomModal.tsx
+++ b/src/components/templates/PartyMap/RoomModal/RoomModal.tsx
@@ -1,15 +1,21 @@
 import React from "react";
-import { currentTimeInUnixEpoch, getCurrentEvent } from "utils/time";
-import RoomModalOngoingEvent from "components/templates/PartyMap/components/RoomModalOngoingEvent";
-import UserList from "components/molecules/UserList";
-import ScheduleItem from "components/templates/PartyMap/components/ScheduleItem";
-import { enterRoom } from "utils/useLocationUpdateEffect";
-import "./RoomModal.scss";
-import { isPartyMapVenue } from "types/PartyMapVenue";
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
 import { Modal } from "react-bootstrap";
+
+import { currentTimeInUnixEpoch, getCurrentEvent } from "utils/time";
+import { enterRoom } from "utils/useLocationUpdateEffect";
+
+import { isPartyMapVenue } from "types/PartyMapVenue";
 import { RoomData } from "types/RoomData";
+
+import { useSelector } from "hooks/useSelector";
+import { useUser } from "hooks/useUser";
+
+import UserList from "components/molecules/UserList";
+
+import { RoomModalOngoingEvent } from "../components";
+import { ScheduleItem } from "../components";
+
+import "./RoomModal.scss";
 
 interface PropsType {
   show: boolean;
@@ -17,7 +23,7 @@ interface PropsType {
   room: RoomData | undefined;
 }
 
-const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
+export const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
   const { user, profile } = useUser();
   const { users, venue } = useSelector((state) => ({
     venue: state.firestore.ordered.currentVenue?.[0],
@@ -99,5 +105,3 @@ const RoomModal: React.FC<PropsType> = ({ show, onHide, room }) => {
     </Modal>
   );
 };
-
-export default RoomModal;

--- a/src/components/templates/PartyMap/RoomModal/index.ts
+++ b/src/components/templates/PartyMap/RoomModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RoomModal";

--- a/src/components/templates/PartyMap/components/Map/Map.tsx
+++ b/src/components/templates/PartyMap/components/Map/Map.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { isRoomValid } from "validation";
-import RoomAttendance from "../RoomAttendance";
-import { PartyMapVenue } from "types/PartyMapVenue";
 
-import "./Map.scss";
+import { isRoomValid } from "validation";
+
+import { PartyMapVenue } from "types/PartyMapVenue";
 import { RoomData } from "types/RoomData";
+
+import { RoomAttendance } from "..";
+import "./Map.scss";
 
 interface PropsType {
   config: PartyMapVenue;

--- a/src/components/templates/PartyMap/components/PartyTitle/PartyTitle.tsx
+++ b/src/components/templates/PartyMap/components/PartyTitle/PartyTitle.tsx
@@ -1,15 +1,18 @@
 import React from "react";
-import CountDown from "components/molecules/CountDown";
-import "./PartyTitle.scss";
+
 import { PartyMapVenue } from "types/PartyMapVenue";
 import { useSelector } from "hooks/useSelector";
+
+import CountDown from "components/molecules/CountDown";
+
+import "./PartyTitle.scss";
 
 interface PropsType {
   startUtcSeconds: number;
   withCountDown: boolean;
 }
 
-const PartyTitle: React.FunctionComponent<PropsType> = ({
+export const PartyTitle: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   withCountDown,
 }) => {
@@ -35,5 +38,3 @@ const PartyTitle: React.FunctionComponent<PropsType> = ({
     </div>
   );
 };
-
-export default PartyTitle;

--- a/src/components/templates/PartyMap/components/PartyTitle/index.ts
+++ b/src/components/templates/PartyMap/components/PartyTitle/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./PartyTitle";

--- a/src/components/templates/PartyMap/components/RoomAttendance.tsx
+++ b/src/components/templates/PartyMap/components/RoomAttendance.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
+
 import { RoomData } from "types/RoomData";
 
 interface PropsType {
@@ -11,7 +11,7 @@ interface PropsType {
   onClick?: () => void;
 }
 
-const RoomAttendance: React.FunctionComponent<PropsType> = ({
+export const RoomAttendance: React.FunctionComponent<PropsType> = ({
   room,
   attendance,
   positioned,
@@ -41,5 +41,3 @@ const RoomAttendance: React.FunctionComponent<PropsType> = ({
     </div>
   );
 };
-
-export default RoomAttendance;

--- a/src/components/templates/PartyMap/components/RoomCard/RoomCard.tsx
+++ b/src/components/templates/PartyMap/components/RoomCard/RoomCard.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import "./RoomCard.scss";
-import RoomAttendance from "../RoomAttendance";
-import { formatMinute } from "utils/time";
+
+import { formatMinute, getCurrentEvent } from "utils/time";
 import { RoomData } from "types/RoomData";
-import { getCurrentEvent } from "utils/time";
+
+import { RoomAttendance } from "..";
+import "./RoomCard.scss";
 
 interface PropsType {
   startUtcSeconds: number;
@@ -12,7 +13,7 @@ interface PropsType {
   onClick: () => void;
 }
 
-const RoomCard: React.FunctionComponent<PropsType> = ({
+export const RoomCard: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   room,
   attendance,
@@ -56,5 +57,3 @@ const RoomCard: React.FunctionComponent<PropsType> = ({
     </div>
   );
 };
-
-export default RoomCard;

--- a/src/components/templates/PartyMap/components/RoomCard/index.ts
+++ b/src/components/templates/PartyMap/components/RoomCard/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RoomCard";

--- a/src/components/templates/PartyMap/components/RoomList/RoomList.tsx
+++ b/src/components/templates/PartyMap/components/RoomList/RoomList.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import "./RoomList.scss";
 
-import { RoomData } from "types/RoomData";
-import RoomCard from "../RoomCard";
 import { eventHappeningNow } from "utils/time";
+import { RoomData } from "types/RoomData";
+
+import { RoomCard } from "..";
+import "./RoomList.scss";
 
 interface PropsType {
   startUtcSeconds: number;
@@ -13,7 +14,7 @@ interface PropsType {
   setIsRoomModalOpen: (value: boolean) => void;
 }
 
-const RoomList: React.FunctionComponent<PropsType> = ({
+export const RoomList: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   rooms,
   attendances,
@@ -48,5 +49,3 @@ const RoomList: React.FunctionComponent<PropsType> = ({
     </>
   );
 };
-
-export default RoomList;

--- a/src/components/templates/PartyMap/components/RoomList/index.ts
+++ b/src/components/templates/PartyMap/components/RoomList/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RoomList";

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import "./RoomModalOngoingEvent.scss";
+
 import { RoomData } from "types/RoomData";
 import { getCurrentEvent } from "utils/time";
 import { useDispatch } from "hooks/useDispatch";
 import { retainAttendance } from "store/actions/Attendance";
+
+import "./RoomModalOngoingEvent.scss";
 
 interface PropsType {
   room: RoomData;
@@ -11,7 +13,7 @@ interface PropsType {
   startUtcSeconds: number;
 }
 
-const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
+export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
   room,
   enterRoom,
   startUtcSeconds,
@@ -58,5 +60,3 @@ const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
     </div>
   );
 };
-
-export default RoomModalOngoingEvent;

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/index.ts
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RoomModalOngoingEvent";

--- a/src/components/templates/PartyMap/components/ScheduleItem/ScheduleItem.tsx
+++ b/src/components/templates/PartyMap/components/ScheduleItem/ScheduleItem.tsx
@@ -1,8 +1,10 @@
-import { useDispatch } from "hooks/useDispatch";
 import React from "react";
+
 import { retainAttendance } from "store/actions/Attendance";
-import { RoomEventData } from "types/RoomEventData";
 import { formatMinute } from "utils/time";
+import { RoomEventData } from "types/RoomEventData";
+import { useDispatch } from "hooks/useDispatch";
+
 import "./ScheduleItem.scss";
 
 interface PropsType {
@@ -13,7 +15,7 @@ interface PropsType {
   roomUrl: string;
 }
 
-const ScheduleItem: React.FunctionComponent<PropsType> = ({
+export const ScheduleItem: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   event,
   isCurrentEvent,
@@ -66,5 +68,3 @@ const ScheduleItem: React.FunctionComponent<PropsType> = ({
     </div>
   );
 };
-
-export default ScheduleItem;

--- a/src/components/templates/PartyMap/components/ScheduleItem/index.ts
+++ b/src/components/templates/PartyMap/components/ScheduleItem/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./ScheduleItem";

--- a/src/components/templates/PartyMap/components/index.ts
+++ b/src/components/templates/PartyMap/components/index.ts
@@ -1,1 +1,7 @@
-export { default as PartyTitle } from "./PartyTitle";
+export { Map } from "./Map/Map";
+export { PartyTitle } from "./PartyTitle/PartyTitle";
+export { RoomAttendance } from "./RoomAttendance";
+export { RoomCard } from "./RoomCard/RoomCard";
+export { RoomList } from "./RoomList/RoomList";
+export { RoomModalOngoingEvent } from "./RoomModalOngoingEvent/RoomModalOngoingEvent";
+export { ScheduleItem } from "./ScheduleItem/ScheduleItem";

--- a/src/components/templates/PartyMap/index.ts
+++ b/src/components/templates/PartyMap/index.ts
@@ -1,1 +1,6 @@
+export { PartyMap } from "./PartyMapPage";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./PartyMapPage";

--- a/src/hooks/useConnectCurrentEvent.ts
+++ b/src/hooks/useConnectCurrentEvent.ts
@@ -4,7 +4,7 @@ import { oneHourAfterTimestamp } from "utils/time";
 import { useState } from "react";
 import { useUser } from "./useUser";
 
-const useConnectCurrentEvent = () => {
+export const useConnectCurrentEvent = () => {
   const { venueId } = useParams();
   const { user } = useUser();
   const [currentTimestamp] = useState(Date.now() / 1000);
@@ -36,4 +36,7 @@ const useConnectCurrentEvent = () => {
   ]);
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default useConnectCurrentEvent;

--- a/src/hooks/useConnectCurrentVenue.ts
+++ b/src/hooks/useConnectCurrentVenue.ts
@@ -1,6 +1,10 @@
 import { useParams } from "react-router-dom";
 import { useFirestoreConnect } from "react-redux-firebase";
+
+import { currentVenueSelector } from "utils/selectors";
 import getQueryParameters from "utils/getQueryParameters";
+
+import { useSelector } from "./useSelector";
 
 const useConnectCurrentVenue = () => {
   let { venueId } = useParams();
@@ -25,6 +29,8 @@ const useConnectCurrentVenue = () => {
       storeAs: "venueEvents",
     },
   ]);
+
+  return useSelector(currentVenueSelector);
 };
 
 export default useConnectCurrentVenue;

--- a/src/hooks/useConnectCurrentVenue.ts
+++ b/src/hooks/useConnectCurrentVenue.ts
@@ -6,7 +6,11 @@ import getQueryParameters from "utils/getQueryParameters";
 
 import { useSelector } from "./useSelector";
 
-const useConnectCurrentVenue = () => {
+/**
+ * @deprecated use useConnectCurrentVenueNG instead
+ * @see useConnectCurrentVenueNG
+ */
+export const useConnectCurrentVenue = () => {
   let { venueId } = useParams();
   if (!venueId) {
     venueId = getQueryParameters(window.location.search)?.venueId;
@@ -33,4 +37,7 @@ const useConnectCurrentVenue = () => {
   return useSelector(currentVenueSelector);
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default useConnectCurrentVenue;

--- a/src/hooks/useConnectCurrentVenueNG.ts
+++ b/src/hooks/useConnectCurrentVenueNG.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+
+import { AnyVenue } from "types/Firestore";
+import { SparkleSelector } from "types/SparkleSelector";
+import { VenueEvent } from "types/VenueEvent";
+
+import { useSelector } from "./useSelector";
+import { useSparkleFirestoreConnect } from "./useSparkleFirestoreConnect";
+
+export const currentVenueNGSelector: SparkleSelector<AnyVenue | undefined> = (
+  state
+) => state.firestore.data.currentVenueNG;
+
+export const currentVenueEventsNGSelector: SparkleSelector<
+  Record<string, VenueEvent> | undefined
+> = (state) => state.firestore.data.currentVenueEventsNG;
+
+export const useConnectCurrentVenueNG = (venueId: string) => {
+  useSparkleFirestoreConnect(
+    !!venueId
+      ? [
+          {
+            collection: "venues",
+            doc: venueId,
+            storeAs: "currentVenueNG",
+          },
+          {
+            collection: "venues",
+            doc: venueId,
+            subcollections: [{ collection: "events" }],
+            orderBy: ["start_utc_seconds", "asc"],
+            storeAs: "currentVenueEventsNG",
+          },
+        ]
+      : []
+  );
+
+  const currentVenueNG = useSelector(currentVenueNGSelector);
+  const currentVenueEventsNG = useSelector(currentVenueEventsNGSelector);
+
+  return useMemo(
+    () => ({
+      currentVenue: currentVenueNG,
+      currentVenueEvents: currentVenueEventsNG,
+    }),
+    [currentVenueNG, currentVenueEventsNG]
+  );
+};

--- a/src/hooks/useConnectCurrentVenueNG.ts
+++ b/src/hooks/useConnectCurrentVenueNG.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { WithId } from "utils/id";
 import { AnyVenue } from "types/Firestore";
 import { SparkleSelector } from "types/SparkleSelector";
 import { VenueEvent } from "types/VenueEvent";
@@ -15,6 +16,28 @@ export const currentVenueEventsNGSelector: SparkleSelector<
   Record<string, VenueEvent> | undefined
 > = (state) => state.firestore.data.currentVenueEventsNG;
 
+/**
+ * HACK: we should do something better than the explicit as WithId<AnyVenue> here
+ * (though this should be no worse than how it was)
+ *
+ * @deprecated this selector only exists for the benefit of minimising the changes
+ * required to upgrade from some of our older patterns till we can upgrade them
+ */
+export const currentVenueNGLegacyWorkaroundSelector: SparkleSelector<WithId<
+  AnyVenue
+>> = (state) => state.firestore.ordered.currentVenueNG?.[0] as WithId<AnyVenue>;
+
+/**
+ * HACK: we should do something better than the explicit as WithId<VenueEvent> here
+ * (though this should be no worse than how it was)
+ *
+ * @deprecated this selector only exists for the benefit of minimising the changes
+ * required to upgrade from some of our older patterns till we can upgrade them
+ */
+export const currentVenueEventsNGLegacyWorkaroundSelector: SparkleSelector<
+  WithId<VenueEvent>[]
+> = (state) =>
+  state.firestore.ordered.currentVenueEventsNG as WithId<VenueEvent>[];
 export const useConnectCurrentVenueNG = (venueId: string) => {
   useSparkleFirestoreConnect(
     !!venueId

--- a/src/hooks/useConnectPartyGoers.ts
+++ b/src/hooks/useConnectPartyGoers.ts
@@ -5,7 +5,7 @@ import { partygoersSelector } from "utils/selectors";
 import { useSelector } from "./useSelector";
 import { useUserLastSeenLimit } from "./useUserLastSeenLimit";
 
-const useConnectPartyGoers = () => {
+export const useConnectPartyGoers = () => {
   const userLastSeenLimit = useUserLastSeenLimit();
 
   useFirestoreConnect([
@@ -19,4 +19,7 @@ const useConnectPartyGoers = () => {
   return useSelector(partygoersSelector);
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default useConnectPartyGoers;

--- a/src/hooks/useConnectPartyGoers.ts
+++ b/src/hooks/useConnectPartyGoers.ts
@@ -1,4 +1,8 @@
 import { useFirestoreConnect } from "react-redux-firebase";
+
+import { partygoersSelector } from "utils/selectors";
+
+import { useSelector } from "./useSelector";
 import { useUserLastSeenLimit } from "./useUserLastSeenLimit";
 
 const useConnectPartyGoers = () => {
@@ -11,6 +15,8 @@ const useConnectPartyGoers = () => {
       storeAs: "partygoers",
     },
   ]);
+
+  return useSelector(partygoersSelector);
 };
 
 export default useConnectPartyGoers;

--- a/src/hooks/useConnectPartyGoers.ts
+++ b/src/hooks/useConnectPartyGoers.ts
@@ -1,18 +1,8 @@
-import { useEffect, useState } from "react";
-import { getHoursAgoInSeconds } from "utils/time";
 import { useFirestoreConnect } from "react-redux-firebase";
+import { useUserLastSeenLimit } from "./useUserLastSeenLimit";
 
 const useConnectPartyGoers = () => {
-  const [userLastSeenLimit, setUserLastSeenLimit] = useState(
-    getHoursAgoInSeconds(3)
-  );
-  useEffect(() => {
-    const id = setInterval(() => {
-      setUserLastSeenLimit(getHoursAgoInSeconds(3));
-    }, 5 * 60 * 1000);
-
-    return () => clearInterval(id);
-  }, [setUserLastSeenLimit]);
+  const userLastSeenLimit = useUserLastSeenLimit();
 
   useFirestoreConnect([
     {

--- a/src/hooks/useConnectUserPurchaseHistory.ts
+++ b/src/hooks/useConnectUserPurchaseHistory.ts
@@ -2,7 +2,7 @@ import { useParams } from "react-router-dom";
 import { useFirestoreConnect } from "react-redux-firebase";
 import { useUser } from "./useUser";
 
-const useConnectUserPurchaseHistory = () => {
+export const useConnectUserPurchaseHistory = () => {
   const { venueId } = useParams();
   const { user } = useUser();
 
@@ -19,4 +19,7 @@ const useConnectUserPurchaseHistory = () => {
   ]);
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default useConnectUserPurchaseHistory;

--- a/src/hooks/useSparkleFirestoreConnect.ts
+++ b/src/hooks/useSparkleFirestoreConnect.ts
@@ -1,0 +1,37 @@
+import {
+  ReduxFirestoreQuerySetting,
+  useFirestoreConnect,
+} from "react-redux-firebase";
+import { ValidFirestoreKeys } from "types/Firestore";
+
+/**
+ * This type allows us to automagically constrain the storeAs
+ * parameter to keys that exist within ValidFirestoreKeys, ensuring
+ * that we can't forget to define it in our types when using functions
+ * that rely on this type (eg. useSparkleFirestoreConnect)
+ *
+ * @see ValidFirestoreKeys
+ * @see useSparkleFirestoreConnect
+ * @see ReduxFirestoreQuerySetting
+ */
+export interface SparkleRFQConfig extends ReduxFirestoreQuerySetting {
+  storeAs?: ValidFirestoreKeys;
+}
+
+/**
+ * A wrapper for useFirestoreConnect() that ensures the config
+ * we pass it can only use a storeAs key that has been defined
+ * in our FirestoreData/FirestoreOrdered types.
+ *
+ * Note: the config does NOT need to be memo'd before being passed
+ * to this function as useSparkleFirestoreConnect() determines equality
+ * through a deep comparison using lodash's isEqual() function.
+ *
+ * @param config the config to be passed to useFirestoreConnect()
+ *
+ * @see SparkleRFQConfig
+ * @see ValidFirestoreKeys
+ * @see ReduxFirestoreQuerySetting
+ */
+export const useSparkleFirestoreConnect = (config: SparkleRFQConfig[]) =>
+  useFirestoreConnect(config);

--- a/src/hooks/useSparkleFirestoreConnect.ts
+++ b/src/hooks/useSparkleFirestoreConnect.ts
@@ -1,8 +1,15 @@
 import {
   ReduxFirestoreQuerySetting,
   useFirestoreConnect,
+  isLoaded as _isLoaded,
+  isEmpty as _isEmpty,
 } from "react-redux-firebase";
 import { ValidFirestoreKeys } from "types/Firestore";
+
+/**
+ * Type helper representing all types of T except undefined
+ */
+export type Defined<T> = T & Exclude<T, undefined>;
 
 /**
  * This type allows us to automagically constrain the storeAs
@@ -35,3 +42,18 @@ export interface SparkleRFQConfig extends ReduxFirestoreQuerySetting {
  */
 export const useSparkleFirestoreConnect = (config: SparkleRFQConfig[]) =>
   useFirestoreConnect(config);
+
+/**
+ * Use react-redux-firestore's isEmpty helper with
+ * user-defined type guards to properly narrow types
+ * when using this helper.
+ *
+ * @param item item fetched by react-redux-firestore
+ */
+export const hasData = <T>(item: T): item is Defined<T> =>
+  !_isEmpty(item) && item !== undefined;
+
+/**
+ * Re-export react-redux-firestore's isLoaded helper for convenience.
+ */
+export const isLoaded = <T>(item: T) => _isLoaded(item);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,7 +1,10 @@
-import { useSelector } from "./useSelector";
+import { authSelector, profileSelector } from "utils/selectors";
+import { useSelector } from "hooks/useSelector";
 
 export const useUser = () => {
-  const { auth, profile } = useSelector((state) => state.firebase);
+  const auth = useSelector(authSelector);
+  const profile = useSelector(profileSelector);
+
   return {
     user: !auth.isEmpty ? auth : undefined,
     profile: !profile.isEmpty ? profile : undefined,

--- a/src/hooks/useUserLastSeenLimit.ts
+++ b/src/hooks/useUserLastSeenLimit.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { getHoursAgoInSeconds } from "utils/time";
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const calcLastSeenLimit = () => getHoursAgoInSeconds(3);
+
+export const useUserLastSeenLimit = () => {
+  const [userLastSeenLimit, setUserLastSeenLimit] = useState(
+    calcLastSeenLimit()
+  );
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setUserLastSeenLimit(calcLastSeenLimit());
+    }, FIVE_MINUTES_MS);
+
+    return () => clearInterval(id);
+  }, []);
+
+  return userLastSeenLimit;
+};

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -40,7 +40,7 @@ import { VenueTemplate } from "types/VenueTemplate";
 
 import { isTruthyFilter } from "utils/filter";
 import { WithId } from "utils/id";
-import { makeVenueSelector } from "utils/selectors";
+import { makeVenueSelector, venuesOrderedSelector } from "utils/selectors";
 import { venueInsideUrl } from "utils/url";
 import {
   canHaveSubvenues,
@@ -79,7 +79,7 @@ const VenueList: React.FC<VenueListProps> = ({
   selectedVenueId,
   roomIndex,
 }) => {
-  const venues = useSelector((state) => state.firestore.ordered.venues);
+  const venues = useSelector(venuesOrderedSelector);
 
   if (!venues) return <>Loading...</>;
 

--- a/src/pages/FriendShipPage/FriendShipPage.tsx
+++ b/src/pages/FriendShipPage/FriendShipPage.tsx
@@ -10,7 +10,7 @@ import useConnectPartyGoers from "hooks/useConnectPartyGoers";
 import TableHeader from "components/molecules/TableHeader";
 import { useSelector } from "hooks/useSelector";
 
-const FriendShipPage: React.FunctionComponent = () => {
+export const FriendShipPage: React.FunctionComponent = () => {
   const [seatedAtTable, setSeatedAtTable] = useState("");
   const venue = useSelector((state) => state.firestore.data.currentVenue);
 
@@ -88,4 +88,7 @@ const FriendShipPage: React.FunctionComponent = () => {
   );
 };
 
+/**
+ * @deprecated use named export instead
+ */
 export default FriendShipPage;

--- a/src/pages/FriendShipPage/index.ts
+++ b/src/pages/FriendShipPage/index.ts
@@ -1,1 +1,6 @@
+export { FriendShipPage } from "./FriendShipPage";
+
+/**
+ * @deprecated use named export instead
+ */
 export { default } from "./FriendShipPage";

--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -1,18 +1,12 @@
-import { ChatContextWrapper } from "components/context/ChatContext";
-import CountDown from "components/molecules/CountDown";
-import WithNavigationBar from "components/organisms/WithNavigationBar";
-import ArtPiece from "components/templates/ArtPiece";
-import JazzbarRouter from "components/templates/Jazzbar/JazzbarRouter";
-import PartyMap from "components/templates/PartyMap";
-import useConnectCurrentEvent from "hooks/useConnectCurrentEvent";
-import useConnectPartyGoers from "hooks/useConnectPartyGoers";
-import useConnectUserPurchaseHistory from "hooks/useConnectUserPurchaseHistory";
-import { useSelector } from "hooks/useSelector";
-import { useUser } from "hooks/useUser";
-import FriendShipPage from "pages/FriendShipPage";
 import React, { useState, useEffect, useCallback } from "react";
 import { Redirect, useHistory } from "react-router-dom";
+import { useFirestoreConnect, useFirestore } from "react-redux-firebase";
+
+import { LOC_UPDATE_FREQ_MS } from "settings";
+
 import { VenueTemplate } from "types/VenueTemplate";
+
+import { getQueryParameters } from "utils/getQueryParameters";
 import { hasUserBoughtTicketForEvent } from "utils/hasUserBoughtTicket";
 import { isUserAMember } from "utils/isUserAMember";
 import {
@@ -24,21 +18,38 @@ import {
   updateLocationData,
   useLocationUpdateEffect,
 } from "utils/useLocationUpdateEffect";
-import { updateTheme } from "./helpers";
-import "./VenuePage.scss";
-import { PlayaRouter } from "components/templates/Playa/Router";
+import { venueEntranceUrl } from "utils/url";
+
+import { useConnectCurrentEvent } from "hooks/useConnectCurrentEvent";
+import { useConnectPartyGoers } from "hooks/useConnectPartyGoers";
+import { useConnectUserPurchaseHistory } from "hooks/useConnectUserPurchaseHistory";
+import { useSelector } from "hooks/useSelector";
+import { useUser } from "hooks/useUser";
+import { useVenueId } from "hooks/useVenueId";
+
+import { ChatContextWrapper } from "components/context/ChatContext";
+
+import { FriendShipPage } from "pages/FriendShipPage";
+import { updateUserProfile } from "pages/Account/helpers";
+
+import { ArtPiece } from "components/templates/ArtPiece";
+import { AudienceRouter } from "components/templates/Audience/AudienceRouter";
 import { AvatarRouter } from "components/templates/AvatarGrid/Router";
 import { CampRouter } from "components/templates/Camp/Router";
+import { ConversationSpace } from "components/templates/ConversationSpace";
+import { JazzbarRouter } from "components/templates/Jazzbar/JazzbarRouter";
+import { PartyMap } from "components/templates/PartyMap";
+import { PlayaRouter } from "components/templates/Playa/Router";
+
+import { AuthenticationModal } from "components/organisms/AuthenticationModal";
+import { WithNavigationBar } from "components/organisms/WithNavigationBar";
+
+import { CountDown } from "components/molecules/CountDown";
 import { LoadingPage } from "components/molecules/LoadingPage/LoadingPage";
-import AuthenticationModal from "components/organisms/AuthenticationModal";
-import { useFirestoreConnect, useFirestore } from "react-redux-firebase";
-import AudienceRouter from "components/templates/Audience/AudienceRouter";
-import { useVenueId } from "hooks/useVenueId";
-import { venueEntranceUrl } from "utils/url";
-import getQueryParameters from "utils/getQueryParameters";
-import ConversationSpace from "components/templates/ConversationSpace";
-import { updateUserProfile } from "pages/Account/helpers";
-import { LOC_UPDATE_FREQ_MS } from "settings";
+
+import { updateTheme } from "./helpers";
+
+import "./VenuePage.scss";
 
 const hasPaidEvents = (template: VenueTemplate) => {
   return template === VenueTemplate.jazzbar;

--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -10,6 +10,16 @@ import { getQueryParameters } from "utils/getQueryParameters";
 import { hasUserBoughtTicketForEvent } from "utils/hasUserBoughtTicket";
 import { isUserAMember } from "utils/isUserAMember";
 import {
+  currentEventSelector,
+  currentVenueSelector,
+  isCurrentEventRequestedSelector,
+  isCurrentVenueRequestedSelector,
+  isUserPurchaseHistoryRequestedSelector,
+  partygoersSelector,
+  shouldRetainAttendanceSelector,
+  userPurchaseHistorySelector,
+} from "utils/selectors";
+import {
   canUserJoinTheEvent,
   currentTimeInUnixEpoch,
   ONE_MINUTE_IN_SECONDS,
@@ -64,28 +74,21 @@ const VenuePage = () => {
   const [unmounted, setUnmounted] = useState(false);
 
   const { user, profile } = useUser();
-  const {
-    venue,
-    users,
-    userPurchaseHistory,
-    userPurchaseHistoryRequestStatus,
-    currentEvent,
-    eventRequestStatus,
-    venueRequestStatus,
-    retainAttendance,
-  } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-    venueRequestStatus: state.firestore.status.requested.currentVenue,
-    users: state.firestore.ordered.partygoers,
-    currentEvent: state.firestore.ordered.currentEvent,
-    eventRequestStatus: state.firestore.status.requested.currentEvent,
-    eventPurchase: state.firestore.data.eventPurchase,
-    eventPurchaseRequestStatus: state.firestore.status.requested.eventPurchase,
-    userPurchaseHistory: state.firestore.ordered.userPurchaseHistory,
-    userPurchaseHistoryRequestStatus:
-      state.firestore.status.requested.userPurchaseHistory,
-    retainAttendance: state.attendance.retainAttendance,
-  }));
+
+  const users = useSelector(partygoersSelector);
+
+  const venue = useSelector(currentVenueSelector);
+  const venueRequestStatus = useSelector(isCurrentVenueRequestedSelector);
+
+  const currentEvent = useSelector(currentEventSelector);
+  const eventRequestStatus = useSelector(isCurrentEventRequestedSelector);
+
+  const userPurchaseHistory = useSelector(userPurchaseHistorySelector);
+  const userPurchaseHistoryRequestStatus = useSelector(
+    isUserPurchaseHistoryRequestedSelector
+  );
+
+  const retainAttendance = useSelector(shouldRetainAttendanceSelector);
 
   const venueName = venue?.name ?? "";
   const prevLocations = retainAttendance ? profile?.lastSeenIn ?? {} : {};

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -37,52 +37,58 @@ interface UserVisit {
 }
 
 export interface Firestore {
-  status: {
-    requesting: VenueStatus;
-    requested: VenueStatus;
-    timestamps: VenueTimestamps;
-  };
-  data: {
-    currentVenue?: AnyVenue;
-    parentVenue?: AnyVenue;
-    currentEvent: Record<string, VenueEvent>;
-    venueChats: Record<string, RestrictedChatMessage> | null;
-    venueEvents: Record<string, VenueEvent>;
-    userPurchaseHistory: Record<string, Purchase>;
-    partygoers: Record<string, User>;
-    users: Record<string, User>;
-    privatechats: Record<string, PrivateChatMessage>;
-    experiences: Record<string, Experience>;
-    eventPurchase: Record<string, Purchase>;
-    reactions: Record<string, Reaction>;
-    venues?: Record<string, AnyVenue>;
-    events?: Record<string, VenueEvent>;
-    playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
-    allUsers?: Record<string, User>;
-    userModalVisits?: Record<string, UserVisit>;
-    userRoles: Record<string, Role>;
-    allowAllRoles: Record<string, Role>;
-    adminRole: AdminRole;
-  };
-  ordered: {
-    currentVenue: Array<WithId<AnyVenue>>;
-    currentEvent: Array<WithId<VenueEvent>>;
-    venueChats: Array<WithId<RestrictedChatMessage>>;
-    venueEvents: Array<WithId<VenueEvent>>;
-    userPurchaseHistory: Array<WithId<Purchase>>;
-    partygoers: Array<WithId<User>>;
-    users: Array<WithId<User>>;
-    privatechats: Array<WithId<PrivateChatMessage>>;
-    experiences: Array<WithId<Experience>>;
-    eventPurchase: Array<WithId<Purchase>>;
-    reactions: Array<WithId<Reaction>>;
-    venues?: Array<WithId<AnyVenue>>;
-    events?: Array<WithId<VenueEvent>>;
-    playaVenues?: Array<WithId<AnyVenue>>;
-    statsOnlineUsers?: Array<WithId<User>>;
-    statsOpenVenues?: Array<WithId<AnyVenue>>;
-    allUsers?: Array<WithId<User>>;
-    userModalVisits?: Array<WithId<UserVisit>>;
-    chatRequests?: Array<WithId<ChatRequest>>;
-  };
+  status: FirestoreStatus;
+  data: FirestoreData;
+  ordered: FirestoreOrdered;
+}
+
+export interface FirestoreStatus {
+  requesting: VenueStatus;
+  requested: VenueStatus;
+  timestamps: VenueTimestamps;
+}
+
+export interface FirestoreData {
+  currentVenue?: AnyVenue;
+  parentVenue?: AnyVenue;
+  currentEvent: Record<string, VenueEvent>;
+  venueChats: Record<string, RestrictedChatMessage> | null;
+  venueEvents: Record<string, VenueEvent>;
+  userPurchaseHistory: Record<string, Purchase>;
+  partygoers: Record<string, User>;
+  users: Record<string, User>;
+  privatechats: Record<string, PrivateChatMessage>;
+  experiences: Record<string, Experience>;
+  eventPurchase: Record<string, Purchase>;
+  reactions: Record<string, Reaction>;
+  venues?: Record<string, AnyVenue>;
+  events?: Record<string, VenueEvent>;
+  playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
+  allUsers?: Record<string, User>;
+  userModalVisits?: Record<string, UserVisit>;
+  userRoles: Record<string, Role>;
+  allowAllRoles: Record<string, Role>;
+  adminRole: AdminRole;
+}
+
+export interface FirestoreOrdered {
+  currentVenue: Array<WithId<AnyVenue>>;
+  currentEvent: Array<WithId<VenueEvent>>;
+  venueChats: Array<WithId<RestrictedChatMessage>>;
+  venueEvents: Array<WithId<VenueEvent>>;
+  userPurchaseHistory: Array<WithId<Purchase>>;
+  partygoers: Array<WithId<User>>;
+  users: Array<WithId<User>>;
+  privatechats: Array<WithId<PrivateChatMessage>>;
+  experiences: Array<WithId<Experience>>;
+  eventPurchase: Array<WithId<Purchase>>;
+  reactions: Array<WithId<Reaction>>;
+  venues?: Array<WithId<AnyVenue>>;
+  events?: Array<WithId<VenueEvent>>;
+  playaVenues?: Array<WithId<AnyVenue>>;
+  statsOnlineUsers?: Array<WithId<User>>;
+  statsOpenVenues?: Array<WithId<AnyVenue>>;
+  allUsers?: Array<WithId<User>>;
+  userModalVisits?: Array<WithId<UserVisit>>;
+  chatRequests?: Array<WithId<ChatRequest>>;
 }

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -28,6 +28,8 @@ interface UserVisit {
   timeSpent: number;
 }
 
+export type ValidFirestoreKeys = keyof FirestoreData | keyof FirestoreOrdered;
+
 export interface Firestore {
   data: FirestoreData;
   ordered: FirestoreOrdered;
@@ -35,9 +37,9 @@ export interface Firestore {
 }
 
 export interface FirestoreStatus {
-  requesting: Record<keyof FirestoreData, boolean>;
-  requested: Record<keyof FirestoreData, boolean>;
-  timestamps: Record<keyof FirestoreData, number>;
+  requesting: Record<ValidFirestoreKeys, boolean>;
+  requested: Record<ValidFirestoreKeys, boolean>;
+  timestamps: Record<ValidFirestoreKeys, number>;
 }
 
 // note: these entries should be sorted alphabetically

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -17,80 +17,72 @@ import { User } from "./User";
 import { Venue } from "./Venue";
 import { VenueEvent } from "./VenueEvent";
 
-interface VenueStatus {
-  currentVenue: boolean;
-  currentEvent: boolean;
-  eventPurchase: boolean;
-  venueChats: boolean;
-  venueEvents: boolean;
-  userPurchaseHistory: boolean;
-}
+export type AnyVenue = Venue | PartyMapVenue | CampVenue;
 
 interface Experience {
   reactions: Record<string, Reaction>;
   tables: Record<string, Table>;
 }
 
-type VenueTimestamps = Record<keyof VenueStatus, number>;
-export type AnyVenue = Venue | PartyMapVenue | CampVenue;
-
 interface UserVisit {
   timeSpent: number;
 }
 
 export interface Firestore {
-  status: FirestoreStatus;
   data: FirestoreData;
   ordered: FirestoreOrdered;
+  status: FirestoreStatus;
 }
 
 export interface FirestoreStatus {
-  requesting: VenueStatus;
-  requested: VenueStatus;
-  timestamps: VenueTimestamps;
+  requesting: Record<keyof FirestoreData, boolean>;
+  requested: Record<keyof FirestoreData, boolean>;
+  timestamps: Record<keyof FirestoreData, number>;
 }
 
+// note: these entries should be sorted alphabetically
 export interface FirestoreData {
-  currentVenue?: AnyVenue;
-  parentVenue?: AnyVenue;
+  adminRole: AdminRole;
+  allowAllRoles: Record<string, Role>;
+  allUsers?: Record<string, User>;
   currentEvent: Record<string, VenueEvent>;
+  currentVenue?: AnyVenue;
+  eventPurchase: Record<string, Purchase>;
+  events?: Record<string, VenueEvent>;
+  experiences: Record<string, Experience>;
+  parentVenue?: AnyVenue;
+  partygoers: Record<string, User>;
+  playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
+  privatechats: Record<string, PrivateChatMessage>;
+  reactions: Record<string, Reaction>;
+  userModalVisits?: Record<string, UserVisit>;
+  userPurchaseHistory: Record<string, Purchase>;
+  userRoles: Record<string, Role>;
+  users: Record<string, User>;
   venueChats: Record<string, RestrictedChatMessage> | null;
   venueEvents: Record<string, VenueEvent>;
-  userPurchaseHistory: Record<string, Purchase>;
-  partygoers: Record<string, User>;
-  users: Record<string, User>;
-  privatechats: Record<string, PrivateChatMessage>;
-  experiences: Record<string, Experience>;
-  eventPurchase: Record<string, Purchase>;
-  reactions: Record<string, Reaction>;
   venues?: Record<string, AnyVenue>;
-  events?: Record<string, VenueEvent>;
-  playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
-  allUsers?: Record<string, User>;
-  userModalVisits?: Record<string, UserVisit>;
-  userRoles: Record<string, Role>;
-  allowAllRoles: Record<string, Role>;
-  adminRole: AdminRole;
 }
 
+// note: these entries should be sorted alphabetically
 export interface FirestoreOrdered {
-  currentVenue: Array<WithId<AnyVenue>>;
+  allUsers?: Array<WithId<User>>;
+  chatRequests?: Array<WithId<ChatRequest>>;
   currentEvent: Array<WithId<VenueEvent>>;
-  venueChats: Array<WithId<RestrictedChatMessage>>;
-  venueEvents: Array<WithId<VenueEvent>>;
-  userPurchaseHistory: Array<WithId<Purchase>>;
-  partygoers: Array<WithId<User>>;
-  users: Array<WithId<User>>;
-  privatechats: Array<WithId<PrivateChatMessage>>;
-  experiences: Array<WithId<Experience>>;
+  currentVenue: Array<WithId<AnyVenue>>;
   eventPurchase: Array<WithId<Purchase>>;
-  reactions: Array<WithId<Reaction>>;
-  venues?: Array<WithId<AnyVenue>>;
   events?: Array<WithId<VenueEvent>>;
+  experiences: Array<WithId<Experience>>;
+  partygoers: Array<WithId<User>>;
   playaVenues?: Array<WithId<AnyVenue>>;
+  privatechats: Array<WithId<PrivateChatMessage>>;
+  reactions: Array<WithId<Reaction>>;
   statsOnlineUsers?: Array<WithId<User>>;
   statsOpenVenues?: Array<WithId<AnyVenue>>;
-  allUsers?: Array<WithId<User>>;
   userModalVisits?: Array<WithId<UserVisit>>;
-  chatRequests?: Array<WithId<ChatRequest>>;
+  userPurchaseHistory: Array<WithId<Purchase>>;
+  users: Array<WithId<User>>;
+  venueChats: Array<WithId<RestrictedChatMessage>>;
+  venueEvents: Array<WithId<VenueEvent>>;
+  venues?: Array<WithId<AnyVenue>>;
 }

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -1,19 +1,21 @@
-import { Venue } from "./Venue";
-import { Purchase } from "./Purchase";
-import { User } from "./User";
+import { WithId } from "utils/id";
+import { AdminRole } from "hooks/roles";
+
 import {
   RestrictedChatMessage,
   PrivateChatMessage,
 } from "components/context/ChatContext";
-import { VenueEvent } from "./VenueEvent";
-import { Table } from "./Table";
-import { PartyMapVenue } from "./PartyMapVenue";
 import { Reaction } from "components/context/ExperienceContext";
-import { WithId } from "utils/id";
+
 import { CampVenue } from "./CampVenue";
 import { ChatRequest } from "./ChatRequest";
+import { PartyMapVenue } from "./PartyMapVenue";
+import { Purchase } from "./Purchase";
 import { Role } from "./Role";
-import { AdminRole } from "hooks/roles";
+import { Table } from "./Table";
+import { User } from "./User";
+import { Venue } from "./Venue";
+import { VenueEvent } from "./VenueEvent";
 
 interface VenueStatus {
   currentVenue: boolean;

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -49,6 +49,8 @@ export interface FirestoreData {
   allUsers?: Record<string, User>;
   currentEvent: Record<string, VenueEvent>;
   currentVenue?: AnyVenue;
+  currentVenueEventsNG?: Record<string, VenueEvent>;
+  currentVenueNG?: AnyVenue;
   eventPurchase: Record<string, Purchase>;
   events?: Record<string, VenueEvent>;
   experiences: Record<string, Experience>;
@@ -72,6 +74,8 @@ export interface FirestoreOrdered {
   chatRequests?: Array<WithId<ChatRequest>>;
   currentEvent: Array<WithId<VenueEvent>>;
   currentVenue: Array<WithId<AnyVenue>>;
+  currentVenueEventsNG?: Array<WithId<VenueEvent>>;
+  currentVenueNG?: Array<WithId<AnyVenue>>;
   eventPurchase: Array<WithId<Purchase>>;
   events?: Array<WithId<VenueEvent>>;
   experiences: Array<WithId<Experience>>;

--- a/src/types/SparkleSelector.ts
+++ b/src/types/SparkleSelector.ts
@@ -1,3 +1,3 @@
-import { RootState } from "../index";
+import { RootState } from "index";
 
 export type SparkleSelector<T> = (state: RootState) => T;

--- a/src/utils/firestoreSelectors.ts
+++ b/src/utils/firestoreSelectors.ts
@@ -1,0 +1,85 @@
+import { RootState } from "index";
+import {
+  FirestoreData,
+  FirestoreOrdered,
+  FirestoreStatus,
+} from "types/Firestore";
+import { SparkleSelector } from "types/SparkleSelector";
+
+/**
+ * Selector to retrieve Firestore 'data' key from Redux.
+ *
+ * @param state the root Redux store
+ */
+export const firestoreDataSelector: SparkleSelector<FirestoreData> = (
+  state: RootState
+) => state.firestore.data;
+
+/**
+ * Selector to retrieve Firestore 'ordered' key from Redux.
+ *
+ * @param state the root Redux store
+ */
+export const firestoreOrderedSelector: SparkleSelector<FirestoreOrdered> = (
+  state: RootState
+) => state.firestore.ordered;
+
+/**
+ * Selector to retrieve Firestore 'status' key from Redux.
+ *
+ * @param state the root Redux store
+ */
+export const firestoreStatusSelector: SparkleSelector<FirestoreStatus> = (
+  state: RootState
+) => state.firestore.status;
+
+/**
+ * Make a selector function for state.firestore.data[key]
+ *
+ * @param key the key to extract
+ */
+export const makeDataSelector = <T extends keyof FirestoreData>(key: T) => (
+  state: RootState
+) => firestoreDataSelector(state)[key];
+
+/**
+ * Make a selector function for state.firestore.ordered[key]
+ *
+ * @param key the key to extract
+ */
+export const makeOrderedSelector = <T extends keyof FirestoreOrdered>(
+  key: T
+) => (state: RootState) => firestoreOrderedSelector(state)[key];
+
+/**
+ * Make a selector function for state.firestore.status.requesting[key]
+ *
+ * @param key the key to extract
+ */
+export const makeIsRequestingSelector = <
+  T extends keyof FirestoreStatus["requesting"]
+>(
+  key: T
+) => (state: RootState) => firestoreStatusSelector(state).requesting[key];
+
+/**
+ * Make a selector function for state.firestore.status.requested[key]
+ *
+ * @param key the key to extract
+ */
+export const makeIsRequestedSelector = <
+  T extends keyof FirestoreStatus["requested"]
+>(
+  key: T
+) => (state: RootState) => firestoreStatusSelector(state).requested[key];
+
+/**
+ * Make a selector function for state.firestore.status.timestamps[key]
+ *
+ * @param key the key to extract
+ */
+export const makeTimestampSelector = <
+  T extends keyof FirestoreStatus["timestamps"]
+>(
+  key: T
+) => (state: RootState) => firestoreStatusSelector(state).timestamps[key];

--- a/src/utils/getQueryParameters.ts
+++ b/src/utils/getQueryParameters.ts
@@ -1,6 +1,9 @@
 import qs from "qs";
 
-const getQueryParameters = (search: string) =>
+export const getQueryParameters = (search: string) =>
   qs.parse(search, { ignoreQueryPrefix: true });
 
+/**
+ * @deprecated use named export instead
+ */
 export default getQueryParameters;

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -3,10 +3,17 @@ import { FirebaseReducer } from "react-redux-firebase";
 import { RootState } from "index";
 
 import { AnyVenue } from "types/Firestore";
+import { Purchase } from "types/Purchase";
 import { SparkleSelector } from "types/SparkleSelector";
 import { User } from "types/User";
+import { VenueEvent } from "types/VenueEvent";
 
 import { WithId } from "utils/id";
+
+import {
+  makeIsRequestedSelector,
+  makeOrderedSelector,
+} from "./firestoreSelectors";
 
 /**
  * Selector to retrieve Firebase auth from Redux.
@@ -74,3 +81,27 @@ export const makeVenueSelector = (venueId: string) => (
 
   return { ...venues[venueId], id: venueId };
 };
+
+export const currentEventSelector: SparkleSelector<
+  WithId<VenueEvent>[]
+> = makeOrderedSelector("currentEvent");
+
+export const userPurchaseHistorySelector: SparkleSelector<
+  WithId<Purchase>[]
+> = makeOrderedSelector("userPurchaseHistory");
+
+export const shouldRetainAttendanceSelector: SparkleSelector<boolean> = (
+  state: RootState
+) => state.attendance.retainAttendance;
+
+export const isCurrentVenueRequestedSelector: SparkleSelector<boolean> = makeIsRequestedSelector(
+  "currentVenue"
+);
+
+export const isCurrentEventRequestedSelector: SparkleSelector<boolean> = makeIsRequestedSelector(
+  "currentEvent"
+);
+
+export const isUserPurchaseHistoryRequestedSelector: SparkleSelector<boolean> = makeIsRequestedSelector(
+  "userPurchaseHistory"
+);

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -27,6 +27,15 @@ export const profileSelector: SparkleSelector<FirebaseReducer.Profile<User>> = (
 ) => state.firebase.profile;
 
 /**
+ * Selector to retrieve currentVenue?.[0] from the Redux Firestore.
+ *
+ * @param state the Redux store
+ */
+export const currentVenueSelector: SparkleSelector<AnyVenue> = (
+  state: RootState
+) => state.firestore.ordered.currentVenue?.[0];
+
+/**
  * Selector to retrieve partygoers from the Redux Firestore.
  *
  * @param state the Redux store

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -1,7 +1,30 @@
+import { FirebaseReducer } from "react-redux-firebase";
+
 import { RootState } from "index";
+
 import { AnyVenue } from "types/Firestore";
 import { SparkleSelector } from "types/SparkleSelector";
-import { WithId } from "./id";
+import { User } from "types/User";
+
+import { WithId } from "utils/id";
+
+/**
+ * Selector to retrieve Firebase auth from Redux.
+ *
+ * @param state the Redux store
+ */
+export const authSelector: SparkleSelector<FirebaseReducer.AuthState> = (
+  state: RootState
+) => state.firebase.auth;
+
+/**
+ * Selector to retrieve Firebase profile from Redux.
+ *
+ * @param state the Redux store
+ */
+export const profileSelector: SparkleSelector<FirebaseReducer.Profile<User>> = (
+  state: RootState
+) => state.firebase.profile;
 
 /**
  * Selector to retrieve venues from the Redux Firestore.

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -27,6 +27,15 @@ export const profileSelector: SparkleSelector<FirebaseReducer.Profile<User>> = (
 ) => state.firebase.profile;
 
 /**
+ * Selector to retrieve partygoers from the Redux Firestore.
+ *
+ * @param state the Redux store
+ */
+export const partygoersSelector: SparkleSelector<WithId<User>[]> = (
+  state: RootState
+) => state.firestore.ordered.partygoers;
+
+/**
  * Selector to retrieve venues from the Redux Firestore.
  *
  * @param state the Redux store

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -60,6 +60,10 @@ export const venuesSelector: SparkleSelector<Record<string, AnyVenue>> = (
   state
 ) => state.firestore.data.venues || {};
 
+export const venuesOrderedSelector: SparkleSelector<
+  WithId<AnyVenue>[] | undefined
+> = (state) => state.firestore.ordered.venues;
+
 /**
  * Makes a venueSelector selector for a given venueId, which when called
  * will retrieve the specified venue from the Redux Firestore.


### PR DESCRIPTION
**Note:** this is only the first PR for _'Large Party Map' Performance_. I'm splitting them up to make code review easier, and to reduce the risk of deployments by working incrementally. I will link the others here when they are also ready.

----

**IMPORTANT:** This code should be cloned/checked by running before considering it ready to be merged. Subtle breakages may occur due to fixing re-renders (eg. where a feature was inadvertently dependent on the buggy re-render logic)

----

## Summary

- add firebase helper scripts
- add `useUserLastSeenLimit` (extracted from `useConnectPartyGoers`)
- add selectors
  - 'core' selectors for firestore: `firestoreDataSelector`, `firestoreOrderedSelector`, `firestoreStatusSelector`
  - `authSelector`, `profileSelector`, `currentVenueSelector`, `partygoersSelector`, `currentEventSelector`, `userPurchaseHistorySelector`, `shouldRetainAttendanceSelector`, `isCurrentVenueRequestedSelector`, `isCurrentEventRequestedSelector`, `isUserPurchaseHistoryRequestedSelector `
- add 'core' 'make selector' helpers for firestore
- refactor `Firestore` types to separately export `FirestoreStatus`, `FirestoreData`, `FirestoreOrdered` types + sort keys alphabetically + add `ValidFirestoreKeys` type
- add `useSparkleFirestoreConnect()` hook that uses `ValidFirestoreKeys` to constrain the allowed values for `storeAs`
- refactor `useConnectPartyGoers()` to also export selected `partygoers` data
- refactor a number of components to replace inline selectors with external 'static reference' selectors
  - including `VenuePage`, etc
- refactor a number of components/hooks/helpers/etc to use named exports + deprecate their `default` exports
  - note: refactoring all usages of the default exports was considered OOS/tech debt for future cleanup
- cleanup imports on legacy `PartyMap` component + related components (`RoomModal`, `Map`, `PartyTitle`, `RoomAttendance`, `RoomCard`, `RoomList`, `RoomModalOngoingEvent`, `ScheduleItem`)
  - exported all named components from `src/components/templates/PartyMap/components/index.ts`
- cleanup imports on `VenuePage`
- probably a bunch more things now... check the commits for a full list..

You can also look at the [commits](https://github.com/sparkletown/sparkle/pull/721/commits), which should be fairly descriptive/self contained.