### PR TITLE
bug fixing for admin v1

### DIFF
--- a/src/components/organisms/AppRouter/AppRouter.jsx
+++ b/src/components/organisms/AppRouter/AppRouter.jsx
@@ -62,7 +62,7 @@ const AppRouter = () => {
         <Route path="/admin_v2/venue/creation" component={VenueWizard_v2} />
         <Route path="/admin_v2/edit/:venueId" component={VenueWizard_v2} />
 
-        <Route path="/admin/venue/:venueId" component={Admin} />
+        <Route path="/admin/:venueId" component={Admin} />
         <Route path="/admin_v2/:venueId" component={Admin_v2} />
 
         <Route path="/admin" component={Admin} />

--- a/src/hooks/useVenueId.ts
+++ b/src/hooks/useVenueId.ts
@@ -9,7 +9,9 @@ const venuePaths = [
   "/e/:step/:venueId",
   "/in/:venueId",
   "/v/:venueId",
-  "/admin/venue/:venueId",
+  "/admin/:venueId",
+  "/admin/venue/edit/:venueId",
+  "/admin/venue/rooms/:venueId",
   "/admin_v2/:venueId",
   "/admin_v2/edit/:venueId",
 ];

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -97,7 +97,7 @@ const VenueList: React.FC<VenueListProps> = ({
               canHaveSubvenues(venue) ? "camp" : ""
             }`}
           >
-            <Link to={`/admin/venue/${venue.id}`}>{venue.name}</Link>
+            <Link to={`/admin/${venue.id}`}>{venue.name}</Link>
             {isVenueWithRooms(venue) && (
               <ul className="page-container-adminsidebar-subvenueslist">
                 {venue.rooms?.map((room, idx) => (
@@ -105,7 +105,7 @@ const VenueList: React.FC<VenueListProps> = ({
                     key={idx}
                     className={`${idx === roomIndex ? "selected" : ""}`}
                   >
-                    <Link to={`/admin/venue/${venue.id}?roomIndex=${idx}`}>
+                    <Link to={`/admin/${venue.id}?roomIndex=${idx}`}>
                       {room.title}
                     </Link>
                   </li>

--- a/src/pages/Admin/AdminVenueRoomDetails.tsx
+++ b/src/pages/Admin/AdminVenueRoomDetails.tsx
@@ -61,7 +61,7 @@ export const AdminVenueRoomDetails = ({
         user,
         index
       );
-      history.push(`/admin/venue/${venue.id}`);
+      history.push(`/admin/${venue.id}`);
     } catch (e) {
       Bugsnag.notify(e, (event) => {
         event.addMetadata("AdminVenueRoomDetails::updateRoom", {

--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -129,7 +129,7 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
         else await createVenue(vals as VenueInput, user);
 
         vals.name
-          ? history.push(`/admin/venue/${createUrlSafeName(vals.name)}`)
+          ? history.push(`/admin/${createUrlSafeName(vals.name)}`)
           : history.push(`/admin`);
       } catch (e) {
         setFormError(true);

--- a/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
+++ b/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
@@ -41,15 +41,12 @@ export const RoomsForm: React.FC = () => {
 
   useEffect(() => {
     const fetchVenueFromAPI = async () => {
-      console.log(venueId);
       if (!venueId) return history.replace("/admin");
 
       const venueSnapshot = await firestore
         .collection("venues")
         .doc(venueId)
         .get();
-
-      console.log(venueSnapshot);
 
       if (!venueSnapshot.exists) return history.replace("/admin");
       const data = venueSnapshot.data() as Venue;
@@ -58,7 +55,6 @@ export const RoomsForm: React.FC = () => {
         (template) => data.template === template.template
       );
 
-      console.log(template);
       if (!template || !HAS_ROOMS_TEMPLATES.includes(template.template)) {
         history.replace("/admin");
       }

--- a/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
+++ b/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
@@ -41,12 +41,15 @@ export const RoomsForm: React.FC = () => {
 
   useEffect(() => {
     const fetchVenueFromAPI = async () => {
+      console.log(venueId);
       if (!venueId) return history.replace("/admin");
 
       const venueSnapshot = await firestore
         .collection("venues")
         .doc(venueId)
         .get();
+
+      console.log(venueSnapshot);
 
       if (!venueSnapshot.exists) return history.replace("/admin");
       const data = venueSnapshot.data() as Venue;
@@ -55,6 +58,7 @@ export const RoomsForm: React.FC = () => {
         (template) => data.template === template.template
       );
 
+      console.log(template);
       if (!template || !HAS_ROOMS_TEMPLATES.includes(template.template)) {
         history.replace("/admin");
       }
@@ -134,7 +138,7 @@ const RoomInnerForm: React.FC<RoomInnerForm> = (props) => {
       if (!user) return;
       try {
         await upsertRoom(vals as RoomInput, venueId, user, editingRoomIndex);
-        history.push(`/admin/venue/${venueId}`);
+        history.push(`/admin/${venueId}`);
       } catch (e) {
         setFormError(true);
         Bugsnag.notify(e, (event) => {

--- a/src/pages/Admin/Venue/VenueWizard.tsx
+++ b/src/pages/Admin/Venue/VenueWizard.tsx
@@ -55,6 +55,7 @@ const reducer = (
 export const VenueWizard: React.FC = () => {
   const venueId = useVenueId();
 
+  console.log(venueId);
   return venueId ? (
     <VenueWizardEdit venueId={venueId} />
   ) : (
@@ -101,6 +102,7 @@ const VenueWizardCreate: React.FC = () => {
   const { user } = useUser();
   const queryParams = useQuery();
 
+  console.log("asd");
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const parentIdQuery = queryParams.get("parentId");

--- a/src/pages/Admin/Venue/VenueWizard.tsx
+++ b/src/pages/Admin/Venue/VenueWizard.tsx
@@ -55,7 +55,6 @@ const reducer = (
 export const VenueWizard: React.FC = () => {
   const venueId = useVenueId();
 
-  console.log(venueId);
   return venueId ? (
     <VenueWizardEdit venueId={venueId} />
   ) : (
@@ -102,7 +101,6 @@ const VenueWizardCreate: React.FC = () => {
   const { user } = useUser();
   const queryParams = useQuery();
 
-  console.log("asd");
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const parentIdQuery = queryParams.get("parentId");


### PR DESCRIPTION
Some of the urls were missing in the `venuePaths` array which was being used to get the `venueId` in the hook. Because of this, the `venueId` was `undefined` when it wasn't. Also the url of the venue creation has been changed because there was a collision between: `/admin/venue/:venueId` and `/admin/venue/creation` 

Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/194