### PR TITLE
fix z-index of drawers

### DIFF
--- a/src/components/organisms/ChatDrawer/ChatDrawer.scss
+++ b/src/components/organisms/ChatDrawer/ChatDrawer.scss
@@ -1,6 +1,7 @@
 @import "scss/constants.scss";
 
 .chat-drawer-container {
+  z-index: 2;
   display: flex;
   flex-direction: column;
   transition: all 0.2s linear;

--- a/src/components/templates/Camp/components/Map.scss
+++ b/src/components/templates/Camp/components/Map.scss
@@ -180,6 +180,7 @@ $border-radius: 28px;
   z-index: 2;
 }
 .info-drawer-camp {
+  z-index: 2;
   position: fixed;
   top: 40px;
   left: 0px;


### PR DESCRIPTION
increases the z-index of info drawer and chat because some of the elements in camp now have z-index 1