### PR TITLE
tweak room counting and uncounting

### DIFF
--- a/src/components/molecules/UserList/UserList.tsx
+++ b/src/components/molecules/UserList/UserList.tsx
@@ -31,7 +31,7 @@ interface PropsType {
 }
 
 const UserList: React.FunctionComponent<PropsType> = ({
-  users: userList,
+  users: _users,
   limit = DEFAULT_USER_LIST_LIMIT,
   imageSize = 40,
   activity = "partying",
@@ -44,14 +44,16 @@ const UserList: React.FunctionComponent<PropsType> = ({
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();
-  const users = userList?.filter(
+  const usersSanitized = _users?.filter(
     (user) => !user.anonMode && user.partyName && user.id
-  ); // quick fix to get rid of anonymous users
-  const usersToDisplay = isExpanded ? users : users?.slice(0, limit);
-  const attendance = users.length + (attendanceBoost ?? 0);
+  );
+  const usersToDisplay = isExpanded
+    ? usersSanitized
+    : usersSanitized?.slice(0, limit);
+  const attendance = usersSanitized.length + (attendanceBoost ?? 0);
   const venue = useSelector(currentVenueSelectorData);
 
-  if (!users || attendance < 1) return <></>;
+  if (!usersSanitized || attendance < 1) return <></>;
   return (
     <>
       <div className="userlist-container">
@@ -61,7 +63,7 @@ const UserList: React.FunctionComponent<PropsType> = ({
             {attendance === 1 ? "person" : "people"}{" "}
             {isCamp && IS_BURN ? "in the camp" : activity}
           </p>
-          {!disableSeeAll && users.length > limit && (
+          {!disableSeeAll && usersSanitized.length > limit && (
             <p
               className="clickable-text"
               onClick={() => setIsExpanded(!isExpanded)}

--- a/src/components/molecules/UserList/UserList.tsx
+++ b/src/components/molecules/UserList/UserList.tsx
@@ -31,7 +31,7 @@ interface PropsType {
 }
 
 const UserList: React.FunctionComponent<PropsType> = ({
-  users,
+  users: userList,
   limit = DEFAULT_USER_LIST_LIMIT,
   imageSize = 40,
   activity = "partying",
@@ -44,7 +44,9 @@ const UserList: React.FunctionComponent<PropsType> = ({
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();
-  users = users?.filter((user) => !user.anonMode && user.partyName && user.id); // quick fix to get rid of anonymous users
+  const users = userList?.filter(
+    (user) => !user.anonMode && user.partyName && user.id
+  ); // quick fix to get rid of anonymous users
   const usersToDisplay = isExpanded ? users : users?.slice(0, limit);
   const attendance = users.length + (attendanceBoost ?? 0);
   const venue = useSelector(currentVenueSelectorData);

--- a/src/components/templates/Camp/components/CampAttendance.tsx
+++ b/src/components/templates/Camp/components/CampAttendance.tsx
@@ -8,10 +8,10 @@ interface PropsType {
 
 const CampAttendance: FC<PropsType> = ({ attendees }) => {
   return attendees > 0 ? (
-    <>
+    <div className="camp-venue-people-container">
       <div className="camp-venue-people">{attendees}</div>
       <FontAwesomeIcon icon={faUser} />
-    </>
+    </div>
   ) : (
     <></>
   );

--- a/src/components/templates/Camp/components/Map.scss
+++ b/src/components/templates/Camp/components/Map.scss
@@ -222,6 +222,10 @@ $border-radius: 28px;
           font-size: 0.9rem;
           font-size: 20px;
         }
+        .camp-venue-people-container {
+          display: flex;
+          flex-direction: row;
+        }
         .camp-venue-people {
           position: relative;
           display: block;

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import { retainAttendance } from "store/actions/Attendance";
 
@@ -6,7 +6,7 @@ import { CampRoomData } from "types/CampRoomData";
 import { VenueEvent } from "types/VenueEvent";
 
 import { getCurrentEvent } from "utils/event";
-import { isExternalUrl } from "utils/url";
+import { getRoomUrl } from "utils/url";
 
 import { useDispatch } from "hooks/useDispatch";
 
@@ -31,6 +31,19 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
     roomEvents &&
     roomEvents.length > 0 &&
     (currentEvent ? currentEvent : roomEvents[0]);
+
+  const joinRoom = useCallback(() => {
+    enterRoom();
+    window.open(getRoomUrl(room.url), "_blank", "noopener,noreferrer");
+  }, [enterRoom, room.url]);
+
+  const triggerAttendance = useCallback(() => {
+    dispatch(retainAttendance(true));
+  }, [dispatch]);
+
+  const clearAttendance = useCallback(() => {
+    dispatch(retainAttendance(false));
+  }, [dispatch]);
 
   return (
     <div className="room-modal-ongoing-event-container">
@@ -65,31 +78,15 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
           </div>
         </>
       )}
-      {isExternalUrl(room.url) ? (
-        <a
-          onMouseOver={() => dispatch(retainAttendance(true))}
-          onMouseOut={() => dispatch(retainAttendance(false))}
-          className="btn btn-primary room-entry-button"
-          onClick={enterRoom}
-          id={`enter-room-in-ongoing-event-card-${room.title}`}
-          href={room.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {joinButtonText ?? "Enter"}
-        </a>
-      ) : (
-        <a
-          onMouseOver={() => dispatch(retainAttendance(true))}
-          onMouseOut={() => dispatch(retainAttendance(false))}
-          className="btn btn-primary room-entry-button"
-          onClick={enterRoom}
-          id={`enter-room-in-ongoing-event-card-${room.title}`}
-          href={room.url}
-        >
-          {joinButtonText ?? "Enter"}
-        </a>
-      )}
+      <button
+        onMouseOver={triggerAttendance}
+        onMouseOut={clearAttendance}
+        className="btn btn-primary room-entry-button"
+        onClick={joinRoom}
+        id={`enter-room-in-ongoing-event-card-${room.title}`}
+      >
+        {joinButtonText ?? "Enter"}
+      </button>
     </div>
   );
 };

--- a/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/Camp/components/RoomModalOngoingEvent.tsx
@@ -6,7 +6,7 @@ import { CampRoomData } from "types/CampRoomData";
 import { VenueEvent } from "types/VenueEvent";
 
 import { getCurrentEvent } from "utils/event";
-import { getRoomUrl } from "utils/url";
+import { getRoomUrl, openUrl } from "utils/url";
 
 import { useDispatch } from "hooks/useDispatch";
 
@@ -34,7 +34,7 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
 
   const joinRoom = useCallback(() => {
     enterRoom();
-    window.open(getRoomUrl(room.url), "_blank", "noopener,noreferrer");
+    openUrl(getRoomUrl(room.url));
   }, [enterRoom, room.url]);
 
   const triggerAttendance = useCallback(() => {

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
@@ -32,7 +32,7 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
 
   const joinRoom = useCallback(() => {
     enterRoom();
-    window.open(getRoomUrl(room.url), "_blank", "noopener,noreferrer");
+    openUrl(getRoomUrl(room.url));
   }, [enterRoom, room.url]);
 
   const triggerAttendance = useCallback(() => {

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import { retainAttendance } from "store/actions/Attendance";
 
@@ -29,6 +29,19 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
     roomEvents &&
     roomEvents.length > 0 &&
     (currentEvent ? currentEvent : roomEvents[0]);
+
+  const joinRoom = useCallback(() => {
+    enterRoom();
+    window.open(getRoomUrl(room.url), "_blank", "noopener,noreferrer");
+  }, [enterRoom, room.url]);
+
+  const triggerAttendance = useCallback(() => {
+    dispatch(retainAttendance(true));
+  }, [dispatch]);
+
+  const clearAttendance = useCallback(() => {
+    dispatch(retainAttendance(false));
+  }, [dispatch]);
 
   return (
     <div className="room-modal-ongoing-event-container">
@@ -63,18 +76,15 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
           </div>
         </>
       )}
-      <a
-        onMouseOver={() => dispatch(retainAttendance(true))}
-        onMouseOut={() => dispatch(retainAttendance(false))}
+      <button
+        onMouseOver={triggerAttendance}
+        onMouseOut={clearAttendance}
         className="btn btn-primary room-entry-button"
-        onClick={enterRoom}
+        onClick={joinRoom}
         id={`enter-room-in-ongoing-event-card-${room.title}`}
-        href={getRoomUrl(room.url)}
-        target="_blank"
-        rel="noopener noreferrer"
       >
         {joinButtonText ?? "Enter"}
-      </a>
+      </button>
     </div>
   );
 };

--- a/src/hooks/useCampPartygoers.ts
+++ b/src/hooks/useCampPartygoers.ts
@@ -31,7 +31,9 @@ export const useCampPartygoers = (venueName: string): WithId<User>[] => {
   return useMemo(
     () =>
       partygoers?.filter(
-        (partygoer) => partygoer?.lastSeenIn?.[venueName] > lastSeenThresholdMs
+        (partygoer) =>
+          partygoer?.lastSeenIn?.[venueName] >
+          lastSeenThresholdMs - LOC_UPDATE_FREQ_MS
       ) ?? [],
     [partygoers, venueName, lastSeenThresholdMs]
   );


### PR DESCRIPTION
- fixes camp room counting display which was in column instead of row. now number of room attendance is next to the icon
- useCampPartygoers now checks for online users which were in the camp between the last update and now, instead of just now.
- remove mutation of prop
- replace anchors with buttons to disable new tab opening with wheel click and right click