### PR TITLE
Make Bugsnag logo a link per open source program requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ Paste into a google sheet. Leftmost column is the [UNIX timestamp](https://en.wi
 
 Sparkle is using Bugsnag! We are proud to be part of Bugsnag's open source program and are glad that Bugsnag supports open source.
 
-![Bugsnag Logo](https://avatars3.githubusercontent.com/u/1058895?s=200&v=4)
+[![Bugsnag Logo](https://avatars3.githubusercontent.com/u/1058895?s=200&v=4)](https://www.bugsnag.com)


### PR DESCRIPTION
Bugsnag's open source program requires the logo to be linked to their website, they requested a "backlink to Bugsnag". This change adds the link to the image.