### PR TITLE
Re-add support for themecamp template to admin tools

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -243,6 +243,11 @@ export const ALL_VENUE_TEMPLATES: Array<Template> = [
     name: "Party Map",
     description: [""],
   },
+  {
+    template: VenueTemplate.themecamp,
+    name: "Theme Camp (legacy)",
+    description: ["To be removed asap"],
+  },
 ];
 
 export const HAS_ROOMS_TEMPLATES: Array<VenueTemplate> = [


### PR DESCRIPTION
Fixes editing of rooms on partymap template venues. There is currently no admin tool to change a template for a venue, so we should not break the partymap venues