### PR TITLE
Hide attendance boxes when there are zero attendees

### DIFF
--- a/src/components/templates/Camp/components/CampAttendance.tsx
+++ b/src/components/templates/Camp/components/CampAttendance.tsx
@@ -2,31 +2,18 @@ import React, { FC } from "react";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { Attendances } from "types/Attendances";
-import { CampRoomData } from "types/CampRoomData";
-import { CampVenue } from "types/CampVenue";
-
 interface PropsType {
-  venue: CampVenue;
-  attendances: Attendances;
-  room: CampRoomData;
+  attendees: number;
 }
 
-const CampAttendance: FC<PropsType> = ({ attendances, venue, room }) => {
-  return (
+const CampAttendance: FC<PropsType> = ({ attendees }) => {
+  return attendees > 0 ? (
     <>
-      {(attendances[`${venue.name}/${room.title}`] ?? 0) +
-        (room.attendanceBoost ?? 0) >
-        0 && (
-        <>
-          <div className="camp-venue-people">
-            {(attendances[`${venue.name}/${room.title}`] ?? 0) +
-              (room.attendanceBoost ?? 0)}
-          </div>
-          <FontAwesomeIcon icon={faUser} />
-        </>
-      )}
+      <div className="camp-venue-people">{attendees}</div>
+      <FontAwesomeIcon icon={faUser} />
     </>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/templates/Camp/components/MapRoomOverlay.tsx
+++ b/src/components/templates/Camp/components/MapRoomOverlay.tsx
@@ -135,6 +135,10 @@ export const MapRoomOverlay: React.FC<MapRoomOverlayProps> = ({
   const width = room.width_percent;
   const height = room.height_percent;
 
+  const attendees =
+    (attendances[`${venue.name}/${room.title}`] ?? 0) +
+    (room.attendanceBoost ?? 0);
+
   return (
     <div
       className={`room position-absolute ${isSelectedRoom && "isUnderneath"}`}
@@ -162,15 +166,11 @@ export const MapRoomOverlay: React.FC<MapRoomOverlayProps> = ({
           <img src={room.image_url} title={room.title} alt={room.title} />
         </div>
 
-        {shouldShowHovered && (
+        {shouldShowHovered && attendees > 0 && (
           <div className="camp-venue-text">
             <div className="camp-venue-maininfo">
               <div className="camp-venue-title">{room.title}</div>
-              <CampAttendance
-                attendances={attendances}
-                venue={venue}
-                room={room}
-              />
+              <CampAttendance attendees={attendees} />
             </div>
           </div>
         )}
@@ -182,11 +182,7 @@ export const MapRoomOverlay: React.FC<MapRoomOverlayProps> = ({
               {shouldShow1 && (
                 <div className="camp-venue-title">{room.title}</div>
               )}
-              <CampAttendance
-                attendances={attendances}
-                venue={venue}
-                room={room}
-              />
+              <CampAttendance attendees={attendees} />
             </div>
           )}
 

--- a/src/components/templates/PartyMap/components/RoomAttendance.tsx
+++ b/src/components/templates/PartyMap/components/RoomAttendance.tsx
@@ -23,6 +23,7 @@ export const RoomAttendance: FC<PropsType> = ({ venue, room }) => {
       (partygoer) => partygoer.lastSeenIn[`${venue.name}/${room.title}`]
     ) ?? [];
   const numberOfUsersInRoom = usersInRoom?.length;
+  if (numberOfUsersInRoom < 1) return <></>;
   return (
     <div className="attendance-avatars">
       {usersInRoom.map((user, index) => {


### PR DESCRIPTION
This PR **should** hide the tiny blue circle when hovering an empty room, on both the partymap and themecamp templates.