### PR TITLE
shrink video when audience aspect ratio is 16:9

### DIFF
--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -37,8 +37,8 @@ $light: #ffffff;
       }
 
       .aspect-16-9 {
-        min-height: 112.5%;
-        margin-top: -6.5%;
+        max-width: 88.5%;
+        margin-left: 6.5%;
       }
     }
 

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -309,8 +309,6 @@ export const Audience: React.FunctionComponent = () => {
       venue.videoAspect === VideoAspectRatio.SixteenNine ? "aspect-16-9" : ""
     }`;
 
-    console.log(venue.videoAspect)
-
     const renderReactionsContainer = () => (
       <>
         <div className="emoji-container">

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -309,6 +309,8 @@ export const Audience: React.FunctionComponent = () => {
       venue.videoAspect === VideoAspectRatio.SixteenNine ? "aspect-16-9" : ""
     }`;
 
+    console.log(venue.videoAspect)
+
     const renderReactionsContainer = () => (
       <>
         <div className="emoji-container">


### PR DESCRIPTION
Not sure if this is the fix we want. Instead of enlarging the video and make it hide the top seats, now it shrinks from the sides (width only) and doesn't collide with the seats.