### PR TITLE
[sub-PR] Constrain useFirestoreConnect query types to enforce our firestore query patterns

### DIFF
--- a/src/components/molecules/ChatsList/ChatsList.tsx
+++ b/src/components/molecules/ChatsList/ChatsList.tsx
@@ -19,10 +19,7 @@ import { hasElements, isTruthy } from "utils/types";
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 import { useDispatch } from "hooks/useDispatch";
-import {
-  SparkleRFQConfig,
-  useFirestoreConnect,
-} from "hooks/useFirestoreConnect";
+import { useFirestoreConnect } from "hooks/useFirestoreConnect";
 
 import { PrivateChatMessage, sendPrivateChat } from "store/actions/Chat";
 import { chatSort } from "utils/chat";
@@ -32,7 +29,6 @@ import { setPrivateChatMessageIsRead } from "components/molecules/ChatsList/help
 import UserSearchBar from "../UserSearchBar/UserSearchBar";
 
 import "./ChatsList.scss";
-import { WhereOptions } from "react-redux-firebase";
 
 import { filterUniqueKeys } from "utils/filterUniqueKeys";
 
@@ -62,21 +58,15 @@ const ChatsList: React.FunctionComponent = () => {
       .slice(0, NUM_CHAT_UIDS_TO_LOAD);
   }, [privateChats]);
 
