### PR TITLE
fix sparkle-2 environment config (round 2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
               ENV=sparkle-1
             fi
             if [ $CIRCLE_BRANCH = "sparkle2" ]; then
-              ENV=sparkle-2
+              ENV=sparkle-2a
             fi
 
             ./node_modules/.bin/firebase use $ENV --token "$FIREBASE_TOKEN"
@@ -139,8 +139,8 @@ jobs:
             fi
             if [ $CIRCLE_BRANCH = "sparkle2" ]; then
               PREFIX=SPARKLE2_
-              ENV=sparkle-2
-              TARGET=sparkle-2
+              ENV=sparkle-2a
+              TARGET=sparkle-2a
               RELEASE_STAGE=sparkle2
             fi
 


### PR DESCRIPTION
Follow on to https://github.com/sparkletown/sparkle/pull/990 and https://github.com/sparkletown/sparkle/pull/994 to fix a typo I made (had to use `sparkle-2a` when creating the firebase project as `sparkle-2` was already taken)