### PR TITLE
upgrade twilio video to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,9 +3475,9 @@
       "optional": true
     },
     "@twilio/webrtc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.3.0.tgz",
-      "integrity": "sha512-a0ieFb0XUc5HQIMGBypwvTFVxyBEpPvTgnz2E08KxyZvM72igYlAFjZyooq/5BDctu3cJmT9H3coNaUX82l8yw=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@twilio/webrtc/-/webrtc-4.3.2.tgz",
+      "integrity": "sha512-3gIq7XDI3vBoikRBchCnocFmlRQt45KC7v0DKkat+TV6WBXYJx+Hub22PR18PAROkwl5dAmIziByjYWWVhCHgA=="
     },
     "@types/babel__core": {
       "version": "7.1.7",
@@ -21172,11 +21172,11 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio-video": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.5.1.tgz",
-      "integrity": "sha512-YlRJotXQO2T5+MJFMB/JsgT2RRW5dnuKkh7wcApfoZRjnXxSZAIQ6MIDiRUDC8aixRcUqdO+A4j1xVEJQw8khQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.9.0.tgz",
+      "integrity": "sha512-7UJjUmHQGjXxuFwYEMfFBg7t8AZ2vUsV1H/Bl6ulZ0taQO0e0XiiIq8pIpbBx9P8wrycApkc3ru9bbXnTEd44g==",
       "requires": {
-        "@twilio/webrtc": "4.3.0",
+        "@twilio/webrtc": "4.3.2",
         "backoff": "^2.5.0",
         "ws": "^3.3.1",
         "xmlhttprequest": "^1.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3971,9 +3971,9 @@
       }
     },
     "@types/twilio-video": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@types/twilio-video/-/twilio-video-2.0.12.tgz",
-      "integrity": "sha512-GrkdzvOFxGFOGlThKcjQce32Pwycoubl5oQK5+H4KSeyDvGHzyZSbnX7qoyWFMXKSHBc165f3dw+oORdr2E7ew==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/twilio-video/-/twilio-video-2.7.2.tgz",
+      "integrity": "sha512-JG8IvMt6tCYl21nK1nwwFHhn79gEJxwK7cZGeDYYys5Oe+96xHuvMLoOsxLGYDTwAaPbrVlduAq9kHQvnM6+JQ==",
       "dev": true
     },
     "@types/uuid": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.4",
-    "@types/twilio-video": "^2.0.12",
+    "@types/twilio-video": "^2.7.2",
     "@types/yup": "^0.29.3",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "styled-components": "^5.2.1",
     "three": "^0.119.1",
     "three-obj-mtl-loader": "^1.0.3",
-    "twilio-video": "^2.5.1",
+    "twilio-video": "^2.9.0",
     "ws": "^7.3.1",
     "xhr2": "^0.2.0",
     "yup": "^0.29.2"


### PR DESCRIPTION
Doesn't seem like there should be any breaking issues, may fix some bugs. Clicked through a little locally and it seemed to work. Would be good to give it a little more robust testing in staging.

- https://github.com/twilio/twilio-video.js/blob/master/CHANGELOG.md