### PR TITLE
fix fontawesome issues introduced in recent version bump 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,9 +1794,9 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.10.tgz",
-      "integrity": "sha512-UGdpJiLBIqR/8xcLrCarf2pChqQFKjDTD02C7ZS/odpOVVl2YuHYRCLEOQ0GpfOk6jtYhmouSFOFoC8qNCe5cg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.13.tgz",
+      "integrity": "sha512-/HrLnIft5Ks2511Pz6TxHBIctC9QalVscAC64sufQ4sJH/sXaQlG3uR9LCu6VpEwkBemgcBLrz/QPNP/ddbjDg==",
       "requires": {
         "prop-types": "^15.7.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1764,11 +1764,18 @@
       }
     },
     "@fortawesome/free-regular-svg-icons": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-70FAyiS5j+ANYD4dh9NGowTorNDnyvQHHpCM7FpnF7GxtDjBUCKdrFqCPzesEIpNDFNd+La3vex+jDk4nnUfpA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.1.tgz",
+      "integrity": "sha512-eD9NWFy89e7SVVtrLedJUxIpCBGhd4x7s7dhesokjyo1Tw62daqN5UcuAGu1NrepLLq1IeAYUVfWwnOjZ/j3HA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.32"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.32",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
+          "integrity": "sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w=="
+        }
       }
     },
     "@fortawesome/free-solid-svg-icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,16 +1751,16 @@
       "integrity": "sha512-XcdMT5PSZHiuf7LJIhzKIe+RyYa25S3LHRRvLnZc6iFjwXkrSDJ8J/HWO6VT8d2ZTbawp3VcLEjRF/VN8glCrA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz",
-      "integrity": "sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg=="
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
+      "integrity": "sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz",
-      "integrity": "sha512-4LeaNHWvrneoU0i8b5RTOJHKx7E+y7jYejplR7uSVB34+mp3Veg7cbKk7NBCLiI4TyoWS1wh9ZdoyLJR8wSAdg==",
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.32.tgz",
+      "integrity": "sha512-XjqyeLCsR/c/usUpdWcOdVtWFVjPbDFBTQkn2fQRrWhhUoxriQohO2RWDxLyUM8XpD+Zzg5xwJ8gqTYGDLeGaQ==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.32"
       }
     },
     "@fortawesome/free-regular-svg-icons": {

--- a/package-lock.test.ts
+++ b/package-lock.test.ts
@@ -1,12 +1,41 @@
 const { readFileSync } = require("fs");
+const _ = require("lodash");
 
 describe("package-lock.json", () => {
-  test("has lockfileVersion 1", () => {
-    const packageLockJson = JSON.parse(
-      readFileSync("./package-lock.json", "utf8")
-    );
+  const packageLockJson = JSON.parse(
+    readFileSync("./package-lock.json", "utf8")
+  );
 
-    // This test allows us to failfast when npm v7 is used, until we are ready for it
+  /**
+   * This test allows us to failfast when npm v7 is used, until we are ready for it
+   */
+  test("has lockfileVersion 1", () => {
     expect(packageLockJson.lockfileVersion).toBe(1);
+  });
+
+  /**
+   * Ensure that fontawesome deps requirements are kept in alignment to avoid weird breakages.
+   */
+  describe("@fortawesome/fontawesome-*", () => {
+    test("all use a common version of @fortawesome/fontawesome-common-types", () => {
+      const faCommonTypes =
+        packageLockJson.dependencies[`@fortawesome/fontawesome-common-types`];
+
+      const extractRequiredCommonTypesVersion = (dependencyKey) => {
+        const requiresObj =
+          packageLockJson.dependencies[dependencyKey].requires || {};
+
+        return requiresObj["@fortawesome/fontawesome-common-types"];
+      };
+
+      const requiredCommonTypes = Object.keys(packageLockJson.dependencies)
+        .filter((key) => key.startsWith("@fortawesome"))
+        .map(extractRequiredCommonTypesVersion)
+        .filter((key) => !!key);
+
+      expect(_.uniq(requiredCommonTypes)).toEqual(
+        expect.arrayContaining([`^${faCommonTypes.version}`])
+      );
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@bugsnag/js": "^7.5.1",
     "@bugsnag/plugin-react": "^7.3.5",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
-    "@fortawesome/free-regular-svg-icons": "^5.13.0",
+    "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@bugsnag/js": "^7.5.1",
     "@bugsnag/plugin-react": "^7.3.5",
-    "@fortawesome/fontawesome-svg-core": "^1.2.28",
+    "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.9",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
-    "@fortawesome/react-fontawesome": "^0.1.9",
+    "@fortawesome/react-fontawesome": "^0.1.13",
     "@stripe/react-stripe-js": "^1.1.2",
     "@stripe/stripe-js": "^1.8.0",
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
It seems that when https://github.com/sparkletown/sparkle/pull/872 was merged it caused errors while trying to deploy the hosting, due to a TypeScript compilation error:

- https://app.circleci.com/pipelines/github/sparkletown/sparkle/3822/workflows/5974d56e-9d2c-41c1-a041-f4523b99e947/jobs/6370

```
TypeScript error in /home/circleci/project/src/components/molecules/AnnouncementMessage/AnnouncementMessage.tsx(33,30):
Type 'IconDefinition' is not assignable to type 'IconProp'.
  Type 'IconDefinition' is not assignable to type 'IconLookup'.  TS2322
```

I believe the versions of the fontawesome libs need to be kept in sync with one another, this PR will fix that.

I'd also like to understand the differences in the `package-lock.json` (i expect there will be multiple versions of a common dependency, causing the issues), and then can probably write a test to ensure this doesn't happen in future.

As a separate follow up PR, I will also be looking how we can ensure our CI notices TypeScript errors at the linting stage, without having to do a full build of the app (as that is quite heavy, and we don't need it till we're deploying)