### PR TITLE
Refactor useVenueId to use useParams instead of brittle venuePaths hack

### DIFF
--- a/src/hooks/useVenueId.ts
+++ b/src/hooks/useVenueId.ts
@@ -1,37 +1,14 @@
-import { matchPath, useHistory } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
-type VenueRoute = {
-  venueId: string;
-};
-
-// Sometimes in a nested route we want venue ID
-const venuePaths = [
-  "/e/:step/:venueId",
-  "/in/:venueId",
-  "/v/:venueId",
-  "/admin/:venueId",
-  "/admin/venue/edit/:venueId",
-  "/admin/venue/rooms/:venueId",
-  "/admin_v2/:venueId",
-  "/admin_v2/edit/:venueId",
-];
-
-// @debt I think we could just use useParams() here instead of needing to loop through all of the venuePath, so long as the use :venueId in their path
-//   https://reactrouter.com/web/api/Hooks/useparams
-//     useParams returns an object of key/value pairs of URL parameters. Use it to access match.params of the current <Route>.
+/**
+ * Retrieve the venueId from the URL path.
+ *
+ * @see https://reactrouter.com/web/api/Hooks/useparams
+ */
 export const useVenueId: () => string | undefined = () => {
-  const history = useHistory();
+  const { venueId } = useParams();
 
-  for (const path of venuePaths) {
-    const match = matchPath<VenueRoute>(history.location.pathname, {
-      path,
-      exact: true,
-    });
-
-    if (match?.params.venueId) {
-      return match.params.venueId;
-    }
-  }
+  if (typeof venueId === "string") return venueId;
 
   return undefined;
 };


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/164
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/194

This should also fix an edge case bug that was missed in https://github.com/sparkletown/sparkle/pull/1083 that causes the 'map banner' to not be editable (gets stuck on an infinite loading screen)

> I think we could just use `useParams()` here instead of needing to loop through all of the `venuePath`s, so long as they use `:venueId` in their path
> 
> - https://reactrouter.com/web/api/Hooks/useparams
>   - > `useParams` returns an object of key/value pairs of URL parameters. Use it to access `match.params` of the current `<Route>`
> 
> _Originally posted by @0xdevalias in https://github.com/sparkletown/sparkle/pull/1076#discussion_r557069059_