### PR TITLE
'Large Party Map' Performance - Part 2/x

### DIFF
--- a/src/components/molecules/CallOutMessageForm/CallOutMessageForm.tsx
+++ b/src/components/molecules/CallOutMessageForm/CallOutMessageForm.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+
+import { currentVenueSelectorData } from "utils/selectors";
+
 import { useSelector } from "hooks/useSelector";
 
 interface PropsType {
@@ -10,9 +13,7 @@ interface PropsType {
 // eslint-disable-next-line react/display-name
 const CallOutMessageForm = React.forwardRef<HTMLInputElement, PropsType>(
   ({ onSubmit, placeholder, isMessageToTheBandSent }, ref) => {
-    const { venue } = useSelector((state) => ({
-      venue: state.firestore.data.currentVenue,
-    }));
+    const venue = useSelector(currentVenueSelectorData);
     return (
       <form onSubmit={onSubmit} className="form-message">
         <input name="messageToTheBand" placeholder={placeholder} ref={ref} />

--- a/src/components/molecules/EventPaymentButton/EventPaymentButton.tsx
+++ b/src/components/molecules/EventPaymentButton/EventPaymentButton.tsx
@@ -11,6 +11,10 @@ import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
 import { WithId } from "utils/id";
 import { venueEntranceUrl } from "utils/url";
+import {
+  currentVenueSelectorData,
+  userPurchaseHistorySelector,
+} from "utils/selectors";
 
 interface PropsType {
   event: WithId<VenueEvent>;
@@ -31,10 +35,9 @@ const EventPaymentButton: React.FunctionComponent<PropsType> = ({
 }) => {
   useConnectUserPurchaseHistory();
   const { user } = useUser();
-  const { purchaseHistory, venue } = useSelector((state) => ({
-    purchaseHistory: state.firestore.ordered.userPurchaseHistory,
-    venue: state.firestore.data.currentVenue,
-  }));
+
+  const venue = useSelector(currentVenueSelectorData);
+  const purchaseHistory = useSelector(userPurchaseHistorySelector);
 
   const hasUserAlreadyBoughtTicket =
     hasUserBoughtTicketForEvent(purchaseHistory, event.id) ||

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -49,6 +49,7 @@ import UpcomingTickets from "components/molecules/UpcomingTickets";
 
 import "./NavBar.scss";
 import "./playa.scss";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const TicketsPopover: React.FC<{ futureUpcoming: UpcomingEvent[] }> = (
   props: unknown,
@@ -94,7 +95,7 @@ const RadioPopover: React.FC<RadioModalPropsType> = (props) => (
 );
 
 const navBarSelector = (state: RootState) => ({
-  venue: state.firestore.data.currentVenue,
+  venue: currentVenueSelectorData(state),
   privateChats: state.firestore.ordered.privatechats,
   radioStations: state.firestore.data.venues?.playa?.radioStations,
   parentVenue: state.firestore.data.parentVenue,

--- a/src/components/molecules/OnlineStats/OnlineStats.tsx
+++ b/src/components/molecules/OnlineStats/OnlineStats.tsx
@@ -20,6 +20,7 @@ import { useSelector } from "hooks/useSelector";
 import useConnectPartyGoers from "hooks/useConnectPartyGoers";
 import { ENABLE_PLAYA_ADDRESS, PLAYA_VENUE_NAME } from "settings";
 import { playaAddress } from "utils/address";
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
 
 interface PotLuckButtonProps {
   venues?: Array<WithId<AnyVenue>>;
@@ -70,10 +71,8 @@ const OnlineStats: React.FC = () => {
     WithId<User>
   >();
 
-  const { partygoers, venue } = useSelector((state) => ({
-    partygoers: state.firestore.ordered.partygoers,
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
+  const users = useSelector(partygoersSelector);
 
   useEffect(() => {
     const getOnlineStats = firebase

--- a/src/components/molecules/OnlineStats/OnlineStats.tsx
+++ b/src/components/molecules/OnlineStats/OnlineStats.tsx
@@ -72,7 +72,7 @@ const OnlineStats: React.FC = () => {
   >();
 
   const venue = useSelector(currentVenueSelectorData);
-  const users = useSelector(partygoersSelector);
+  const partygoers = useSelector(partygoersSelector);
 
   useEffect(() => {
     const getOnlineStats = firebase

--- a/src/components/molecules/TableComponent/TableComponent.tsx
+++ b/src/components/molecules/TableComponent/TableComponent.tsx
@@ -3,6 +3,7 @@ import { TableComponentPropsType } from "types/Table";
 import "./TableComponent.scss";
 import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const TableComponent: React.FunctionComponent<TableComponentPropsType> = ({
   users,
@@ -14,9 +15,7 @@ const TableComponent: React.FunctionComponent<TableComponentPropsType> = ({
   table,
   tableLocked,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
   const locked = tableLocked(table.reference);
   const usersSeatedAtTable = users.filter(
     (u) => u.data?.[experienceName]?.table === table.reference

--- a/src/components/molecules/UserList/UserList.tsx
+++ b/src/components/molecules/UserList/UserList.tsx
@@ -9,6 +9,7 @@ import { useSelector } from "hooks/useSelector";
 
 // Utils | Settings | Constants
 import { WithId } from "utils/id";
+import { currentVenueSelectorData } from "utils/selectors";
 import { DEFAULT_USER_LIST_LIMIT } from "settings";
 import { IS_BURN } from "secrets";
 
@@ -46,9 +47,7 @@ const UserList: React.FunctionComponent<PropsType> = ({
   users = users?.filter((user) => !user.anonMode && user.partyName && user.id); // quick fix to get rid of anonymous users
   const usersToDisplay = isExpanded ? users : users?.slice(0, limit);
   const attendance = users.length + (attendanceBoost ?? 0);
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
 
   if (!users) return <></>;
   return (

--- a/src/components/organisms/ChatDrawer/ChatDrawer.tsx
+++ b/src/components/organisms/ChatDrawer/ChatDrawer.tsx
@@ -16,6 +16,7 @@ import useRoles from "hooks/useRoles";
 import { useVenueId } from "hooks/useVenueId";
 import { getDaysAgoInSeconds } from "utils/time";
 import { VENUE_CHAT_AGE_DAYS } from "settings";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface ChatOutDataType {
   messageToTheBand: string;
@@ -37,7 +38,7 @@ const ChatDrawer: React.FC<PropsType> = ({
   const { user } = useUser();
   const venueId = useVenueId();
   const { userRoles } = useRoles();
-  const venue = useSelector((state) => state.firestore.data.currentVenue);
+  const venue = useSelector(currentVenueSelectorData);
 
   const chats = useSelector((state) => state.firestore.ordered.venueChats);
   const [isMessageToTheBarSent, setIsMessageToTheBarSent] = useState(false);

--- a/src/components/organisms/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/organisms/EditProfileModal/EditProfileModal.tsx
@@ -9,6 +9,7 @@ import { QuestionType } from "types/Question";
 import ProfilePictureInput from "components/molecules/ProfilePictureInput";
 import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface PropsType {
   show: boolean;
@@ -21,7 +22,7 @@ const EditProfileModal: React.FunctionComponent<PropsType> = ({
 }) => {
   const { user, profile } = useUser();
   const profileQuestions = useSelector(
-    (state) => state.firestore.data.currentVenue?.profile_questions
+    (state) => currentVenueSelectorData(state)?.profile_questions
   );
   const onSubmit = async (data: ProfileFormData & QuestionsFormData) => {
     if (!user) return;

--- a/src/components/organisms/PaymentModal/PaymentModal.tsx
+++ b/src/components/organisms/PaymentModal/PaymentModal.tsx
@@ -12,6 +12,10 @@ import { Venue } from "types/Venue";
 import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
 import { WithId } from "utils/id";
+import {
+  currentVenueSelectorData,
+  userPurchaseHistorySelector,
+} from "utils/selectors";
 
 interface PropsType {
   show: boolean;
@@ -30,18 +34,13 @@ const PaymentModal: React.FunctionComponent<PropsType> = ({
 }) => {
   useConnectUserPurchaseHistory();
   const { user } = useUser();
-  const { purchaseHistory, purchaseHistoryRequestStatus, venue } = useSelector(
-    (state) => ({
-      purchaseHistory: state.firestore.ordered.userPurchaseHistory,
-      purchaseHistoryRequestStatus:
-        state.firestore.status.requested.userPurchaseHistory,
-      venue: state.firestore.data.currentVenue,
-    })
-  ) as {
-    purchaseHistory: Purchase[];
-    purchaseHistoryRequestStatus: boolean;
-    venue: Venue;
-  };
+  const venue = useSelector(currentVenueSelectorData) as Venue;
+  const purchaseHistory = useSelector(
+    userPurchaseHistorySelector
+  ) as Purchase[];
+  const purchaseHistoryRequestStatus = useSelector(
+    (state) => state.firestore.status.requested.userPurchaseHistory
+  );
 
   const [isPaymentProceeding, setIsPaymentProceeding] = useState(false);
   const [isCardBeingSaved, setIsCardBeingSaved] = useState(false);

--- a/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
+++ b/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
@@ -9,6 +9,7 @@ import ProfilePictureInput from "components/molecules/ProfilePictureInput";
 import { useUser } from "hooks/useUser";
 import { DEFAULT_PROFILE_IMAGE } from "settings";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface EditProfileFormValuesType {
   partyName: string;
@@ -25,7 +26,7 @@ const EditProfileForm: React.FunctionComponent<PropsType> = ({
 }) => {
   const { user, profile } = useUser();
   const profileQuestions = useSelector(
-    (state) => state.firestore.data.currentVenue?.profile_questions
+    (state) => currentVenueSelectorData(state)?.profile_questions
   );
   const onSubmit = async (data: ProfileFormData & QuestionsFormData) => {
     if (!user) return;

--- a/src/components/organisms/ProfileModal/UserInformationContent/UserInformationContent.tsx
+++ b/src/components/organisms/ProfileModal/UserInformationContent/UserInformationContent.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_PROFILE_VALUES } from "../constants";
 import { updateUserProfile } from "pages/Account/helpers";
 import { useVenueId } from "hooks/useVenueId";
 import { venueLandingUrl } from "utils/url";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface PropsType {
   setIsEditMode: (value: boolean) => void;
@@ -24,7 +25,7 @@ const UserInformationContent: React.FunctionComponent<PropsType> = ({
 }) => {
   const { user, profile } = useUser();
   const profileQuestions = useSelector(
-    (state) => state.firestore.data.currentVenue?.profile_questions
+    (state) => currentVenueSelectorData(state)?.profile_questions
   );
   const venueId = useVenueId();
 

--- a/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
+++ b/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
@@ -13,6 +13,7 @@ import { useVenueId } from "hooks/useVenueId";
 import { useSelector } from "hooks/useSelector";
 import { Venue } from "types/Venue";
 import { WithId } from "utils/id";
+import { currentVenueSelectorData } from "utils/selectors";
 
 type DatedEvents = Array<{
   dateDay: Date;
@@ -26,7 +27,7 @@ export const SchedulePageModal: React.FunctionComponent = () => {
   const [loaded, setLoaded] = useState(false);
   const { profile } = useUser();
   const venueId = useVenueId();
-  const venue = useSelector((state) => state.firestore.data.currentVenue);
+  const venue = useSelector(currentVenueSelectorData);
 
   useEffect(() => {
     const updateStats = () => {

--- a/src/components/organisms/UserProfileModal/UserProfileModal.tsx
+++ b/src/components/organisms/UserProfileModal/UserProfileModal.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from "react";
 import { Modal } from "react-bootstrap";
+
+import {
+  currentVenueSelectorData,
+  orderedVenuesSelector,
+} from "utils/selectors";
+
 import { useUser } from "hooks/useUser";
 
 import "./UserProfileModal.scss";
@@ -36,9 +42,7 @@ const UserProfileModal: React.FunctionComponent<PropTypes> = ({
   zIndex,
   ...rest
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
 
   const { user } = useUser();
 
@@ -138,7 +142,7 @@ const Badges: React.FC<{ user: WithId<User> }> = ({ user }) => {
   const visits = useSelector(
     (state) => state.firestore.ordered.userModalVisits
   );
-  const venues = useSelector((state) => state.firestore.ordered.venues);
+  const venues = useSelector(orderedVenuesSelector);
 
   const playaTime = useMemo(() => {
     if (!visits) return undefined;
@@ -256,10 +260,8 @@ const getLocationLink = (venue: WithId<AnyVenue>, room?: CampRoomData) => {
 
 const SuspectedLocation: React.FC<{ user: WithId<User> }> = ({ user }) => {
   useFirestoreConnect("venues");
-  const { venues, venue } = useSelector((state) => ({
-    venues: state.firestore.ordered.venues,
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
+  const venues = useSelector(orderedVenuesSelector);
 
   const suspectedLocation = useMemo(
     () => ({

--- a/src/components/templates/ArtPiece/ArtPiece.tsx
+++ b/src/components/templates/ArtPiece/ArtPiece.tsx
@@ -12,11 +12,10 @@ import { SchedulePageModal } from "components/organisms/SchedulePageModal/Schedu
 import { IS_BURN } from "secrets";
 import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
 import BannerMessage from "components/molecules/BannerMessage";
+import { currentVenueSelectorData } from "utils/selectors";
 
 export const ArtPiece = () => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
 
   const [isLeftColumnExpanded, setIsLeftColumnExpanded] = useState(false);
   const [showEventSchedule, setShowEventSchedule] = useState(false);

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -30,6 +30,7 @@ import { useVenueId } from "hooks/useVenueId";
 import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
 import { REACTION_TIMEOUT } from "settings";
 import { WithId } from "utils/id";
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
 
 // Typings
 import { User } from "types/User";
@@ -131,10 +132,9 @@ const requiredAuditoriumSize = (occupants: number) => {
 export const Audience: React.FunctionComponent = () => {
   const venueId = useVenueId();
   const { user, profile } = useUser();
-  const { venue, partygoers } = useSelector((state) => ({
-    partygoers: state.firestore.ordered.partygoers,
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
+  const partygoers = useSelector(partygoersSelector);
+
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();

--- a/src/components/templates/Audience/AudienceRouter.tsx
+++ b/src/components/templates/Audience/AudienceRouter.tsx
@@ -5,13 +5,12 @@ import VideoAdmin from "pages/VideoAdmin";
 import { Venue } from "types/Venue";
 import { ExperienceContextWrapper } from "components/context/ExperienceContext";
 import { Audience } from "./Audience";
+import { currentVenueSelectorData } from "utils/selectors";
 
 export const AudienceRouter: React.FunctionComponent = () => {
   const match = useRouteMatch();
 
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  })) as { venue: Venue };
+  const venue = useSelector(currentVenueSelectorData) as Venue;
 
   return (
     <Switch>

--- a/src/components/templates/AvatarGrid/AvatarAdmin.tsx
+++ b/src/components/templates/AvatarGrid/AvatarAdmin.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "hooks/useSelector";
 import firebase from "firebase/app";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const AvatarAdmin: React.FC = () => {
   const [bannerMessage, setBannerMessage] = useState("");
   const [error, setError] = useState<string | null>();
 
-  const currentVenue = useSelector(
-    (state) => state.firestore.data.currentVenue
-  );
+  const currentVenue = useSelector(currentVenueSelectorData);
+
   const FIREBASE_VENUE_ID = "memrisechats";
 
   useEffect(() => {

--- a/src/components/templates/AvatarGrid/AvatarGrid.tsx
+++ b/src/components/templates/AvatarGrid/AvatarGrid.tsx
@@ -18,6 +18,7 @@ import { useVenueId } from "hooks/useVenueId";
 // Utils | Settings | Constants
 import { WithId } from "utils/id";
 import { enterRoom } from "utils/useLocationUpdateEffect";
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
 import { currentTimeInUnixEpoch } from "utils/time";
 
 // Typings
@@ -33,10 +34,10 @@ const DEFAULT_ROWS = 25;
 const AvatarGrid = () => {
   const venueId = useVenueId();
   const { user, profile } = useUser();
-  const { venue, partygoers } = useSelector((state) => ({
-    partygoers: state.firestore.ordered.partygoers,
-    venue: state.firestore.data.currentVenue,
-  }));
+
+  const venue = useSelector(currentVenueSelectorData);
+  const partygoers = useSelector(partygoersSelector);
+
   const [isRoomModalOpen, setIsRoomModalOpen] = useState<boolean>(false);
   const [selectedRoom, setSelectedRoom] = useState<AvatarGridRoom | undefined>(
     undefined

--- a/src/components/templates/Camp/Camp.tsx
+++ b/src/components/templates/Camp/Camp.tsx
@@ -2,14 +2,14 @@ import React, { useState, useCallback, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { Modal } from "react-bootstrap";
 
+import { RootState } from "index";
 import { createUrlSafeName } from "api/admin";
-import { LOC_UPDATE_FREQ_MS } from "settings";
 import { IS_BURN } from "secrets";
 
 import { CampRoomData } from "types/CampRoomData";
 import { CampVenue } from "types/CampVenue";
 
-import useConnectPartyGoers from "hooks/useConnectPartyGoers";
+import { useCampPartygoers } from "hooks/useCampPartygoers";
 import { useSelector } from "hooks/useSelector";
 
 import ChatDrawer from "components/organisms/ChatDrawer";
@@ -28,34 +28,16 @@ import { RoomModal } from "./components/RoomModal";
 
 import "./Camp.scss";
 
+const campVenueSelector = (state: RootState) =>
+  state.firestore.ordered.currentVenue?.[0] as CampVenue;
+
 const Camp: React.FC = () => {
-  useConnectPartyGoers();
   const [isRoomModalOpen, setIsRoomModalOpen] = useState(false);
   const [selectedRoom, setSelectedRoom] = useState<CampRoomData | undefined>();
   const [showEventSchedule, setShowEventSchedule] = useState(false);
-  const [nowMs, setNowMs] = useState(new Date().getTime());
 
-  const { partygoers, venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0] as CampVenue,
-    partygoers: state.firestore.ordered.partygoers,
-  }));
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNowMs(new Date().getTime());
-    }, LOC_UPDATE_FREQ_MS);
-
-    return () => clearInterval(interval);
-  }, [setNowMs]);
-
-  const usersInCamp = partygoers
-    ? partygoers.filter(
-        (partygoer) =>
-          partygoer?.lastSeenIn &&
-          partygoer?.lastSeenIn[venue.name] >
-            (nowMs - LOC_UPDATE_FREQ_MS * 2) / 1000
-      )
-    : [];
+  const venue = useSelector(campVenueSelector);
+  const usersInCamp = useCampPartygoers(venue.name);
 
   const attendances = usersInCamp
     ? usersInCamp.reduce<Record<string, number>>((acc, value) => {

--- a/src/components/templates/Camp/Camp.tsx
+++ b/src/components/templates/Camp/Camp.tsx
@@ -1,25 +1,32 @@
 import React, { useState, useCallback, useEffect } from "react";
-import useConnectPartyGoers from "hooks/useConnectPartyGoers";
-import { useSelector } from "hooks/useSelector";
+import { useParams } from "react-router-dom";
+import { Modal } from "react-bootstrap";
+
+import { createUrlSafeName } from "api/admin";
 import { LOC_UPDATE_FREQ_MS } from "settings";
 import { IS_BURN } from "secrets";
-import UserList from "components/molecules/UserList";
+
 import { CampRoomData } from "types/CampRoomData";
+import { CampVenue } from "types/CampVenue";
+
+import useConnectPartyGoers from "hooks/useConnectPartyGoers";
+import { useSelector } from "hooks/useSelector";
+
+import ChatDrawer from "components/organisms/ChatDrawer";
+import { SchedulePageModal } from "components/organisms/SchedulePageModal/SchedulePageModal";
+
+import UserList from "components/molecules/UserList";
 import CountDown from "components/molecules/CountDown";
+import SparkleFairiesPopUp from "components/molecules/SparkleFairiesPopUp/SparkleFairiesPopUp";
+
+import BannerMessage from "components/molecules/BannerMessage";
+import { InfoDrawer } from "components/molecules/InfoDrawer/InfoDrawer";
+
 import { Map } from "./components/Map";
 import { RoomList } from "./components/RoomList";
 import { RoomModal } from "./components/RoomModal";
-import { CampVenue } from "types/CampVenue";
-import ChatDrawer from "components/organisms/ChatDrawer";
-import SparkleFairiesPopUp from "components/molecules/SparkleFairiesPopUp/SparkleFairiesPopUp";
-import { useParams } from "react-router-dom";
-import { InfoDrawer } from "components/molecules/InfoDrawer/InfoDrawer";
-import { Modal } from "react-bootstrap";
-import { SchedulePageModal } from "components/organisms/SchedulePageModal/SchedulePageModal";
-import { createUrlSafeName } from "api/admin";
 
 import "./Camp.scss";
-import BannerMessage from "components/molecules/BannerMessage";
 
 const Camp: React.FC = () => {
   useConnectPartyGoers();

--- a/src/components/templates/Camp/CampAdmin.tsx
+++ b/src/components/templates/Camp/CampAdmin.tsx
@@ -2,14 +2,13 @@ import React, { useState, useEffect } from "react";
 import { useSelector } from "hooks/useSelector";
 import firebase from "firebase/app";
 import { useVenueId } from "hooks/useVenueId";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const CampAdmin: React.FC = () => {
   const [bannerMessage, setBannerMessage] = useState("");
   const [error, setError] = useState<string | null>();
 
-  const currentVenue = useSelector(
-    (state) => state.firestore.data.currentVenue
-  );
+  const currentVenue = useSelector(currentVenueSelectorData);
   const venueId = useVenueId();
 
   useEffect(() => {

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -6,6 +6,8 @@ import { retainAttendance } from "store/actions/Attendance";
 
 import firebase from "firebase/app";
 
+import { orderedVenuesSelector } from "utils/selectors";
+
 import { CampRoomData } from "types/CampRoomData";
 import { CampVenue } from "types/CampVenue";
 import { User } from "types/User";
@@ -64,9 +66,7 @@ export const Map: React.FC<MapProps> = ({
   const [isHittingRoom, setIsHittingRoom] = useState(false);
   const [rows, setRows] = useState<number>(0);
 
-  const { venues } = useSelector((state) => ({
-    venues: state.firestore.ordered.venues,
-  }));
+  const venues = useSelector(orderedVenuesSelector);
 
   const columns = venue.columns ?? DEFAULT_COLUMNS;
   const rooms = [...venue.rooms];

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -13,6 +13,7 @@ import { RoomVisibility } from "types/Venue";
 
 import { WithId } from "utils/id";
 import { currentTimeInUnixEpoch } from "utils/time";
+import { getRoomUrl, isExternalUrl, openRoomUrl } from "utils/url";
 import { enterRoom } from "utils/useLocationUpdateEffect";
 
 import { useUser } from "hooks/useUser";
@@ -184,13 +185,6 @@ export const Map: React.FC<MapProps> = ({
     [columns, isHittingRoom, rooms, rows, selectedRoom, setSelectedRoom]
   );
 
-  const isExternalLink = useCallback(
-    (url: string) =>
-      url.includes("http") &&
-      new URL(window.location.href).host !== new URL(getRoomUrl(url)).host,
-    []
-  );
-
   const roomEnter = useCallback(
     (room: CampRoomData) => {
       const roomVenue = venues?.find((venue) =>
@@ -246,12 +240,7 @@ export const Map: React.FC<MapProps> = ({
       if (enterPress && selectedRoom) {
         setKeyDown(true);
         setTimeout(() => setKeyDown(false), MOVEMENT_INTERVAL);
-
-        const isExternalUrl = isExternalLink(selectedRoom.url);
-        window.open(
-          getRoomUrl(selectedRoom.url),
-          isExternalUrl ? "_blank" : "noopener,noreferrer"
-        );
+        openRoomUrl(selectedRoom.url);
         roomEnter(selectedRoom);
         return;
       }
@@ -307,7 +296,6 @@ export const Map: React.FC<MapProps> = ({
     enterPress,
     selectedRoom,
     partygoersBySeat,
-    isExternalLink,
     roomEnter,
     hitRoom,
     takeSeat,
@@ -324,10 +312,6 @@ export const Map: React.FC<MapProps> = ({
       rooms.push(chosenRoom[0]);
     }
   }
-
-  const getRoomUrl = (roomUrl: string) => {
-    return roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
-  };
 
   const openModal = (room: CampRoomData) => {
     setSelectedRoom(room);
@@ -374,8 +358,8 @@ export const Map: React.FC<MapProps> = ({
     room: CampRoomData
   ) => {
     e.stopPropagation();
-    if (isExternalLink(room.url)) {
-      window.open(getRoomUrl(room.url));
+    if (isExternalUrl(room.url)) {
+      openRoomUrl(room.url);
     } else {
       window.location.href = getRoomUrl(room.url);
     }
@@ -580,7 +564,7 @@ export const Map: React.FC<MapProps> = ({
                         <p>{room.about}</p>
                       </div>
                       <div className="camp-venue-actions">
-                        {isExternalLink(room.url) ? (
+                        {isExternalUrl(room.url) ? (
                           <a
                             className="btn btn-block btn-small btn-primary"
                             onClick={() => roomEnter(room)}

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -1,24 +1,34 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { CampVenue } from "types/CampVenue";
-import { CampRoomData } from "types/CampRoomData";
-import "./Map.scss";
-import { enterRoom } from "../../../../utils/useLocationUpdateEffect";
-import { useUser } from "../../../../hooks/useUser";
-import { IS_BURN } from "secrets";
-import { RoomVisibility } from "types/Venue";
-import { useDispatch } from "hooks/useDispatch";
-import { retainAttendance } from "store/actions/Attendance";
-import { currentTimeInUnixEpoch } from "utils/time";
-import UserProfilePicture from "components/molecules/UserProfilePicture";
-import { User } from "types/User";
-import { WithId } from "utils/id";
-import { useVenueId } from "hooks/useVenueId";
-import firebase from "firebase/app";
-import UserProfileModal from "components/organisms/UserProfileModal";
-import CampAttendance from "./CampAttendance";
-import { useSelector } from "hooks/useSelector";
 
-interface PropsType {
+import { IS_BURN } from "secrets";
+
+import { retainAttendance } from "store/actions/Attendance";
+
+import firebase from "firebase/app";
+
+import { CampRoomData } from "types/CampRoomData";
+import { CampVenue } from "types/CampVenue";
+import { User } from "types/User";
+import { RoomVisibility } from "types/Venue";
+
+import { WithId } from "utils/id";
+import { currentTimeInUnixEpoch } from "utils/time";
+import { enterRoom } from "utils/useLocationUpdateEffect";
+
+import { useUser } from "hooks/useUser";
+import { useDispatch } from "hooks/useDispatch";
+import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
+
+import UserProfileModal from "components/organisms/UserProfileModal";
+
+import UserProfilePicture from "components/molecules/UserProfilePicture";
+
+import CampAttendance from "./CampAttendance";
+
+import "./Map.scss";
+
+interface MapProps {
   venue: CampVenue;
   partygoers: WithId<User>[];
   attendances: { [location: string]: number };
@@ -31,7 +41,7 @@ const DEFAULT_COLUMNS = 40;
 const DEFAULT_ROWS = 25;
 const MOVEMENT_INTERVAL = 350;
 
-export const Map: React.FC<PropsType> = ({
+export const Map: React.FC<MapProps> = ({
   venue,
   partygoers,
   attendances,

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -21,7 +21,7 @@ import UserList from "components/molecules/UserList";
 import { RoomModalOngoingEvent } from "./RoomModalOngoingEvent";
 import { ScheduleItem } from "./ScheduleItem";
 
-import "templates/PartyMap/RoomModal/RoomModal.scss";
+import "components/templates/PartyMap/RoomModal/RoomModal.scss";
 
 interface RoomModalProps {
   show: boolean;

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -21,7 +21,7 @@ import UserList from "components/molecules/UserList";
 import { RoomModalOngoingEvent } from "./RoomModalOngoingEvent";
 import { ScheduleItem } from "./ScheduleItem";
 
-import "./RoomModal.scss";
+import "templates/PartyMap/RoomModal/RoomModal.scss";
 
 interface RoomModalProps {
   show: boolean;

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -1,26 +1,36 @@
 import React from "react";
-import { getCurrentEvent } from "utils/event";
-import { RoomModalOngoingEvent } from "./RoomModalOngoingEvent";
-import UserList from "components/molecules/UserList";
-import { ScheduleItem } from "./ScheduleItem";
-import { enterRoom } from "utils/useLocationUpdateEffect";
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
+import { useFirestoreConnect } from "react-redux-firebase";
 import { Modal } from "react-bootstrap";
+
 import { CampRoomData } from "types/CampRoomData";
 
-import "../../../templates/PartyMap/RoomModal/RoomModal.scss";
+import { getCurrentEvent } from "utils/event";
+import { enterRoom } from "utils/useLocationUpdateEffect";
+import {
+  currentVenueSelector,
+  orderedVenuesSelector,
+  partygoersSelector,
+} from "utils/selectors";
 import { currentTimeInUnixEpoch, ONE_MINUTE_IN_SECONDS } from "utils/time";
-import { useFirestoreConnect } from "react-redux-firebase";
 
-interface PropsType {
+import { useUser } from "hooks/useUser";
+import { useSelector } from "hooks/useSelector";
+
+import UserList from "components/molecules/UserList";
+
+import { RoomModalOngoingEvent } from "./RoomModalOngoingEvent";
+import { ScheduleItem } from "./ScheduleItem";
+
+import "./RoomModal.scss";
+
+interface RoomModalProps {
   show: boolean;
   onHide: () => void;
   room: CampRoomData | undefined;
   joinButtonText?: string;
 }
 
-export const RoomModal: React.FC<PropsType> = ({
+export const RoomModal: React.FC<RoomModalProps> = ({
   show,
   onHide,
   room,
@@ -28,12 +38,13 @@ export const RoomModal: React.FC<PropsType> = ({
 }) => {
   useFirestoreConnect("venues");
   const { user, profile } = useUser();
-  const { users, venueEvents, venues, venue } = useSelector((state) => ({
-    users: state.firestore.ordered.partygoers,
-    venueEvents: state.firestore.ordered.venueEvents,
-    venues: state.firestore.ordered.venues,
-    venue: state.firestore.ordered.currentVenue?.[0],
-  }));
+
+  const venue = useSelector(currentVenueSelector);
+  const venues = useSelector(orderedVenuesSelector);
+  const venueEvents = useSelector(
+    (state) => state.firestore.ordered.venueEvents
+  );
+  const users = useSelector(partygoersSelector);
 
   if (!room) {
     return <></>;

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -10,7 +10,7 @@ import { isExternalUrl } from "utils/url";
 
 import { useDispatch } from "hooks/useDispatch";
 
-import "./RoomModalOngoingEvent.scss";
+import "../../../templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.scss";
 
 interface RoomModalOngoingEventProps {
   room: CampRoomData;

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -1,32 +1,35 @@
 import React from "react";
-import { CampRoomData } from "types/CampRoomData";
-import { getCurrentEvent } from "utils/event";
-import { VenueEvent } from "types/VenueEvent";
 
-import "../../../templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.scss";
-import { useDispatch } from "hooks/useDispatch";
 import { retainAttendance } from "store/actions/Attendance";
 
-interface PropsType {
+import { CampRoomData } from "types/CampRoomData";
+import { VenueEvent } from "types/VenueEvent";
+
+import { getCurrentEvent } from "utils/event";
+
+import { useDispatch } from "hooks/useDispatch";
+
+import "./RoomModalOngoingEvent.scss";
+
+interface RoomModalOngoingEventProps {
   room: CampRoomData;
   roomEvents: VenueEvent[];
   enterRoom: () => void;
   joinButtonText?: string;
 }
 
-export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
+export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
   room,
   roomEvents,
   enterRoom,
   joinButtonText,
 }) => {
+  const dispatch = useDispatch();
   const currentEvent = roomEvents && getCurrentEvent(roomEvents);
   const eventToDisplay =
     roomEvents &&
     roomEvents.length > 0 &&
     (currentEvent ? currentEvent : roomEvents[0]);
-  const whatsOnText = currentEvent ? "What's on now" : "What's on next";
-  const dispatch = useDispatch();
   const getRoomUrl = (roomUrl: string) => {
     return roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
   };
@@ -45,7 +48,7 @@ export const RoomModalOngoingEvent: React.FunctionComponent<PropsType> = ({
               className="sparkle-icon"
               alt="sparkle-icon"
             />
-            {whatsOnText}
+            {currentEvent ? "What's on now" : "What's on next"}
           </div>
           <div className="artist-ongoing-container">
             <div className="event-title">{eventToDisplay.name}</div>

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -6,6 +6,7 @@ import { CampRoomData } from "types/CampRoomData";
 import { VenueEvent } from "types/VenueEvent";
 
 import { getCurrentEvent } from "utils/event";
+import { isExternalUrl } from "utils/url";
 
 import { useDispatch } from "hooks/useDispatch";
 
@@ -30,13 +31,6 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
     roomEvents &&
     roomEvents.length > 0 &&
     (currentEvent ? currentEvent : roomEvents[0]);
-  const getRoomUrl = (roomUrl: string) => {
-    return roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
-  };
-
-  const isExternalLink = (url: string) =>
-    url.includes("http") &&
-    new URL(window.location.href).host !== new URL(getRoomUrl(url)).host;
 
   return (
     <div className="room-modal-ongoing-event-container">
@@ -71,7 +65,7 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
           </div>
         </>
       )}
-      {isExternalLink(room.url) ? (
+      {isExternalUrl(room.url) ? (
         <a
           onMouseOver={() => dispatch(retainAttendance(true))}
           onMouseOut={() => dispatch(retainAttendance(false))}

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -1,3 +1,9 @@
+import React, { useEffect, useState } from "react";
+
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
+
+import { useSelector } from "hooks/useSelector";
+
 import InformationCard from "components/molecules/InformationCard";
 import TableComponent from "components/molecules/TableComponent";
 import TableHeader from "components/molecules/TableHeader";
@@ -6,17 +12,13 @@ import UserList from "components/molecules/UserList";
 import ChatDrawer from "components/organisms/ChatDrawer";
 import InformationLeftColumn from "components/organisms/InformationLeftColumn";
 import Room from "components/organisms/Room";
-import { useSelector } from "hooks/useSelector";
-import React, { useEffect, useState } from "react";
 import { LOC_UPDATE_FREQ_MS } from "settings";
 import { TABLES } from "./constants";
 import "./ConversationSpace.scss";
 
 export const ConversationSpace: React.FunctionComponent = () => {
-  const { venue, users } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-    users: state.firestore.ordered.partygoers,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
+  const users = useSelector(partygoersSelector);
 
   const [isLeftColumnExpanded, setIsLeftColumnExpanded] = useState(false);
   const [seatedAtTable, setSeatedAtTable] = useState("");

--- a/src/components/templates/Jazzbar/JazzBarSkeletonPage/JazzBarSkeletonPage.tsx
+++ b/src/components/templates/Jazzbar/JazzBarSkeletonPage/JazzBarSkeletonPage.tsx
@@ -4,6 +4,7 @@ import InformationCard from "components/molecules/InformationCard";
 import InformationLeftColumn from "components/organisms/InformationLeftColumn";
 import "./JazzBarSkeletonPage.scss";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface PropsType {
   children: React.ReactNode;
@@ -12,9 +13,7 @@ interface PropsType {
 const JazzBarSkeletonPage: React.FunctionComponent<PropsType> = ({
   children,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
 
   const [isLeftColumnExpanded, setIsLeftColumnExpanded] = useState(false);
 

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -24,6 +24,7 @@ import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import "./JazzTab.scss";
 import { LOC_UPDATE_FREQ_MS } from "settings";
 import { useFirestoreConnect } from "react-redux-firebase";
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
 
 interface PropsType {
   setUserList: (value: User[]) => void;
@@ -50,10 +51,9 @@ const Jazz: React.FunctionComponent<PropsType> = ({ setUserList, venue }) => {
   const [nowMs, setNowMs] = useState(new Date().getTime());
 
   const { user } = useUser();
-  const { firestoreVenue, users } = useSelector((state) => ({
-    firestoreVenue: state.firestore.data.currentVenue,
-    users: state.firestore.ordered.partygoers,
-  }));
+
+  const firestoreVenue = useSelector(currentVenueSelectorData);
+  const users = useSelector(partygoersSelector);
 
   const venueToUse = venue ? venue : firestoreVenue;
 

--- a/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
+++ b/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
@@ -7,14 +7,13 @@ import { ExperienceContextWrapper } from "components/context/ExperienceContext";
 import { Venue } from "types/Venue";
 import { useSelector } from "hooks/useSelector";
 import VideoAdmin from "pages/VideoAdmin";
+import { currentVenueSelectorData } from "utils/selectors";
 
 export const JazzbarRouter: React.FunctionComponent = () => {
   const match = useRouteMatch();
   useConnectPartyGoers();
 
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  })) as { venue: Venue };
+  const venue = useSelector(currentVenueSelectorData) as Venue;
 
   return (
     <ExperienceContextWrapper venueName={venue.name}>

--- a/src/components/templates/PartyMap/components/PartyTitle/PartyTitle.tsx
+++ b/src/components/templates/PartyMap/components/PartyTitle/PartyTitle.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { PartyMapVenue } from "types/PartyMapVenue";
+import { currentVenueSelectorData } from "utils/selectors";
 import { useSelector } from "hooks/useSelector";
 
 import CountDown from "components/molecules/CountDown";
@@ -16,9 +17,7 @@ export const PartyTitle: React.FunctionComponent<PropsType> = ({
   startUtcSeconds,
   withCountDown,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  })) as { venue: PartyMapVenue };
+  const venue = useSelector(currentVenueSelectorData) as PartyMapVenue;
 
   return (
     <div className="col">

--- a/src/components/templates/Playa/PlayaAdmin.tsx
+++ b/src/components/templates/Playa/PlayaAdmin.tsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect } from "react";
 import { useSelector } from "hooks/useSelector";
 import firebase from "firebase/app";
 import { PLAYA_VENUE_ID } from "settings";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const PlayaAdmin: React.FC = () => {
   const [bannerMessage, setBannerMessage] = useState("");
   const [error, setError] = useState<string | null>();
 
-  const playaVenue = useSelector((state) => state.firestore.data.currentVenue);
+  const playaVenue = useSelector(currentVenueSelectorData);
 
   useEffect(() => {
     setBannerMessage(playaVenue?.bannerMessage || "");

--- a/src/hooks/useCampPartygoers.ts
+++ b/src/hooks/useCampPartygoers.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { LOC_UPDATE_FREQ_MS } from "settings";
+import { User } from "types/User";
+import { WithId } from "utils/id";
+
+import {
+  partygoersSelector,
+  useConnectPartyGoers,
+} from "./useConnectPartyGoers";
+import { useSelector } from "./useSelector";
+
+/**
+ * Hook to retrieve a list of partygoers who were in venueName
+ * within lastSeenThreshold.
+ *
+ * @param venueName venueName to filter partygoers by
+ */
+export const useCampPartygoers = (venueName: string): WithId<User>[] => {
+  useConnectPartyGoers();
+  const partygoers = useSelector(partygoersSelector);
+
+  const [lastSeenThresholdMs, setLastSeenThresholdMs] = useState(Date.now());
+  const updateLastSeenThresholdMs = useCallback(() => {
+    setLastSeenThresholdMs((Date.now() - LOC_UPDATE_FREQ_MS * 2) / 1000);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(updateLastSeenThresholdMs, LOC_UPDATE_FREQ_MS);
+    return () => clearInterval(interval);
+  }, [updateLastSeenThresholdMs]);
+
+  return useMemo(
+    () =>
+      partygoers.filter(
+        (partygoer) => partygoer?.lastSeenIn?.[venueName] > lastSeenThresholdMs
+      ),
+    [partygoers, venueName, lastSeenThresholdMs]
+  );
+};

--- a/src/hooks/useCampPartygoers.ts
+++ b/src/hooks/useCampPartygoers.ts
@@ -3,11 +3,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { LOC_UPDATE_FREQ_MS } from "settings";
 import { User } from "types/User";
 import { WithId } from "utils/id";
+import { partygoersSelector } from "utils/selectors";
 
-import {
-  partygoersSelector,
-  useConnectPartyGoers,
-} from "./useConnectPartyGoers";
+import { useConnectPartyGoers } from "./useConnectPartyGoers";
 import { useSelector } from "./useSelector";
 
 /**

--- a/src/hooks/useConnectPartyGoers.ts
+++ b/src/hooks/useConnectPartyGoers.ts
@@ -5,6 +5,7 @@ import { partygoersSelector } from "utils/selectors";
 import { useSelector } from "./useSelector";
 import { useUserLastSeenLimit } from "./useUserLastSeenLimit";
 
+// @debt rename this useConnectPartygoers for consistency
 export const useConnectPartyGoers = () => {
   const userLastSeenLimit = useUserLastSeenLimit();
 

--- a/src/pages/Account/CodeOfConduct.tsx
+++ b/src/pages/Account/CodeOfConduct.tsx
@@ -10,6 +10,7 @@ import { useUser } from "hooks/useUser";
 import { useHistory } from "react-router-dom";
 import { useSelector } from "hooks/useSelector";
 import { venueInsideUrl } from "utils/url";
+import { currentVenueSelectorData } from "utils/selectors";
 import { IS_BURN } from "secrets";
 
 interface PropsType {
@@ -55,9 +56,7 @@ const CodeOfConduct: React.FunctionComponent<PropsType> = ({ location }) => {
   useConnectCurrentVenue();
 
   const { user } = useUser();
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
   const history = useHistory();
   const { venueId, returnUrl } = getQueryParameters(location.search);
   const { register, handleSubmit, errors, formState, watch } = useForm<

--- a/src/pages/Account/Login.tsx
+++ b/src/pages/Account/Login.tsx
@@ -10,6 +10,7 @@ import { RouterLocation } from "types/RouterLocation";
 import { updateTheme } from "pages/VenuePage/helpers";
 import { useSelector } from "hooks/useSelector";
 import { venueLandingUrl } from "utils/url";
+import { currentVenueSelectorData } from "utils/selectors";
 
 interface LoginFormData {
   email: string;
@@ -28,9 +29,7 @@ const Login: React.FunctionComponent<PropsType> = ({ location }) => {
   useConnectCurrentVenue();
   const history = useHistory();
   const { venueId } = getQueryParameters(location.search);
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
   const { register, handleSubmit, errors, formState, setError } = useForm<
     LoginFormData
   >({

--- a/src/pages/Account/Questions.tsx
+++ b/src/pages/Account/Questions.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
+import { currentVenueSelectorData } from "utils/selectors";
 import { updateUserProfile } from "./helpers";
 import "./Account.scss";
 import { QuestionType } from "types/Question";
@@ -26,9 +27,7 @@ const Questions: React.FunctionComponent<PropsType> = ({ location }) => {
 
   const history = useHistory();
   const { user } = useUser();
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-  })) as { venue: Venue };
+  const venue = useSelector(currentVenueSelectorData) as Venue;
   const { register, handleSubmit, formState } = useForm<QuestionsFormData>({
     mode: "onChange",
   });

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -40,7 +40,7 @@ import { VenueTemplate } from "types/VenueTemplate";
 
 import { isTruthyFilter } from "utils/filter";
 import { WithId } from "utils/id";
-import { makeVenueSelector } from "utils/selectors";
+import { makeVenueSelector, orderedVenuesSelector } from "utils/selectors";
 import { venueInsideUrl } from "utils/url";
 import {
   canHaveSubvenues,
@@ -79,7 +79,7 @@ const VenueList: React.FC<VenueListProps> = ({
   selectedVenueId,
   roomIndex,
 }) => {
-  const venues = useSelector((state) => state.firestore.ordered.venues);
+  const venues = useSelector(orderedVenuesSelector);
 
   if (!venues) return <>Loading...</>;
 

--- a/src/pages/FriendShipPage/FriendShipPage.tsx
+++ b/src/pages/FriendShipPage/FriendShipPage.tsx
@@ -9,10 +9,11 @@ import TableComponent from "components/molecules/TableComponent";
 import useConnectPartyGoers from "hooks/useConnectPartyGoers";
 import TableHeader from "components/molecules/TableHeader";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelectorData } from "utils/selectors";
 
 export const FriendShipPage: React.FunctionComponent = () => {
   const [seatedAtTable, setSeatedAtTable] = useState("");
-  const venue = useSelector((state) => state.firestore.data.currentVenue);
+  const venue = useSelector(currentVenueSelectorData);
 
   useConnectPartyGoers();
 

--- a/src/pages/ReactionPage/ReactionPage.tsx
+++ b/src/pages/ReactionPage/ReactionPage.tsx
@@ -47,10 +47,10 @@ const ReactionPage = () => {
               <ReactionList reactions={messagesToTheBand} chats={chats} />
             )}
           </div>
-          {partyGoers && (
+          {partygoers && (
             <div className="col-4">
               <UserList
-                users={partyGoers}
+                users={partygoers}
                 isAudioEffectDisabled
                 imageSize={50}
               />

--- a/src/pages/ReactionPage/ReactionPage.tsx
+++ b/src/pages/ReactionPage/ReactionPage.tsx
@@ -8,20 +8,17 @@ import ReactionList from "components/templates/Jazzbar/components/ReactionList";
 import { useSelector } from "hooks/useSelector";
 import { MessageToTheBandReaction } from "components/context/ExperienceContext";
 import { WithId } from "utils/id";
+import { currentVenueSelectorData, partygoersSelector } from "utils/selectors";
 
 const ReactionPage = () => {
   useConnectPartyGoers();
 
-  const { reactions, usersById, partyGoers, venue, chats } = useSelector(
-    (state) => ({
-      reactions: state.firestore.ordered.reactions,
-      usersById: state.firestore.data.partygoers,
-      partyGoers: state.firestore.ordered.partygoers,
-      venue: state.firestore.data.currentVenue,
-      chats: state.firestore.ordered.venueChats?.filter(
-        (chat) => chat.deleted !== true
-      ),
-    })
+  const venue = useSelector(currentVenueSelectorData);
+  const partygoers = useSelector(partygoersSelector);
+  const usersById = partygoers;
+  const reactions = useSelector((state) => state.firestore.ordered.reactions);
+  const chats = useSelector((state) =>
+    state.firestore.ordered.venueChats?.filter((chat) => chat.deleted !== true)
   );
 
   useFirestoreConnect([

--- a/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
+++ b/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
@@ -10,6 +10,7 @@ import { useFirebase } from "react-redux-firebase";
 import { Redirect, useHistory, useParams } from "react-router-dom";
 import { EntranceStepTemplate } from "types/EntranceStep";
 import { venueEntranceUrl, venueInsideUrl } from "utils/url";
+import { currentVenueSelectorData } from "utils/selectors";
 
 export const VenueEntrancePage: React.FunctionComponent<{}> = () => {
   const { user, profile } = useUser();
@@ -17,7 +18,7 @@ export const VenueEntrancePage: React.FunctionComponent<{}> = () => {
   const history = useHistory();
   const { step, venueId } = useParams();
   useConnectCurrentVenue();
-  const venue = useSelector((state) => state.firestore.data.currentVenue);
+  const venue = useSelector(currentVenueSelectorData);
 
   if (!venue || !venueId) {
     return <LoadingPage />;

--- a/src/pages/VenueLandingPage/VenueLandingPage.tsx
+++ b/src/pages/VenueLandingPage/VenueLandingPage.tsx
@@ -25,6 +25,10 @@ import { isUserAMember } from "utils/isUserAMember";
 import { getTimeBeforeParty, ONE_MINUTE_IN_SECONDS } from "utils/time";
 import "./VenueLandingPage.scss";
 import { venueEntranceUrl, venueInsideUrl } from "utils/url";
+import {
+  currentVenueSelectorData,
+  userPurchaseHistorySelector,
+} from "utils/selectors";
 
 export interface VenueLandingPageProps {
   venue: Firestore["data"]["currentVenue"];
@@ -38,17 +42,14 @@ export const VenueLandingPage: React.FunctionComponent<VenueLandingPageProps> = 
   const { venueId } = useParams();
   useConnectCurrentVenue();
 
-  const {
-    venue,
-    venueEvents,
-    venueRequestStatus,
-    purchaseHistory,
-  } = useSelector((state) => ({
-    venue: state.firestore.data.currentVenue,
-    venueRequestStatus: state.firestore.status.requested.currentVenue,
-    venueEvents: state.firestore.ordered.venueEvents,
-    purchaseHistory: state.firestore.ordered.userPurchaseHistory,
-  }));
+  const venue = useSelector(currentVenueSelectorData);
+  const venueRequestStatus = useSelector(
+    (state) => state.firestore.status.requested.currentVenue
+  );
+  const venueEvents = useSelector(
+    (state) => state.firestore.ordered.venueEvents
+  );
+  const purchaseHistory = useSelector(userPurchaseHistorySelector);
 
   useFirestoreConnect({
     collection: "venues",

--- a/src/pages/VideoAdmin/VideoAdmin.tsx
+++ b/src/pages/VideoAdmin/VideoAdmin.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from "react";
 import { useSelector } from "hooks/useSelector";
 import firebase from "firebase/app";
 import { useVenueId } from "hooks/useVenueId";
+import { currentVenueSelectorData } from "utils/selectors";
 
 const VideoAdmin: React.FC = () => {
   const venueId = useVenueId();
   const [iframeUrl, setIframeUrl] = useState("");
   const [error, setError] = useState<string | null>();
 
-  const venue = useSelector((state) => state.firestore.data.currentVenue);
+  const venue = useSelector(currentVenueSelectorData);
 
   useEffect(() => {
     setIframeUrl(venue?.iframeUrl || "");

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -42,6 +42,11 @@ export const currentVenueSelector: SparkleSelector<AnyVenue> = (
   state: RootState
 ) => state.firestore.ordered.currentVenue?.[0];
 
+// @debt can we merge this with currentVenueSelector and just use 1 canonical version?
+export const currentVenueSelectorData: SparkleSelector<AnyVenue | undefined> = (
+  state
+) => state.firestore.data.currentVenue;
+
 /**
  * Selector to retrieve partygoers from the Redux Firestore.
  *
@@ -59,6 +64,10 @@ export const partygoersSelector: SparkleSelector<WithId<User>[]> = (
 export const venuesSelector: SparkleSelector<Record<string, AnyVenue>> = (
   state
 ) => state.firestore.data.venues || {};
+
+export const orderedVenuesSelector: SparkleSelector<
+  WithId<AnyVenue>[] | undefined
+> = (state) => state.firestore.ordered.venues;
 
 /**
  * Makes a venueSelector selector for a given venueId, which when called

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -24,3 +24,19 @@ export const venueRoomUrl = (venue: WithId<AnyVenue>, roomTitle: string) => {
   );
   return venueRoom ? venueRoom.url : venueInsideUrl(venue.id);
 };
+
+export const isExternalUrl = (url: string) =>
+  url.includes("http") &&
+  window.location.host !== new URL(getRoomUrl(url)).host;
+
+// @debt I feel like we could construct this url in a better way
+export const getRoomUrl = (roomUrl: string) =>
+  roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
+
+export const openRoomUrl = (url: string) => {
+  openUrl(getRoomUrl(url));
+};
+
+export const openUrl = (url: string) => {
+  window.open(url, isExternalUrl(url) ? "_blank" : "noopener,noreferrer");
+};


### PR DESCRIPTION
Part 1: https://github.com/sparkletown/sparkle/pull/726 (though this PR isn't directly dependant on it)

This PR contains a bunch of smaller cleanup parts as part of improving the performance of `src/components/templates/Camp/components/Map.tsx`. I decided to split them out into this PR to minimize the complexity of the bigger changes to come.

Main changes:

- 5447ea43 add useCampPartygoers() hook + minor cleanup in useConnectPartyGoers()
- 5eb19306 refactor Camp to use useCampPartygoers() hook + static selector reference for campVenueSelector
- refactor isExternalUrl, getRoomUrl, openRoomUrl, openUrl into utils + updates references
- add currentVenueSelectorData, orderedVenuesSelector + refactor components to use them + some minor cleanup on the way

See [commits](https://github.com/sparkletown/sparkle/pull/727/commits) for the rest.