### PR TITLE
Disable smoke-test in CircleCI config (as it is broken currently anyway)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,20 +24,20 @@ jobs:
             - run: npm run lint
             - run: npm run build # somehow linting rules differ from eslint
             - *notify-on-fail
-  smoke-test:
-    executor:
-      name: node/default
-    steps:
-      - checkout
-      - node/with-cache:
-          cache-version: v2
-          steps:
-            - run: sudo apt-get update
-            - run: sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-            - run: npm install
-            - run: npm run cy:install # cache this instead
-            - run: npm run cy:run
-            - *notify-on-fail
+#  smoke-test:
+#    executor:
+#      name: node/default
+#    steps:
+#      - checkout
+#      - node/with-cache:
+#          cache-version: v2
+#          steps:
+#            - run: sudo apt-get update
+#            - run: sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+#            - run: npm install
+#            - run: npm run cy:install # cache this instead
+#            - run: npm run cy:run
+#            - *notify-on-fail
   deploy-functions:
     executor:
       name: node/default


### PR DESCRIPTION
Since it's broken currently this shouldn't hurt anything, and will reduce the noise on our notifications (and our brains for having to mentally filter out the 'important' from the 'not important' notifications)