### PR TITLE
fix sparkle-2 environment config (round 3)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -51,7 +51,7 @@
     },
     "sparkle-2a": {
       "hosting": {
-        "sparkle-2": [
+        "sparkle-2a": [
           "sparkle-2a"
         ]
       }


### PR DESCRIPTION
Follow on to https://github.com/sparkletown/sparkle/pull/990, https://github.com/sparkletown/sparkle/pull/994, and https://github.com/sparkletown/sparkle/pull/995 to fix a typo I made (had to use `sparkle-2a` when creating the firebase project as `sparkle-2` was already taken)