### PR TITLE
make video room names unique

### DIFF
--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -94,7 +94,7 @@ export const ConversationSpace: React.FunctionComponent = () => {
                 <div className="participants-container">
                   <Room
                     venueName={venue.name}
-                    roomName={seatedAtTable}
+                    roomName={`${venue.name}-${seatedAtTable}`}
                     setUserList={() => {}}
                   />
                 </div>

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -239,7 +239,7 @@ const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
               )}
               {seatedAtTable && (
                 <Room
-                  roomName={seatedAtTable}
+                  roomName={`${venueToUse.name}-${seatedAtTable}`}
                   venueName={venueToUse.name}
                   setUserList={setUserList}
                   setSeatedAtTable={setSeatedAtTable}


### PR DESCRIPTION
The video room names were the same and people were getting in different tables and venues but the same video rooms because the table reference was the same