### PR TITLE
GitHub mention bot via GH Action

### DIFF
--- a/.github/mention-to-slack.yml
+++ b/.github/mention-to-slack.yml
@@ -1,0 +1,10 @@
+# For Github User
+# github_username: "slack_member_id"
+
+thecadams: "Chris Adams"
+IvanBuljovcic: "Ivan Buljovcic"
+denisdimitrov: "Denis Dimitrov"
+0xdevalias: "devalias"
+
+# For Github Team
+# github_teamname: "slack_member_id"

--- a/.github/workflows/mention-to-slack.yml
+++ b/.github/workflows/mention-to-slack.yml
@@ -1,0 +1,24 @@
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request:
+    types: [opened, edited, review_requested]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  mention-to-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run
+        uses: sparkletown/actions-mention-to-slack@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          icon-url: https://img.icons8.com/color/256/000000/github-2.png
+          bot-name: "GitHub Mention Bot"
+          run-id: ${{ github.run_id }}


### PR DESCRIPTION
This forks https://github.com/marketplace/actions/github-mention-to-slack in case it is ever compromised and so we can control the feature set, and makes it available in Sparkle repo as a GH action.