### PR TITLE
Restore venueChats after removal of contexts

### DIFF
--- a/src/components/molecules/VenueChat/VenueChat.tsx
+++ b/src/components/molecules/VenueChat/VenueChat.tsx
@@ -20,6 +20,7 @@ import ChatBox from "components/molecules/Chatbox";
 
 import "./VenueChat.scss";
 import { sendRoomChat } from "store/actions/Chat";
+import { useConnectVenueChats } from "hooks/useConnectVenueChats";
 
 interface ChatOutDataType {
   messageToTheBand: string;
@@ -33,6 +34,7 @@ const VenueChat: FC = () => {
     storeAs: "venueChatUsers",
   };
   useFirestoreConnect(venueId ? venueChatUsersQuery : undefined);
+  useConnectVenueChats(venueId);
   const { userRoles } = useRoles();
   const { user } = useUser();
 

--- a/src/components/organisms/Chatbox/Chatbox.tsx
+++ b/src/components/organisms/Chatbox/Chatbox.tsx
@@ -11,6 +11,8 @@ import { User } from "types/User";
 import ChatMessage from "components/molecules/ChatMessage";
 import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
+import { useConnectVenueChats } from "hooks/useConnectVenueChats";
 import { useFirestoreConnect } from "react-redux-firebase";
 import { WithId } from "utils/id";
 import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
@@ -69,6 +71,8 @@ const Chatbox: React.FunctionComponent<PropsType> = ({
         }
       : undefined
   );
+  const venueId = useVenueId();
+  useConnectVenueChats(venueId);
   const chats = useSelector(venueChatsSelector);
   const privateChats = useSelector(privateChatsSelector);
   const chatsToDisplay = useMemo(() => {

--- a/src/hooks/useConnectVenueChats.ts
+++ b/src/hooks/useConnectVenueChats.ts
@@ -1,0 +1,14 @@
+import { useFirestoreConnect } from "react-redux-firebase";
+
+export const useConnectVenueChats = (venueId?: string) => {
+  useFirestoreConnect(
+    venueId
+      ? {
+          collection: "venues",
+          doc: venueId,
+          subcollections: [{ collection: "chats" }],
+          storeAs: "venueChats",
+        }
+      : undefined
+  );
+};


### PR DESCRIPTION
This fix brings back the `useFirestoreConnect` in `ChatContext` which was filling out the `venueChats`. It was not brought across in #956 nor in #1007, but is referenced in the code.