### PR TITLE
Create Code Climate config file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,45 @@
+# See
+#   https://docs.codeclimate.com/docs/default-analysis-configuration
+#   https://docs.codeclimate.com/docs/advanced-configuration
+#   https://docs.codeclimate.com/docs/list-of-engines
+version: "2"
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+#  similar-code:
+#    config:
+#      threshold: # language-specific defaults. an override will affect all languages.
+#  identical-code:
+#    config:
+#      threshold: # language-specific defaults. an override will affect all languages.
+#plugins:
+#  PLUGINAME:
+#    enabled: true
+exclude_patterns:
+  - configs/
+  - cypress/
+  - public/
+  - "**/node_modules/"
+  - "**/*.d.ts"


### PR DESCRIPTION
Adds Code Climate configuration file to the repo as per:

- https://docs.codeclimate.com/docs/advanced-configuration

Note: the settings as configured here are pretty much the defaults, but mapped out explicitly. We can customize it more in a future PR if we want to.