### PR TITLE
Disable utils/url isValidUrl check in openUrl

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -43,12 +43,16 @@ export const openRoomUrl = (url: string) => {
 export const openUrl = (url: string) => {
   if (!isValidUrl(url)) {
     Bugsnag.notify(
-      new Error(`Invalid URL ${url} on page ${window.location.href}; ignoring`),
+      // new Error(`Invalid URL ${url} on page ${window.location.href}; ignoring`),
+      new Error(
+        `Invalid URL ${url} on page ${window.location.href}; allowing for now (workaround)`
+      ),
       (event) => {
         event.addMetadata("utils/url::openUrl", { url });
       }
     );
-    return;
+    // @debt keep the checking in place so we can debug further, but don't block attempts to open
+    // return;
   }
 
   window.open(url, "_blank", "noopener,noreferrer");


### PR DESCRIPTION
This check seems to be failing for some zoom links for some reason. While we debug/figure that out, we'll allow links to be opened as per the old logic without this check.