### PR TITLE
add configuration for sparkle-3 to sparkle-10 environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,30 @@ jobs:
             if [ $CIRCLE_BRANCH = "sparkle2" ]; then
               ENV=sparkle-2a
             fi
+            if [ $CIRCLE_BRANCH = "sparkle3" ]; then
+              ENV=sparkle-3
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle4" ]; then
+              ENV=sparkle-4
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle5" ]; then
+              ENV=sparkle-5
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle6" ]; then
+              ENV=sparkle-6
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle7" ]; then
+              ENV=sparkle-7
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle8" ]; then
+              ENV=sparkle-8
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle9" ]; then
+              ENV=sparkle-9
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle10" ]; then
+              ENV=sparkle-10
+            fi
 
             ./node_modules/.bin/firebase use $ENV --token "$FIREBASE_TOKEN"
             ./node_modules/.bin/firebase deploy --only functions --token "$FIREBASE_TOKEN"
@@ -143,6 +167,54 @@ jobs:
               TARGET=sparkle-2a
               RELEASE_STAGE=sparkle2
             fi
+            if [ $CIRCLE_BRANCH = "sparkle3" ]; then
+              PREFIX=SPARKLE3_
+              ENV=sparkle-3
+              TARGET=sparkle-3
+              RELEASE_STAGE=sparkle3
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle4" ]; then
+              PREFIX=SPARKLE4_
+              ENV=sparkle-4
+              TARGET=sparkle-4
+              RELEASE_STAGE=sparkle4
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle5" ]; then
+              PREFIX=SPARKLE5_
+              ENV=sparkle-5
+              TARGET=sparkle-5
+              RELEASE_STAGE=sparkle5
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle6" ]; then
+              PREFIX=SPARKLE6_
+              ENV=sparkle-6
+              TARGET=sparkle-6
+              RELEASE_STAGE=sparkle6
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle7" ]; then
+              PREFIX=SPARKLE7_
+              ENV=sparkle-7
+              TARGET=sparkle-7
+              RELEASE_STAGE=sparkle7
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle8" ]; then
+              PREFIX=SPARKLE8_
+              ENV=sparkle-8
+              TARGET=sparkle-8
+              RELEASE_STAGE=sparkle8
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle9" ]; then
+              PREFIX=SPARKLE9_
+              ENV=sparkle-9
+              TARGET=sparkle-9
+              RELEASE_STAGE=sparkle9
+            fi
+            if [ $CIRCLE_BRANCH = "sparkle10" ]; then
+              PREFIX=SPARKLE10_
+              ENV=sparkle-10
+              TARGET=sparkle-10
+              RELEASE_STAGE=sparkle10
+            fi
 
             ./scripts/init-env.sh $PREFIX
 
@@ -186,6 +258,14 @@ workflows:
                 - sparkleverse
                 - sparkle1
                 - sparkle2
+                - sparkle3
+                - sparkle4
+                - sparkle5
+                - sparkle6
+                - sparkle7
+                - sparkle8
+                - sparkle9
+                - sparkle10
       - deploy-hosting:
           requires:
             - lint-and-test
@@ -197,6 +277,14 @@ workflows:
                 - sparkleverse
                 - sparkle1
                 - sparkle2
+                - sparkle3
+                - sparkle4
+                - sparkle5
+                - sparkle6
+                - sparkle7
+                - sparkle8
+                - sparkle9
+                - sparkle10
 #      - smoke-test:
 #          requires:
 #            - deploy-functions

--- a/.firebaserc
+++ b/.firebaserc
@@ -5,7 +5,15 @@
     "prod": "co-reality-map",
     "sparkleverse": "sparkle-verse",
     "sparkle1": "sparkle-1",
-    "sparkle2": "sparkle-2a"
+    "sparkle2": "sparkle-2a",
+    "sparkle3": "sparkle-3",
+    "sparkle4": "sparkle-4",
+    "sparkle5": "sparkle-5",
+    "sparkle6": "sparkle-6",
+    "sparkle7": "sparkle-7",
+    "sparkle8": "sparkle-8",
+    "sparkle9": "sparkle-9",
+    "sparkle10": "sparkle-10"
   },
   "targets": {
     "co-reality-map": {
@@ -53,6 +61,62 @@
       "hosting": {
         "sparkle-2a": [
           "sparkle-2a"
+        ]
+      }
+    },
+    "sparkle-3": {
+      "hosting": {
+        "sparkle-3": [
+          "sparkle-3"
+        ]
+      }
+    },
+    "sparkle-4": {
+      "hosting": {
+        "sparkle-4": [
+          "sparkle-4"
+        ]
+      }
+    },
+    "sparkle-5": {
+      "hosting": {
+        "sparkle-5": [
+          "sparkle-5"
+        ]
+      }
+    },
+    "sparkle-6": {
+      "hosting": {
+        "sparkle-6": [
+          "sparkle-6"
+        ]
+      }
+    },
+    "sparkle-7": {
+      "hosting": {
+        "sparkle-7": [
+          "sparkle-7"
+        ]
+      }
+    },
+    "sparkle-8": {
+      "hosting": {
+        "sparkle-8": [
+          "sparkle-8"
+        ]
+      }
+    },
+    "sparkle-9": {
+      "hosting": {
+        "sparkle-9": [
+          "sparkle-9"
+        ]
+      }
+    },
+    "sparkle-10": {
+      "hosting": {
+        "sparkle-10": [
+          "sparkle-10"
         ]
       }
     }

--- a/firebase.json
+++ b/firebase.json
@@ -72,6 +72,94 @@
         }
       ],
       "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-3",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-4",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-5",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-6",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-7",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-8",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-9",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "sparkle-10",
+      "public": "build",
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
     }
   ],
   "functions": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,19 @@ if (BUGSNAG_API_KEY) {
   const TEST = "test";
   const STAGING = "staging";
   const PRODUCTION = "production";
-  const SPARKLE_ENVS = ["sparkleverse", "sparkle1", "sparkle2"];
+  const SPARKLE_ENVS = [
+    "sparkleverse",
+    "sparkle1",
+    "sparkle2",
+    "sparkle3",
+    "sparkle4",
+    "sparkle5",
+    "sparkle6",
+    "sparkle7",
+    "sparkle8",
+    "sparkle9",
+    "sparkle10",
+  ];
 
   const releaseStage = () => {
     if (


### PR DESCRIPTION
This should be the required configuration changes for setting up/deploying the `sparkle-3` through `sparkle-10` environments.

Based on reviewing the code changes made in https://github.com/sparkletown/sparkle/pull/984 + the 'direct to branch' commits made following (which are collected together in https://github.com/sparkletown/sparkle/pull/989), and following the same model as https://github.com/sparkletown/sparkle/pull/990