### PR TITLE
Add browserslist:update-db helper script + update the underlying caniuse-lite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5944,9 +5944,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001150",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz",
-      "integrity": "sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ=="
+      "version": "1.0.30001162",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001162.tgz",
+      "integrity": "sha512-E9FktFxaNnp4ky3ucIGzEXLM+Knzlpuq1oN1sFAU0KeayygabGTmOsndpo8QrL4D9pcThlf4D2pUKaDxPCUmVw=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "cy:install": "cypress install",
     "cy:run": "cypress run",
     "firebase": "npx --no-install -- firebase",
-    "firebase:emulate-functions": "npm run firebase -- emulators:start --only functions"
+    "firebase:emulate-functions": "npm run firebase -- emulators:start --only functions",
+    "browserslist:update-db": "npx browserslist@latest --update-db"
   },
   "proxy": "http://localhost:3001",
   "browserslist": {


### PR DESCRIPTION
Ref: https://github.com/browserslist/browserslist#browsers-data-updating

> You need to do it regularly for two reasons:
> 
> 1. To use the latest browser’s versions and statistics in queries like `last 2 versions` or `>1%`. For example, if you created your project 2 years ago and did not update your dependencies, `last 1 version` will return 2 year old browsers.
> 2. `caniuse-lite` deduplication: to synchronize version in different tools.