### PR TITLE
Event duplication

### DIFF
--- a/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
+++ b/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
@@ -84,7 +84,6 @@ export const SchedulePageModal: FC<SchedulePageModalProps> = ({
         <li
           key={formatDate(day.dateDay.getTime())}
           className={`button ${idx === date ? "active" : ""}`}
-          style={{ width: 100 }}
           onClick={() => setDate(idx)}
         >
           {formatDateToWeekday(day.dateDay.getTime() / 1000)}
@@ -97,8 +96,7 @@ export const SchedulePageModal: FC<SchedulePageModalProps> = ({
     () =>
       orderedEvents[date]?.events.map((event) => (
         <EventDisplay
-          // @debt I think is probably a poor choice for a key?
-          key={event.name + Math.random().toString()}
+          key={event.id}
           event={event}
           venue={relatedVenuesById[event.venueId] ?? currentVenue}
         />

--- a/src/types/VenueEvent.ts
+++ b/src/types/VenueEvent.ts
@@ -11,6 +11,7 @@ export interface VenueEvent {
   collective_price: number;
   host: string;
   room?: string;
+  id?: string;
 }
 
 export type AdminVenueDetailsPartProps = {


### PR DESCRIPTION
Removed `Math.random()` from `key=` assignment.
This was a possible cause to events being duplicated in the UI