### PR TITLE
workaround bouncy partygoers without id + admin subvenue room fixes

### DIFF
--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -266,8 +266,8 @@ export const Map: React.FC<MapProps> = ({
               />
             );
           })}
-          // @debt this can be undefined because our types are broken so check
-          explicitly
+
+          {/*@debt this can be undefined because our types are broken so check explicitly*/}
           {partygoers?.map(
             (partygoer) =>
               partygoer?.id && ( // @debt workaround, sometimes partygoers are duplicated but the new ones don't have id's

--- a/src/components/templates/Camp/components/Map.tsx
+++ b/src/components/templates/Camp/components/Map.tsx
@@ -266,19 +266,23 @@ export const Map: React.FC<MapProps> = ({
               />
             );
           })}
-
-          {partygoers.map((partygoer) => (
-            <MapPartygoerOverlay
-              key={partygoer.id}
-              partygoer={partygoer}
-              venueId={venue.id}
-              myUserUid={user.uid}
-              totalRows={totalRows}
-              totalColumns={totalColumns}
-              withMiniAvatars={venue.miniAvatars}
-              setSelectedUserProfile={setSelectedUserProfile}
-            />
-          ))}
+          // @debt this can be undefined because our types are broken so check
+          explicitly
+          {partygoers?.map(
+            (partygoer) =>
+              partygoer?.id && ( // @debt workaround, sometimes partygoers are duplicated but the new ones don't have id's
+                <MapPartygoerOverlay
+                  key={partygoer.id}
+                  partygoer={partygoer}
+                  venueId={venue.id}
+                  myUserUid={user.uid}
+                  totalRows={totalRows}
+                  totalColumns={totalColumns}
+                  withMiniAvatars={venue.miniAvatars}
+                  setSelectedUserProfile={setSelectedUserProfile}
+                />
+              )
+          )}
         </div>
       ))}
 

--- a/src/components/templates/PartyMap/components/Map/Map.tsx
+++ b/src/components/templates/PartyMap/components/Map/Map.tsx
@@ -245,18 +245,21 @@ export const Map: React.FC<PropsType> = ({
   const partygoersOverlay = useMemo(
     () =>
       // @debt this can be undefined because our types are broken so check explicitly
-      partygoers?.map((partygoer) => (
-        <MapPartygoerOverlay
-          key={partygoer.id}
-          partygoer={partygoer}
-          venueId={venue.id}
-          myUserUid={userUid ?? ""} // @debt fix this to be less hacky
-          totalRows={rows}
-          totalColumns={columns}
-          withMiniAvatars={venue.miniAvatars}
-          setSelectedUserProfile={setSelectedUserProfile}
-        />
-      )),
+      partygoers?.map(
+        (partygoer) =>
+          partygoer?.id && ( // @debt workaround, sometimes partygoers are duplicated but the new ones don't have id's
+            <MapPartygoerOverlay
+              key={partygoer.id}
+              partygoer={partygoer}
+              venueId={venue.id}
+              myUserUid={userUid ?? ""} // @debt fix this to be less hacky
+              totalRows={rows}
+              totalColumns={columns}
+              withMiniAvatars={venue.miniAvatars}
+              setSelectedUserProfile={setSelectedUserProfile}
+            />
+          )
+      ),
     [columns, partygoers, rows, userUid, venue.id, venue.miniAvatars]
   );
 

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -34,7 +34,7 @@ import {
 } from "settings";
 import { IS_BURN } from "secrets";
 
-import { isCampVenue } from "types/CampVenue";
+import { isCampVenue, isVenueWithRooms } from "types/CampVenue";
 import { AdminVenueDetailsPartProps, VenueEvent } from "types/VenueEvent";
 import { VenueTemplate } from "types/VenueTemplate";
 
@@ -100,7 +100,7 @@ const VenueList: React.FC<VenueListProps> = ({
             }`}
           >
             <Link to={`/admin/venue/${venue.id}`}>{venue.name}</Link>
-            {isCampVenue(venue) && (
+            {isVenueWithRooms(venue) && (
               <ul className="page-container-adminsidebar-subvenueslist">
                 {venue.rooms.map((room, idx) => (
                   <li


### PR DESCRIPTION
Partygoers seem to be duplicated sometimes, but the duplicates don't have id's.