-  const chatUsersOption: WhereOptions = [DOCUMENT_ID, "in", chatUserIds];
-
-  const chatQuery = useMemo<SparkleRFQConfig>(() => {
-    if (!hasElements(chatUserIds)) return;
-
-    return [
-      {
-        collection: "users",
-        where: chatUsersOption,
-        storeAs: "chatUsers",
-      },
-    ];
-  }, [chatUserIds, chatUsersOption]);
-
-  useFirestoreConnect(chatQuery);
+  useFirestoreConnect(
+    hasElements(chatUserIds)
+      ? {
+          collection: "users",
+          where: [DOCUMENT_ID, "in", chatUserIds],
+          storeAs: "chatUsers",
+        }
+      : undefined
+  );
 
   const lastMessageByUserReducer = useCallback(
     (agg, item) => {

--- a/src/components/organisms/Chatbox/Chatbox.tsx
+++ b/src/components/organisms/Chatbox/Chatbox.tsx
@@ -5,9 +5,11 @@ import { debounce } from "lodash";
 
 import { isChatValid } from "validation";
 
+import { ValidStoreAsKeys } from "types/Firestore";
+import { User } from "types/User";
+
 import ChatForm from "./ChatForm";
 import "./Chatbox.scss";
-import { User } from "types/User";
 import ChatMessage from "components/molecules/ChatMessage";
 import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
@@ -21,7 +23,7 @@ import { chatSort } from "utils/chat";
 import { privateChatsSelector, venueChatsSelector } from "utils/selectors";
 
 // Don't pull everything
-// REVISIT: only grab most recent N from server
+// @debt REVISIT: only grab most recent N from server
 const RECENT_MESSAGE_COUNT = 200;
 
 interface PropsType {
@@ -57,13 +59,15 @@ const Chatbox: React.FunctionComponent<PropsType> = ({
   const debouncedSearch = debounce((v) => setSearchValue(v), 500);
   const searchRef = useRef<HTMLInputElement>(null);
 
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "currentUserPrivateChats"` or similar
   useFirestoreConnect(
-    user && user.uid
+    user?.uid
       ? {
           collection: "privatechats",
           doc: user.uid,
           subcollections: [{ collection: "chats" }],
-          storeAs: "privatechats",
+          storeAs: "privatechats" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
         }
       : undefined
   );

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -6,6 +6,7 @@ import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import { IFRAME_ALLOW } from "settings";
 import { UserInfo } from "firebase/app";
 
+import { ValidStoreAsKeys } from "types/Firestore";
 import { User } from "types/User";
 import { Venue } from "types/Venue";
 
@@ -61,12 +62,14 @@ const createReaction = (reaction: ReactionType, user: UserInfo) => {
 };
 
 const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "currentVenueExperiences"` or similar
   useFirestoreConnect(
     venue?.name
       ? {
           collection: "experiences",
           doc: venue.name,
-          storeAs: "experiences",
+          storeAs: "experiences" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
         }
       : undefined
   );

--- a/src/hooks/roles.ts
+++ b/src/hooks/roles.ts
@@ -1,6 +1,6 @@
 import { isEmpty, isLoaded } from "react-redux-firebase";
 import { SparkleSelector } from "types/SparkleSelector";
-import { SparkleRFQConfig, useFirestoreConnect } from "./useFirestoreConnect";
+import { AnySparkleRFQuery, useFirestoreConnect } from "./useFirestoreConnect";
 import { useSelector } from "./useSelector";
 
 export type AdminRole = {
@@ -8,7 +8,7 @@ export type AdminRole = {
   users: string[];
 };
 
-export const adminRoleQuery: SparkleRFQConfig = {
+export const adminRoleQuery: AnySparkleRFQuery = {
   collection: "roles",
   doc: "admin",
   storeAs: "adminRole",

--- a/src/hooks/useFirestoreConnect.ts
+++ b/src/hooks/useFirestoreConnect.ts
@@ -1,49 +1,80 @@
 // eslint-disable-next-line no-restricted-imports
 import {
+  isEmpty as _isEmpty,
+  isLoaded as _isLoaded,
   ReduxFirestoreQuerySetting,
   useFirestoreConnect as _useFirestoreConnect,
-  isLoaded as _isLoaded,
-  isEmpty as _isEmpty,
+  WhereOptions,
 } from "react-redux-firebase";
 
-import { ValidFirestoreKeys } from "types/Firestore";
+import {
+  ValidFirestoreRootCollections,
+  ValidStoreAsKeys,
+} from "types/Firestore";
+import { Defined } from "types/utility";
 
 /**
- * Type helper representing all types of T except undefined
+ * Query to access a root firestore collection
  */
-export type Defined<T> = T & Exclude<T, undefined>;
-
-/**
- * This type allows us to automagically constrain the storeAs
- * parameter to keys that exist within ValidFirestoreKeys, ensuring
- * that we can't forget to define it in our types when using functions
- * that rely on this type (eg. useFirestoreConnect)
- *
- * @see ValidFirestoreKeys
- * @see useFirestoreConnect
- * @see ReduxFirestoreQuerySetting
- */
-
-export type SparkleUseFirestoreConfigObject = ReduxFirestoreQuerySetting & {
-  storeAs?: ValidFirestoreKeys;
+export type SparkleRFCollectionQuery = ReduxFirestoreQuerySetting & {
+  collection: ValidFirestoreRootCollections;
+  doc?: never;
+  where?: never;
+  subcollections?: never;
+  storeAs?: never;
 };
 
 /**
- * This type lists all allowed argument types for @useFirestoreConnect function
- *
- * @see SparkleUseFirestoreConfigObject
- * @see ValidFirestoreKeys
+ * Query to access a root firestore collection with a where filter
  */
-export type SparkleRFQConfig =
-  | SparkleUseFirestoreConfigObject
-  | SparkleUseFirestoreConfigObject[]
-  | ValidFirestoreKeys
-  | undefined;
+export type SparkleRFCollectionWhereQuery = ReduxFirestoreQuerySetting & {
+  collection: ValidFirestoreRootCollections;
+  doc?: never;
+  where: WhereOptions | WhereOptions[];
+  subcollections?: never;
+  storeAs: ValidStoreAsKeys;
+};
 
 /**
- * A wrapper for useFirestoreConnect() that ensures the config
- * we pass it can only use a storeAs key that has been defined
- * in our FirestoreData/FirestoreOrdered types.
+ * Query to access a single document from a firestore collection
+ */
+export type SparkleRFSingleDocumentQuery = ReduxFirestoreQuerySetting & {
+  collection: ValidFirestoreRootCollections;
+  doc: string;
+  where?: never;
+  subcollections?: never;
+  storeAs: ValidStoreAsKeys;
+};
+
+/**
+ * Query to access a subcollection within a single document within a firestore collection
+ */
+export type SparkleRFSubcollectionQuery = ReduxFirestoreQuerySetting & {
+  collection: ValidFirestoreRootCollections;
+  doc: string;
+  where?: WhereOptions | WhereOptions[];
+  subcollections: ReduxFirestoreQuerySetting[];
+  storeAs: ValidStoreAsKeys;
+};
+
+/**
+ * All valid Sparkle useFirestoreConnect query types
+ *
+ * @see useFirestoreConnect
+ * @see SparkleRFCollectionQuery
+ * @see SparkleRFCollectionWhereQuery
+ * @see SparkleRFSingleDocumentQuery
+ * @see SparkleRFSubcollectionQuery
+ */
+export type AnySparkleRFQuery =
+  | SparkleRFCollectionQuery
+  | SparkleRFCollectionWhereQuery
+  | SparkleRFSingleDocumentQuery
+  | SparkleRFSubcollectionQuery;
+
+/**
+ * A wrapper for react-redux-firestore's useFirestoreConnect() that ensures the
+ * config we pass it conforms to our set of allowed query types.
  *
  * Note: the config does NOT need to be memo'd before being passed
  * to this function as useFirestoreConnect() determines equality
@@ -51,12 +82,16 @@ export type SparkleRFQConfig =
  *
  * @param config the config to be passed to useFirestoreConnect()
  *
- * @see SparkleRFQConfig
- * @see ValidFirestoreKeys
+ * @see AnySparkleRFQuery
  * @see ReduxFirestoreQuerySetting
+ * @see ValidFirestoreRootCollections
  */
-export const useFirestoreConnect = (config: SparkleRFQConfig) =>
-  _useFirestoreConnect(config);
+export const useFirestoreConnect = (
+  config?:
+    | AnySparkleRFQuery
+    | AnySparkleRFQuery[]
+    | ValidFirestoreRootCollections
+) => _useFirestoreConnect(config);
 
 /**
  * Use react-redux-firestore's isEmpty helper with
@@ -71,4 +106,9 @@ export const hasData = <T>(item: T): item is Defined<T> =>
 /**
  * Re-export react-redux-firestore's isLoaded helper for convenience.
  */
-export const isLoaded = <T>(item: T) => _isLoaded(item);
+export const isLoaded = <T>(item: T): boolean => _isLoaded(item);
+
+/**
+ * Re-export react-redux-firestore's isEmpty helper for convenience.
+ */
+export const isEmpty = <T>(item: T): boolean => _isEmpty(item);

--- a/src/hooks/useVenueId.ts
+++ b/src/hooks/useVenueId.ts
@@ -11,7 +11,11 @@ const venuePaths = [
   "/v/:venueId",
   "/admin_v2/venue/:venueId",
 ];
-export const useVenueId: () => string | null = () => {
+
+// @debt I think we could just use useParams() here instead of needing to loop through all of the venuePath, so long as the use :venueId in their path
+//   https://reactrouter.com/web/api/Hooks/useparams
+//     useParams returns an object of key/value pairs of URL parameters. Use it to access match.params of the current <Route>.
+export const useVenueId: () => string | undefined = () => {
   const history = useHistory();
 
   for (const path of venuePaths) {
@@ -24,5 +28,5 @@ export const useVenueId: () => string | null = () => {
     }
   }
 
-  return null;
+  return undefined;
 };

--- a/src/hooks/users.ts
+++ b/src/hooks/users.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { isLoaded } from "react-redux-firebase";
 
+import { User } from "types/User";
+import { ValidStoreAsKeys } from "types/Firestore";
+
 import { usersSelector, usersByIdSelector } from "utils/selectors";
 import { WithId } from "utils/id";
 
@@ -9,17 +12,17 @@ import { useUserLastSeenThreshold } from "hooks/useUserLastSeenThreshold";
 import { useVenueId } from "hooks/useVenueId";
 import { useFirestoreConnect } from "hooks/useFirestoreConnect";
 
-import { User } from "types/User";
-
 const useConnectVenueUsers = () => {
   const venueId = useVenueId();
 
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "currentVenueUsers"` or similar
   useFirestoreConnect(
     venueId
       ? {
           collection: "users",
           where: ["enteredVenueIds", "array-contains", venueId],
-          storeAs: "users",
+          storeAs: "users" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
         }
       : undefined
   );

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -32,6 +32,7 @@ import {
 import { IS_BURN } from "secrets";
 
 import { isVenueWithRooms } from "types/CampVenue";
+import { ValidStoreAsKeys } from "types/Firestore";
 import { AdminVenueDetailsPartProps, VenueEvent } from "types/VenueEvent";
 import { VenueTemplate } from "types/VenueTemplate";
 
@@ -62,10 +63,7 @@ import VenueDeleteModal from "./Venue/VenueDeleteModal";
 import { VenueOwnersModal } from "./VenueOwnersModal";
 
 import "./Admin.scss";
-import {
-  SparkleRFQConfig,
-  useFirestoreConnect,
-} from "hooks/useFirestoreConnect";
+import { useFirestoreConnect } from "hooks/useFirestoreConnect";
 import { useVenueId } from "hooks/useVenueId";
 
 dayjs.extend(advancedFormat);
@@ -427,14 +425,13 @@ const Admin: React.FC = () => {
 
   const { isAdminUser, isLoading: isAdminUserLoading } = useIsAdminUser(userId);
 
-  const venuesOwnedByUserQuery = useMemo<SparkleRFQConfig>(
-    () => ({
-      collection: "venues",
-      where: [["owners", "array-contains", userId]],
-    }),
-    [userId]
-  );
-  useFirestoreConnect(venuesOwnedByUserQuery);
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "venuesOwnedByUser"` or similar
+  useFirestoreConnect({
+    collection: "venues",
+    where: [["owners", "array-contains", userId]],
+    storeAs: "venues" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
+  });
 
   const venueId = useVenueId();
   const queryParams = useQuery();

--- a/src/pages/ReactionPage/ReactionPage.tsx
+++ b/src/pages/ReactionPage/ReactionPage.tsx
@@ -23,17 +23,17 @@ const ReactionPage = () => {
 
   const hasPartygoers = useMemo(() => partygoers.length > 0, [partygoers]);
 
-  useFirestoreConnect([
+  useFirestoreConnect(
     venue
       ? {
           collection: "experiences",
           doc: venue.name,
           subcollections: [{ collection: "reactions" }],
-          storeAs: "reactions",
           orderBy: ["created_at", "desc"],
+          storeAs: "reactions",
         }
-      : {},
-  ]);
+      : undefined
+  );
 
   const messagesToTheBand = reactions?.filter(
     (reaction) => reaction.reaction === "messageToTheBand"

--- a/src/pages/SparkleSpaceMarketingPage/WelcomePage/WelcomePage.tsx
+++ b/src/pages/SparkleSpaceMarketingPage/WelcomePage/WelcomePage.tsx
@@ -2,11 +2,11 @@ import React, { useState } from "react";
 import firebase from "firebase/app";
 import { useFirestoreConnect } from "hooks/useFirestoreConnect";
 import { IFRAME_ALLOW, PLAYA_VENUE_NAME } from "settings";
-import { ValidFirestoreKeys } from "types/Firestore";
+import { ValidFirestoreRootCollections } from "types/Firestore";
 
 const WelcomePage: React.FunctionComponent = () => {
-  // @dept Probably we should remove this piece of software if it is not functional anymore
-  useFirestoreConnect("marketingemails" as ValidFirestoreKeys);
+  // @debt we should remove this code file if it's not being used anymore
+  useFirestoreConnect("marketingemails" as ValidFirestoreRootCollections);
   const [email, setEmail] = useState("");
   const [emailSubmitted, setEmailSubmitted] = useState(false);
   const [emailSubmitError, setEmailSubmitError] = useState(null);

--- a/src/pages/VenueLandingPage/VenueLandingPage.tsx
+++ b/src/pages/VenueLandingPage/VenueLandingPage.tsx
@@ -135,6 +135,8 @@ export const VenueLandingPage: React.FunctionComponent<VenueLandingPageProps> = 
   };
 
   const onJoinClick = () => {
+    if (!venueId) return;
+
     const venueEntrance = venue.entrance && venue.entrance.length;
     window.location.href =
       user && !venueEntrance

--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -4,6 +4,7 @@ import { useFirestore } from "react-redux-firebase";
 
 import { LOC_UPDATE_FREQ_MS } from "settings";
 
+import { ValidStoreAsKeys } from "types/Firestore";
 import { VenueTemplate } from "types/VenueTemplate";
 
 import { getQueryParameters } from "utils/getQueryParameters";
@@ -220,13 +221,15 @@ const VenuePage: React.FC = () => {
     });
   }, [firestore, venueId, venueIdFromParams]);
 
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "currentUserPrivateChats"` or similar
   useFirestoreConnect(
     user?.uid
       ? {
           collection: "privatechats",
           doc: user.uid,
           subcollections: [{ collection: "chats" }],
-          storeAs: "privatechats",
+          storeAs: "privatechats" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
         }
       : undefined
   );

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -1,7 +1,7 @@
-import { WithId } from "utils/id";
 import { AdminRole } from "hooks/roles";
 
-import { RestrictedChatMessage, PrivateChatMessage } from "store/actions/Chat";
+import { PrivateChatMessage, RestrictedChatMessage } from "store/actions/Chat";
+import { WithId } from "utils/id";
 import { Reaction } from "utils/reactions";
 
 import { CampVenue } from "./CampVenue";
@@ -25,7 +25,22 @@ export interface UserVisit {
   timeSpent: number;
 }
 
+export type ValidFirestoreRootCollections =
+  | "customers"
+  | "experiences"
+  | "privatechats"
+  | "purchases"
+  | "roles"
+  | "userprivate"
+  | "users"
+  | "venues";
+
 export type ValidFirestoreKeys = keyof FirestoreData | keyof FirestoreOrdered;
+
+export type ValidStoreAsKeys = Exclude<
+  ValidFirestoreKeys,
+  ValidFirestoreRootCollections
+>;
 
 export interface Firestore {
   data: FirestoreData;


### PR DESCRIPTION
Sub-PR to https://github.com/sparkletown/sparkle/pull/801 that constrains the `useFirestoreConnect` query types to enforce our firestore query patterns.

This reinstates and improves upon the original type narrowing intended by https://github.com/sparkletown/sparkle/pull/784, as called out in https://github.com/sparkletown/sparkle/pull/801#issuecomment-759752827