### PR TITLE
Fix partymap height for safari

### DIFF
--- a/src/components/templates/PartyMap/components/Map/Map.scss
+++ b/src/components/templates/PartyMap/components/Map/Map.scss
@@ -31,6 +31,7 @@ $border-radius: 28px;
 
 .party-map-background {
   border-radius: 15px;
+  height: 100%;
 }
 
 .camp-background {


### PR DESCRIPTION
Safari doesn't seem to use width to set height the way Chrome does:

https://stackoverflow.com/questions/11276367/forcing-aspect-ratio-with-css-doesnt-work-on-safari

This fix explicitly sets the height on the map background image, so it doesn't default to the intrinsic height of the image.