### PR TITLE
open privacy policy link in new tab

### DIFF
--- a/src/components/molecules/Footer/Footer.tsx
+++ b/src/components/molecules/Footer/Footer.tsx
@@ -17,7 +17,9 @@ export const Footer = () => (
 
     <div>|</div>
 
-    <a href={PRIVACY_POLICY}>Privacy Policy</a>
+    <a href={PRIVACY_POLICY} {...getExtraLinkProps(true)}>
+      Privacy Policy
+    </a>
 
     <div>|</div>
 


### PR DESCRIPTION
Opens the privacy policy link in a new tab just like the rest of the links in the footer.

Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/200