### PR TITLE
Add custom 'slim' template to circleci slack/notify on fail step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ notify-on-fail: &notify-on-fail
     condition: always
     steps:
       - slack/notify:
-          event: fail
+          event: always
           custom: |
             {
               "blocks": [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,48 @@ notify-on-fail: &notify-on-fail
     steps:
       - slack/notify:
           event: fail
-          template: basic_fail_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ Job `${CIRCLE_JOB}` on branch `${CIRCLE_BRANCH}` has failed"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Committer*: ${CIRCLE_USERNAME}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*SHA:* ${CIRCLE_SHA1}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "\n *Mentions*: ${SLACK_PARAM_MENTIONS}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${CIRCLE_BUILD_URL}"
+                    }
+                  ]
+                }
+              ]
+            }
 
 version: 2.1
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ notify-on-fail: &notify-on-fail
     condition: always
     steps:
       - slack/notify:
-          event: always
+          event: fail
           custom: |
             {
               "blocks": [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ workflows:
 #          requires:
 #            - deploy-functions
 #            - deploy-hosting
-          filters:
-            branches:
-              only:
-                - staging
+#          filters:
+#            branches:
+#              only:
+#                - staging

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import "./wdyr";
 
+throw new Error("TODO: remove this commit, forcing a break test for CircleCI");
+
 import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,5 @@
 import "./wdyr";
 
-throw new Error("TODO: remove this commit, forcing a break test for CircleCI");
-
 import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";


### PR DESCRIPTION
This replaces the `basic_fail_1` template ([ref](https://github.com/CircleCI-Public/slack-orb/blob/master/src/message_templates/basic_fail_1.json)) with a custom template that makes the messages slimmer and less spammy.