### PR TITLE
fix root Firestore types to be possibly undefined

### DIFF
--- a/src/components/context/ChatContext.tsx
+++ b/src/components/context/ChatContext.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from "react";
 import { useFirestoreConnect } from "react-redux-firebase";
+
 import firebase from "firebase/app";
 import { useSelector } from "hooks/useSelector";
+import { currentVenueSelector } from "utils/selectors";
 
 interface ChatContextType {
   sendGlobalChat: (from: string, text: string) => void;
@@ -85,18 +87,21 @@ function buildMessage(data: MessageBuilderInput): ChatMessage {
 export const ChatContextWrapper: React.FC<React.PropsWithChildren<{}>> = ({
   children,
 }) => {
-  const { venue } = useSelector((state) => ({
-    venue: state.firestore.ordered.currentVenue?.[0],
-  }));
+  const venue = useSelector(currentVenueSelector);
 
-  const chatCollectionName = `venues/${venue.id}/chats`;
+  // @debt this could end up as 'venues/undefined/chats'
+  const chatCollectionName = `venues/${venue?.id}/chats`;
 
-  useFirestoreConnect({
-    collection: "venues",
-    doc: venue.id,
-    subcollections: [{ collection: "chats" }],
-    storeAs: "venueChats",
-  });
+  useFirestoreConnect(
+    !!venue
+      ? {
+          collection: "venues",
+          doc: venue.id,
+          subcollections: [{ collection: "chats" }],
+          storeAs: "venueChats",
+        }
+      : undefined
+  );
 
   const sendGlobalChat = useCallback(
     (from, text) => {

--- a/src/components/molecules/ChatsList/ChatsList.tsx
+++ b/src/components/molecules/ChatsList/ChatsList.tsx
@@ -75,32 +75,36 @@ const ChatsList: React.FunctionComponent = () => {
 
   const onClickOnSender = useCallback(
     (sender: WithId<User>) => {
+      if (!privateChats) return;
+
       const chatsToUpdate = privateChats.filter(
         (chat) => !chat.isRead && chat.from === sender.id
       );
+
+      // @debt we're not using the return value, so should this be .forEach() instead of .map()?
       chatsToUpdate.map(
         (chat) => user && setPrivateChatMessageIsRead(user.uid, chat.id)
       );
+
       setSelectedUser(sender);
     },
     [privateChats, user]
   );
 
-  const chatsToDisplay = useMemo(
-    () =>
-      privateChats &&
-      privateChats
-        .filter(
-          (message) =>
-            message.deleted !== true &&
-            message.type === "private" &&
-            (message.to === selectedUser?.id ||
-              message.from === selectedUser?.id) &&
-            message.ts_utc.seconds > HIDE_BEFORE
-        )
-        .sort(chatSort),
-    [privateChats, selectedUser]
-  );
+  const chatsToDisplay = useMemo(() => {
+    if (!privateChats) return [];
+
+    return privateChats
+      .filter(
+        (message) =>
+          message.deleted !== true &&
+          message.type === "private" &&
+          (message.to === selectedUser?.id ||
+            message.from === selectedUser?.id) &&
+          message.ts_utc.seconds > HIDE_BEFORE
+      )
+      .sort(chatSort);
+  }, [privateChats, selectedUser, HIDE_BEFORE]);
 
   const chatContext = useContext(ChatContext);
   const submitMessage = useCallback(

--- a/src/components/molecules/LiveSchedule/LiveEvent.tsx
+++ b/src/components/molecules/LiveSchedule/LiveEvent.tsx
@@ -18,6 +18,9 @@ export const LiveEvent: FC<LiveEventProps> = ({ liveEvent }) => {
   const { user, profile } = useUser();
   const venue = useSelector(venueSelector);
   const enterLiveEvent = useCallback(() => {
+    if (!venue) return;
+
+    // @debt room ends up as any here
     const room = venue?.rooms?.find((room) => room.title === liveEvent.room);
 
     const isExternal = isExternalUrl(room.url);
@@ -26,6 +29,7 @@ export const LiveEvent: FC<LiveEventProps> = ({ liveEvent }) => {
     } else {
       window.location.href = room.url;
     }
+
     enterRoom(
       user!,
       { [`${venue.name}/${room.title}`]: currentTimeInUnixEpoch },

--- a/src/components/molecules/MessageList/MessageList.tsx
+++ b/src/components/molecules/MessageList/MessageList.tsx
@@ -6,6 +6,7 @@ import { Message } from "components/molecules/Message";
 import { useSelector } from "hooks/useSelector";
 import { WithId } from "utils/id";
 import { Modal } from "react-bootstrap";
+import { partygoersDataSelector } from "utils/selectors";
 
 interface MessageListProps {
   messages: WithId<RestrictedChatMessage>[];
@@ -18,7 +19,7 @@ export const MessageList: React.FC<MessageListProps> = ({
   allowDelete,
   deleteMessage,
 }) => {
-  const usersById = useSelector((state) => state.firestore.data.partygoers);
+  const usersById = useSelector(partygoersDataSelector);
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();
@@ -66,7 +67,7 @@ export const MessageList: React.FC<MessageListProps> = ({
         <div className="text-center">
           <p>
             Permanently delete message &quot;{messageToDelete?.text}&quot; from{" "}
-            {usersById[messageToDelete?.from ?? ""]?.partyName}?
+            {usersById?.[messageToDelete?.from ?? ""]?.partyName}?
           </p>
           <button
             type="button"

--- a/src/components/molecules/OnlineStats/OnlineStats.tsx
+++ b/src/components/molecules/OnlineStats/OnlineStats.tsx
@@ -130,13 +130,14 @@ const OnlineStats: React.FC = () => {
         : undefined,
     [venuesWithAttendance]
   );
-  const fuseUsers = useMemo(
-    () =>
-      new Fuse(partygoers, {
-        keys: ["partyName"],
-      }),
-    [partygoers]
-  );
+
+  const fuseUsers = useMemo(() => {
+    if (!partygoers) return;
+
+    return new Fuse(partygoers, {
+      keys: ["partyName"],
+    });
+  }, [partygoers]);
 
   const filteredVenues = useMemo(() => {
     if (filterVenueText === "") return venuesWithAttendance;
@@ -278,7 +279,7 @@ const OnlineStats: React.FC = () => {
               </div>
               <div className="users-container">
                 <div className="online-users">
-                  {partygoers.length} burners live
+                  {partygoers?.length} burners live
                 </div>
                 <div className="search-container">
                   <input
@@ -290,7 +291,7 @@ const OnlineStats: React.FC = () => {
                   />
                 </div>
                 <div className="people">
-                  {filteredUsers.map(
+                  {filteredUsers?.map(
                     (user, index) =>
                       !user.anonMode && (
                         <div
@@ -342,7 +343,8 @@ const OnlineStats: React.FC = () => {
         >
           <span>
             <FontAwesomeIcon className={"search-icon"} icon={faSearch} />
-            {liveEvents.length} live events / {partygoers.length} burners online
+            {liveEvents.length} live events / {partygoers?.length} burners
+            online
           </span>
         </OverlayTrigger>
       )}

--- a/src/components/molecules/VenueChat/VenueChat.tsx
+++ b/src/components/molecules/VenueChat/VenueChat.tsx
@@ -60,16 +60,15 @@ const VenueChat: FC = () => {
 
   const chatsToDisplay = useMemo(
     () =>
-      chats &&
       chats
-        .filter(
+        ?.filter(
           (message) =>
             message.deleted !== true &&
             message.type === "room" &&
             message.to === venueId &&
             message.ts_utc.seconds > HIDE_BEFORE
         )
-        .sort(chatSort),
+        .sort(chatSort) ?? [],
     [chats, venueId, HIDE_BEFORE]
   );
 

--- a/src/components/organisms/Chatbox/Chatbox.tsx
+++ b/src/components/organisms/Chatbox/Chatbox.tsx
@@ -17,7 +17,7 @@ import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
 import { chatSort } from "components/context/ChatContext";
 
 // Don't pull everything
-// REVISIT: only grab most recent N from server
+// @debt REVISIT: only grab most recent N from server
 const RECENT_MESSAGE_COUNT = 200;
 
 interface PropsType {
@@ -104,7 +104,8 @@ const Chatbox: React.FunctionComponent<PropsType> = ({
   };
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !userArray) return;
+
     if (!isRecipientChangeBlocked) {
       const lastChat = chatsToDisplay && chatsToDisplay[0];
       setPrivateRecipient(undefined);
@@ -231,31 +232,32 @@ const Chatbox: React.FunctionComponent<PropsType> = ({
                     />
                     {searchValue && (
                       <ul className="list-unstyled">
-                        {userArray
-                          .filter(
-                            (u) =>
-                              !u.anonMode &&
-                              u.partyName
-                                ?.toLowerCase()
-                                .includes(searchValue.toLowerCase())
-                          )
-                          .filter((u) => u.id !== undefined)
-                          .map((u) => (
-                            <Dropdown.Item
-                              onClick={() => setPrivateRecipient(u)}
-                              id="chatbox-dropdown-private-recipient"
-                              key={u.id}
-                            >
-                              <img
-                                src={u.pictureUrl}
-                                className="picture-logo"
-                                alt={u.partyName}
-                                width="20"
-                                height="20"
-                              />
-                              {u.partyName}
-                            </Dropdown.Item>
-                          ))}
+                        {userArray &&
+                          userArray
+                            .filter(
+                              (u) =>
+                                !u.anonMode &&
+                                u.partyName
+                                  ?.toLowerCase()
+                                  .includes(searchValue.toLowerCase())
+                            )
+                            .filter((u) => u.id !== undefined)
+                            .map((u) => (
+                              <Dropdown.Item
+                                onClick={() => setPrivateRecipient(u)}
+                                id="chatbox-dropdown-private-recipient"
+                                key={u.id}
+                              >
+                                <img
+                                  src={u.pictureUrl}
+                                  className="picture-logo"
+                                  alt={u.partyName}
+                                  width="20"
+                                  height="20"
+                                />
+                                {u.partyName}
+                              </Dropdown.Item>
+                            ))}
                       </ul>
                     )}
                   </Dropdown.Menu>

--- a/src/components/organisms/PrivateChatModal/PrivateChatModal.tsx
+++ b/src/components/organisms/PrivateChatModal/PrivateChatModal.tsx
@@ -59,6 +59,8 @@ const PrivateChatModal: React.FunctionComponent = () => {
     }, {});
 
   const onClickOnSender = (sender: WithId<User>) => {
+    if (!privateChats) return;
+
     const chatsToUpdate = privateChats.filter(
       (chat) => !chat.isRead && chat.from === sender.id
     );

--- a/src/components/organisms/Room/Room.tsx
+++ b/src/components/organisms/Room/Room.tsx
@@ -155,7 +155,7 @@ const Room: React.FC<RoomProps> = ({
   }, [roomName, token, setParticipantCount]);
 
   useEffect(() => {
-    if (!room) return;
+    if (!room || !users) return;
 
     setUserList([
       ...participants.map((p) => users[p.identity]),
@@ -178,7 +178,9 @@ const Room: React.FC<RoomProps> = ({
   // Video stream and local participant take up 2 slots
   // Ensure capacity is always even, so the grid works
 
-  const profileData = room ? users[room.localParticipant.identity] : undefined;
+  const profileData = room
+    ? users?.[room.localParticipant.identity]
+    : undefined;
 
   const meComponent = useMemo(() => {
     return room && profileData ? (
@@ -198,12 +200,12 @@ const Room: React.FC<RoomProps> = ({
   const othersComponents = useMemo(
     () =>
       participants.map((participant, index) => {
-        if (!participant) {
+        if (!participant || !users) {
           return null;
         }
 
         const bartender = !!meIsBartender
-          ? users[participant.identity]?.data?.[roomName]?.bartender
+          ? users?.[participant.identity]?.data?.[roomName]?.bartender
           : undefined;
 
         return (

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -190,7 +190,7 @@ export const Audience: React.FunctionComponent = () => {
   // That way, when the audience size is expanded these people keep their seats
   const partygoersBySeat: WithId<User>[][] = [];
   let seatedPartygoers = 0;
-  partygoers.forEach((partygoer) => {
+  partygoers?.forEach((partygoer) => {
     if (
       !venueId ||
       !partygoer?.data ||

--- a/src/components/templates/AvatarGrid/RoomModal.tsx
+++ b/src/components/templates/AvatarGrid/RoomModal.tsx
@@ -53,7 +53,7 @@ export const RoomModal: React.FC<PropsType> = ({
 
   const dispatch = useDispatch();
 
-  if (!room) {
+  if (!room || !venue) {
     return <></>;
   }
 
@@ -79,9 +79,9 @@ export const RoomModal: React.FC<PropsType> = ({
           getCurrentTimeInUTCSeconds()
     );
 
-  const usersInRoom = partygoers.filter(
-    (goer) => goer.room === `${venueName}/${room.title}`
-  );
+  const usersInRoom =
+    partygoers?.filter((goer) => goer.room === `${venueName}/${room.title}`) ??
+    [];
 
   return (
     <Modal show={show} onHide={onHide}>

--- a/src/components/templates/Camp/components/RoomList.tsx
+++ b/src/components/templates/Camp/components/RoomList.tsx
@@ -36,7 +36,8 @@ export const RoomList: React.FunctionComponent<PropsType> = ({
             key={room.title}
             room={room}
             attendance={
-              (attendances[`${venue.name}/${room?.title}`] ?? 0) +
+              // @debt this could end up as undefined/roomTitle
+              (attendances[`${venue?.name}/${room?.title}`] ?? 0) +
               (room.attendanceBoost ?? 0)
             }
             onClick={() => openModal(room)}

--- a/src/components/templates/Camp/components/RoomModal.tsx
+++ b/src/components/templates/Camp/components/RoomModal.tsx
@@ -61,11 +61,14 @@ export const RoomModal: React.FC<RoomModalProps> = ({
     const roomVenue = venues?.find((venue) =>
       room.url.endsWith(`/${venue.id}`)
     );
+
     const venueRoom = roomVenue
       ? { [roomVenue.name]: currentTimeInUnixEpoch }
       : {};
+
     room &&
       user &&
+      venue &&
       enterRoom(
         user,
         {
@@ -77,14 +80,15 @@ export const RoomModal: React.FC<RoomModalProps> = ({
   };
 
   const roomEvents =
-    venueEvents &&
-    venueEvents.filter(
-      (event) =>
-        event.room === room.title &&
-        event.start_utc_seconds +
-          event.duration_minutes * ONE_MINUTE_IN_SECONDS >
-          currentTimeInUnixEpoch
-    );
+    (venueEvents &&
+      venueEvents?.filter(
+        (event) =>
+          event.room === room.title &&
+          event.start_utc_seconds +
+            event.duration_minutes * ONE_MINUTE_IN_SECONDS >
+            currentTimeInUnixEpoch
+      )) ??
+    [];
   const currentEvent = roomEvents && getCurrentEvent(roomEvents);
 
   return (

--- a/src/components/templates/Jazzbar/components/ReactionList.tsx
+++ b/src/components/templates/Jazzbar/components/ReactionList.tsx
@@ -16,6 +16,7 @@ import {
 import { useSelector } from "hooks/useSelector";
 import { WithId } from "utils/id";
 import { ChatMessage } from "components/context/ChatContext";
+import { partygoersDataSelector } from "utils/selectors";
 
 interface ReactionListProps {
   reactions: Reaction[];
@@ -28,9 +29,8 @@ const ReactionList: React.FC<ReactionListProps> = ({
   chats,
   small = false,
 }) => {
-  const { usersById } = useSelector((state) => ({
-    usersById: state.firestore.data.partygoers,
-  }));
+  const usersById = useSelector(partygoersDataSelector);
+
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -44,52 +44,52 @@ export interface FirestoreStatus {
 
 // note: these entries should be sorted alphabetically
 export interface FirestoreData {
-  adminRole: AdminRole;
-  allowAllRoles: Record<string, Role>;
+  adminRole?: AdminRole;
+  allowAllRoles?: Record<string, Role>;
   allUsers?: Record<string, User>;
   chatUsers?: Record<string, User>;
-  currentEvent: Record<string, VenueEvent>;
+  currentEvent?: Record<string, VenueEvent>;
   currentVenue?: AnyVenue;
   currentVenueEventsNG?: Record<string, VenueEvent>;
   currentVenueNG?: AnyVenue;
-  eventPurchase: Record<string, Purchase>;
+  eventPurchase?: Record<string, Purchase>;
   events?: Record<string, VenueEvent>;
-  experiences: Record<string, Experience>;
+  experiences?: Record<string, Experience>;
   parentVenue?: AnyVenue;
-  partygoers: Record<string, User>;
+  partygoers?: Record<string, User>;
   playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
-  privatechats: Record<string, PrivateChatMessage>;
-  reactions: Record<string, Reaction>;
+  privatechats?: Record<string, PrivateChatMessage>;
+  reactions?: Record<string, Reaction>;
   userModalVisits?: Record<string, UserVisit>;
-  userPurchaseHistory: Record<string, Purchase>;
-  userRoles: Record<string, Role>;
-  users: Record<string, User>;
-  venueChats: Record<string, RestrictedChatMessage> | null;
-  venueEvents: Record<string, VenueEvent>;
+  userPurchaseHistory?: Record<string, Purchase>;
+  userRoles?: Record<string, Role>;
+  users?: Record<string, User>;
+  venueChats?: Record<string, RestrictedChatMessage> | null;
+  venueEvents?: Record<string, VenueEvent>;
   venues?: Record<string, AnyVenue>;
 }
 
 // note: these entries should be sorted alphabetically
 export interface FirestoreOrdered {
-  allUsers?: Array<WithId<User>>;
-  chatRequests?: Array<WithId<ChatRequest>>;
-  currentEvent: Array<WithId<VenueEvent>>;
-  currentVenue: Array<WithId<AnyVenue>>;
-  currentVenueEventsNG?: Array<WithId<VenueEvent>>;
-  currentVenueNG?: Array<WithId<AnyVenue>>;
-  eventPurchase: Array<WithId<Purchase>>;
-  events?: Array<WithId<VenueEvent>>;
-  experiences: Array<WithId<Experience>>;
-  partygoers: Array<WithId<User>>;
-  playaVenues?: Array<WithId<AnyVenue>>;
-  privatechats: Array<WithId<PrivateChatMessage>>;
-  reactions: Array<WithId<Reaction>>;
-  statsOnlineUsers?: Array<WithId<User>>;
-  statsOpenVenues?: Array<WithId<AnyVenue>>;
-  userModalVisits?: Array<WithId<UserVisit>>;
-  userPurchaseHistory: Array<WithId<Purchase>>;
-  users: Array<WithId<User>>;
-  venueChats: Array<WithId<RestrictedChatMessage>>;
-  venueEvents: Array<WithId<VenueEvent>>;
-  venues?: Array<WithId<AnyVenue>>;
+  allUsers?: WithId<User>[];
+  chatRequests?: WithId<ChatRequest>[];
+  currentEvent?: WithId<VenueEvent>[];
+  currentVenue?: WithId<AnyVenue>[];
+  currentVenueEventsNG?: WithId<VenueEvent>[];
+  currentVenueNG?: WithId<AnyVenue>[];
+  eventPurchase?: WithId<Purchase>[];
+  events?: WithId<VenueEvent>[];
+  experiences?: WithId<Experience>[];
+  partygoers?: WithId<User>[];
+  playaVenues?: WithId<AnyVenue>[];
+  privatechats?: WithId<PrivateChatMessage>[];
+  reactions?: WithId<Reaction>[];
+  statsOnlineUsers?: WithId<User>[];
+  statsOpenVenues?: WithId<AnyVenue>[];
+  userModalVisits?: WithId<UserVisit>[];
+  userPurchaseHistory?: WithId<Purchase>[];
+  users?: WithId<User>[];
+  venueChats?: WithId<RestrictedChatMessage>[];
+  venueEvents?: WithId<VenueEvent>[];
+  venues?: WithId<AnyVenue>[];
 }

--- a/src/types/Venue.ts
+++ b/src/types/Venue.ts
@@ -75,6 +75,7 @@ export interface Venue {
   showLiveSchedule?: boolean;
   showGrid?: boolean;
   roomVisibility?: RoomVisibility;
+  // @debt we probably should figure a better type than any here
   rooms?: any[];
   width: number;
   height: number;

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -38,9 +38,9 @@ export const profileSelector: SparkleSelector<FirebaseReducer.Profile<User>> = (
  *
  * @param state the Redux store
  */
-export const currentVenueSelector: SparkleSelector<AnyVenue> = (
-  state: RootState
-) => state.firestore.ordered.currentVenue?.[0];
+export const currentVenueSelector: SparkleSelector<
+  WithId<AnyVenue> | undefined
+> = (state: RootState) => state.firestore.ordered.currentVenue?.[0];
 
 // @debt can we merge this with currentVenueSelector and just use 1 canonical version?
 export const currentVenueSelectorData: SparkleSelector<AnyVenue | undefined> = (
@@ -52,9 +52,12 @@ export const currentVenueSelectorData: SparkleSelector<AnyVenue | undefined> = (
  *
  * @param state the Redux store
  */
-export const partygoersSelector: SparkleSelector<WithId<User>[]> = (
+export const partygoersSelector: SparkleSelector<WithId<User>[] | undefined> = (
   state: RootState
 ) => state.firestore.ordered.partygoers;
+
+export const partygoersDataSelector = (state: RootState) =>
+  state.firestore.data.partygoers;
 
 /**
  * Selector to retrieve venues from the Redux Firestore.
@@ -92,11 +95,11 @@ export const makeVenueSelector = (venueId: string) => (
 };
 
 export const currentEventSelector: SparkleSelector<
-  WithId<VenueEvent>[]
+  WithId<VenueEvent>[] | undefined
 > = makeOrderedSelector("currentEvent");
 
 export const userPurchaseHistorySelector: SparkleSelector<
-  WithId<Purchase>[]
+  WithId<Purchase>[] | undefined
 > = makeOrderedSelector("userPurchaseHistory");
 
 export const shouldRetainAttendanceSelector: SparkleSelector<boolean> = (


### PR DESCRIPTION
A number of the root firestore types implied that the data would always be present, even though that's not guaranteed. This has lead to a few unexpected, including https://github.com/sparkletown/sparkle/pull/743

- TODO: There are more type errors that need fixing with proper checks as they are potentially undefined
- see https://github.com/sparkletown/sparkle/pull/744 for more potential issues around how we're using `Record`

**Note:** I will probably rebase this onto latest staging/fix conflicts/etc before going much further with it. So expect a rebase/force-push to come on this branch in the near future.