### PR TITLE
[MASTER][BUGFIX] fix undefined TypeError in useCampPartygoers hook

### DIFF
--- a/src/hooks/useCampPartygoers.ts
+++ b/src/hooks/useCampPartygoers.ts
@@ -30,9 +30,9 @@ export const useCampPartygoers = (venueName: string): WithId<User>[] => {
 
   return useMemo(
     () =>
-      partygoers.filter(
+      partygoers?.filter(
         (partygoer) => partygoer?.lastSeenIn?.[venueName] > lastSeenThresholdMs
-      ),
+      ) ?? [],
     [partygoers, venueName, lastSeenThresholdMs]
   );
 };


### PR DESCRIPTION
([ref](https://trello.com/c/KdLgkkbe))

**Note:** this PR is opened directly against `master` as this fix is urgent, and staging is currently not in an available state.

This bug is occasionally showing a black screen when logging in and/or when logging in for the first time, which is blocking upcoming events.

The types say that this shouldn't be possible, but the types are clearly wrong:

- https://github.com/sparkletown/sparkle/blob/staging/src/types/Firestore.ts#L73-L95

I believe technically all of these keys could be undefined, so they should really be `?` for all of them.