### PR TITLE
fix Admin Venue TemplateForm component to not show broken images

### DIFF
--- a/src/pages/Admin/Venue/TemplateForm.tsx
+++ b/src/pages/Admin/Venue/TemplateForm.tsx
@@ -43,6 +43,12 @@ export const TemplateForm: React.FC<WizardPage> = ({ next, state }) => {
   const [selectedTemplate, setSelectedTemplate] = useState<
     Template | undefined
   >(state.templatePage?.template);
+
+  const templateImage = !!selectedTemplate
+    ? templateImageMap[selectedTemplate.template]
+    : undefined;
+  const hasTemplateImage = !!templateImage;
+
   return (
     <div className="page">
       <div className="page-side">
@@ -60,12 +66,8 @@ export const TemplateForm: React.FC<WizardPage> = ({ next, state }) => {
         </div>
       </div>
       <div className="page-side">
-        {selectedTemplate && (
-          <img
-            src={templateImageMap[selectedTemplate.template]}
-            alt="venue"
-            className="venue-art"
-          />
+        {hasTemplateImage && (
+          <img src={templateImage} alt="venue" className="venue-art" />
         )}
       </div>
     </div>
@@ -119,12 +121,14 @@ interface TemplateCardProps {
   onClick: () => void;
 }
 
-const TemplateCard: React.FC<TemplateCardProps> = (props) => {
-  const {
-    template: { template, name, description },
-    onClick,
-    selected,
-  } = props;
+const TemplateCard: React.FC<TemplateCardProps> = ({
+  template: { template, name, description },
+  onClick,
+  selected,
+}) => {
+  const thumbnailImage = templateThumbImageMap[template];
+  const hasThumbnail = !!thumbnailImage;
+
   return (
     <div
       className={`pickspace-component-container pickspace-component-container_zoom ${
@@ -134,7 +138,7 @@ const TemplateCard: React.FC<TemplateCardProps> = (props) => {
     >
       <div className="centered-flex">
         <div className="pickspace-thumbnail">
-          <img src={templateThumbImageMap[template]} alt="venue thumb" />
+          {hasThumbnail && <img src={thumbnailImage} alt="venue thumb" />}
         </div>
         <div className="flex-one">
           <h3>{name}</h3>


### PR DESCRIPTION
When the images were `undefined` it would show broken links, now it just won't try and show an image there. 💅 