### PR TITLE
🚧 lint only javascript related files

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,9 @@
   },
   "lint-staged": {
     "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write",
+      "prettier --write"
+    ],
+    "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json}": [
       "eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx"
     ]
   },


### PR DESCRIPTION
Run _ESLint_ only on JavaScript related files

This is due to the script failing while trying to lint _.scss_ or _.css_ files and not allowing the commit to continue