### PR TITLE
Fix crash in events

### DIFF
--- a/src/components/molecules/EventDisplay/EventDisplay.tsx
+++ b/src/components/molecules/EventDisplay/EventDisplay.tsx
@@ -17,13 +17,15 @@ import "./EventDisplay.scss";
 
 interface EventDisplayProps {
   event: firebase.firestore.DocumentData;
-  venue: WithId<AnyVenue>;
+  venue?: WithId<AnyVenue>;
 }
 
 export const EventDisplay: FC<EventDisplayProps> = ({ event, venue }) => {
   const { user, profile } = useUser();
 
   const enterEvent = useCallback(() => {
+    if (!venue) return;
+
     const room = venue?.rooms?.find((room) => room.title === event.room);
 
     if (!room) {
@@ -69,7 +71,7 @@ export const EventDisplay: FC<EventDisplayProps> = ({ event, venue }) => {
         </div>
         <div className="schedule-event-info-room">
           <div onClick={enterEvent}>
-            {event.room ?? "Enter"} - {venue.name}
+            {event.room ?? "Enter"} {venue && `- ${venue.name}`}
           </div>
         </div>
       </div>

--- a/src/components/molecules/LiveSchedule/LiveEvent.tsx
+++ b/src/components/molecules/LiveSchedule/LiveEvent.tsx
@@ -53,7 +53,7 @@ export const LiveEvent: FC<LiveEventProps> = ({ venue, event }) => {
         </div>
         <div className="schedule-event-info-room">
           <div onClick={enterLiveEvent}>
-            {event.room ?? "Enter"} - {venue.name}
+            {event.room ?? "Enter"} {venue && `- ${venue.name}`}
           </div>
         </div>
       </div>

--- a/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
+++ b/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
@@ -40,10 +40,10 @@ export const SchedulePageModal: FC<SchedulePageModalProps> = ({
     withEvents: true,
   });
 
-  const relatedVenuesById: Record<
+  const relatedVenuesById: Partial<Record<
     string,
     WithId<AnyVenue>
-  > = relatedVenues.reduce(itemsToObjectByIdReducer, {});
+  >> = relatedVenues.reduce(itemsToObjectByIdReducer, {});
 
   const orderedEvents: DatedEvents = useMemo(() => {
     const liveAndFutureEvents = relatedVenueEvents.filter(isEventLiveOrFuture);


### PR DESCRIPTION
TypeScript did not catch that Record<> can return undefined if the key is not present. This appears to be a deficiency in the Record<> type. More info here: https://fnune.com/typescript/2019/01/30/typescript-series-1-record-is-usually-not-the-best-choice/

This fix wraps the cast in a Partial<> to force handling of the undefined case. Fortunately, no other areas were affeted by this specific bug.