### PR TITLE
Prevent multiple listeners

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,6 +81,8 @@ const stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY ?? "");
 const rrfConfig = {
   userProfile: "users",
   useFirestoreForProfile: true,
+  oneListenerPerPath: true,
+  allowMultipleListeners: false,
 };
 
 firebase.initializeApp(FIREBASE_CONFIG);


### PR DESCRIPTION
Both these settings affect whether duplicate listeners can be attached to a given path.

This affects the behavior of this function: https://github.com/prescottprue/redux-firestore/blob/master/src/actions/firestore.js

With this change, one heavier venue becomes responsive in 15 seconds vs. 60 seconds without.

We should test whether some other data goes missing with this change present.