### PR TITLE
Prevent mixpanel failing if no venue template is passed

### DIFF
--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -98,6 +98,8 @@ const VenuePage = () => {
   const retainAttendance = useSelector(shouldRetainAttendanceSelector);
 
   const venueName = venue?.name ?? "";
+  const venueTemplate = venue?.template;
+
   const prevLocations = retainAttendance ? profile?.lastSeenIn ?? {} : {};
 
   const updateUserLocation = useCallback(() => {
@@ -241,8 +243,6 @@ const VenuePage = () => {
       : undefined
   );
 
-  const venueTemplate = venue.template;
-
   useEffect(() => {
     if (user && profile && venueId && venueTemplate) {
       mixpanel.track("VenuePage loaded", {
@@ -251,6 +251,7 @@ const VenuePage = () => {
       });
     }
   }, [user, profile, venueId, venueTemplate, mixpanel]);
+
   if (!user) {
     return <Login formType="initial" />;
   }


### PR DESCRIPTION
useEffect hook for mixpanel was causing an error because the `venue.template` was undefined.