### PR TITLE
fixes jazzbar table lock/unlock functionality

### DIFF
--- a/src/components/molecules/TableHeader/TableHeader.tsx
+++ b/src/components/molecules/TableHeader/TableHeader.tsx
@@ -5,7 +5,7 @@ import { usePartygoers } from "hooks/users";
 import { useUser } from "hooks/useUser";
 import { useSelector } from "hooks/useSelector";
 import { Table } from "types/Table";
-import { experiencesSelector } from "utils/selectors";
+import { experienceSelector } from "utils/selectors";
 
 interface TableHeaderProps {
   seatedAtTable: string;
@@ -22,7 +22,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
 }) => {
   const { user, profile } = useUser();
 
-  const experience = useSelector(experiencesSelector);
+  const experience = useSelector(experienceSelector);
   const users = usePartygoers();
 
   const tableOfUser = seatedAtTable

--- a/src/components/molecules/TableHeader/TableHeader.tsx
+++ b/src/components/molecules/TableHeader/TableHeader.tsx
@@ -22,7 +22,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
 }) => {
   const { user, profile } = useUser();
 
-  const experiences = useSelector(experiencesSelector);
+  const experience = useSelector(experiencesSelector);
   const users = usePartygoers();
 
   const tableOfUser = seatedAtTable
@@ -59,13 +59,13 @@ const TableHeader: React.FC<TableHeaderProps> = ({
       return false;
     }
     // Locked state is in the experience record
-    return experiences?.[venueName]?.tables?.[table]?.locked;
+    return experience?.tables?.[table]?.locked;
   };
 
   const onLockedChanged = (tableName: string, locked: boolean) => {
     const doc = `experiences/${venueName}`;
     const update = {
-      tables: { ...experiences?.[venueName]?.tables, [tableName]: { locked } },
+      tables: { ...experience?.tables, [tableName]: { locked } },
     };
     firestoreUpdate(doc, update);
   };

--- a/src/components/molecules/TablesUserList/TablesUserList.tsx
+++ b/src/components/molecules/TablesUserList/TablesUserList.tsx
@@ -12,6 +12,7 @@ import { useSelector } from "hooks/useSelector";
 import { usePartygoers, useIsVenueUsersLoaded } from "hooks/users";
 import { WithId } from "utils/id";
 import { isTruthy } from "utils/types";
+import { experiencesSelector } from "utils/selectors";
 
 interface PropsType {
   venueName: string;
@@ -71,11 +72,7 @@ const TablesUserList: React.FunctionComponent<PropsType> = ({
   const { user, profile } = useUser();
   const partygoers = usePartygoers();
   const isVenueUsersLoaded = useIsVenueUsersLoaded();
-  const { experience } = useSelector((state) => ({
-    experience:
-      state.firestore.data.experiences &&
-      state.firestore.data.experiences[venueName],
-  }));
+  const experience = useSelector(experiencesSelector);
 
   useEffect(() => {
     if (!profile) return;

--- a/src/components/molecules/TablesUserList/TablesUserList.tsx
+++ b/src/components/molecules/TablesUserList/TablesUserList.tsx
@@ -12,7 +12,7 @@ import { useSelector } from "hooks/useSelector";
 import { usePartygoers, useIsVenueUsersLoaded } from "hooks/users";
 import { WithId } from "utils/id";
 import { isTruthy } from "utils/types";
-import { experiencesSelector } from "utils/selectors";
+import { experienceSelector } from "utils/selectors";
 
 interface PropsType {
   venueName: string;
@@ -72,7 +72,7 @@ const TablesUserList: React.FunctionComponent<PropsType> = ({
   const { user, profile } = useUser();
   const partygoers = usePartygoers();
   const isVenueUsersLoaded = useIsVenueUsersLoaded();
-  const experience = useSelector(experiencesSelector);
+  const experience = useSelector(experienceSelector);
 
   useEffect(() => {
     if (!profile) return;

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -7,6 +7,7 @@ import { currentVenueSelectorData } from "utils/selectors";
 import { useInterval } from "hooks/useInterval";
 import { useSelector } from "hooks/useSelector";
 import { usePartygoers } from "hooks/users";
+import { useExperiences } from "hooks/useExperiences";
 
 import ChatDrawer from "components/organisms/ChatDrawer";
 import InformationLeftColumn from "components/organisms/InformationLeftColumn";
@@ -33,6 +34,8 @@ export const ConversationSpace: React.FunctionComponent = () => {
   useInterval(() => {
     setNowMs(Date.now());
   }, LOC_UPDATE_FREQ_MS);
+
+  useExperiences(venue?.name);
 
   if (!venue) return <>Loading...</>;
 

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -62,23 +62,22 @@ const createReaction = (reaction: ReactionType, user: UserInfo) => {
 };
 
 const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
+  const firestoreVenue = useSelector(currentVenueSelectorData);
+  const venueToUse = venue ? venue : firestoreVenue;
+
   // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
   //   this should be something like `storeAs: "currentVenueExperiences"` or similar
   useFirestoreConnect(
-    venue?.name
+    venueToUse?.name
       ? {
           collection: "experiences",
-          doc: venue.name,
+          doc: venueToUse.name,
           storeAs: "experiences" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
         }
       : undefined
   );
 
   const { user } = useUser();
-
-  const firestoreVenue = useSelector(currentVenueSelectorData);
-
-  const venueToUse = venue ? venue : firestoreVenue;
 
   const jazzbarTables = venueToUse?.config?.tables ?? JAZZBAR_TABLES;
 

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -6,7 +6,6 @@ import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import { IFRAME_ALLOW } from "settings";
 import { UserInfo } from "firebase/app";
 
-import { ValidStoreAsKeys } from "types/Firestore";
 import { User } from "types/User";
 import { Venue } from "types/Venue";
 
@@ -32,13 +31,13 @@ import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 import { useVenueId } from "hooks/useVenueId";
 import { usePartygoers } from "hooks/users";
-import { useFirestoreConnect } from "hooks/useFirestoreConnect";
 
 import { addReaction } from "store/actions/Reactions";
 
 import { JAZZBAR_TABLES } from "./constants";
 
 import "./JazzTab.scss";
+import { useExperiences } from "hooks/useExperiences";
 
 interface JazzProps {
   setUserList: (value: User[]) => void;
@@ -65,17 +64,7 @@ const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
   const firestoreVenue = useSelector(currentVenueSelectorData);
   const venueToUse = venue ? venue : firestoreVenue;
 
-  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
-  //   this should be something like `storeAs: "currentVenueExperiences"` or similar
-  useFirestoreConnect(
-    venueToUse?.name
-      ? {
-          collection: "experiences",
-          doc: venueToUse.name,
-          storeAs: "experiences" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
-        }
-      : undefined
-  );
+  useExperiences(venueToUse?.name);
 
   const { user } = useUser();
 

--- a/src/hooks/useExperiences.ts
+++ b/src/hooks/useExperiences.ts
@@ -1,0 +1,17 @@
+import { ValidStoreAsKeys } from "types/Firestore";
+
+import { useFirestoreConnect } from "./useFirestoreConnect";
+
+export const useExperiences = (venueName?: string) => {
+  // @debt refactor this + related code so as not to rely on using a shadowed 'storeAs' key
+  //   this should be something like `storeAs: "currentVenueExperiences"` or similar
+  useFirestoreConnect(
+    venueName
+      ? {
+          collection: "experiences",
+          doc: venueName,
+          storeAs: "experience" as ValidStoreAsKeys, // @debt super hacky, but we're consciously subverting our helper protections
+        }
+      : undefined
+  );
+};

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -65,7 +65,7 @@ export interface FirestoreData {
   currentVenueNG?: AnyVenue;
   eventPurchase?: Record<string, Purchase>;
   events?: Record<string, VenueEvent>;
-  experiences: Record<string, Record<string, Table>>;
+  experience: Experience;
   parentVenue?: AnyVenue;
   playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
   privatechats?: Record<string, PrivateChatMessage>;
@@ -88,7 +88,7 @@ export interface FirestoreOrdered {
   currentVenueNG?: Array<WithId<AnyVenue>>;
   eventPurchase?: Array<WithId<Purchase>>;
   events?: Array<WithId<VenueEvent>>;
-  experiences: Array<WithId<Experience>>;
+  experience: WithId<Experience>;
   parentVenue?: Array<WithId<AnyVenue>>;
   parentVenueEvents?: Array<WithId<VenueEvent>>;
   playaVenues?: Array<WithId<AnyVenue>>;

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -18,7 +18,7 @@ export type AnyVenue = Venue | PartyMapVenue | CampVenue;
 
 interface Experience {
   reactions: Record<string, Reaction>;
-  tables: Record<string, Table>;
+  tables: Record<string, Record<string, Table>>;
 }
 
 export interface UserVisit {
@@ -65,7 +65,7 @@ export interface FirestoreData {
   currentVenueNG?: AnyVenue;
   eventPurchase?: Record<string, Purchase>;
   events?: Record<string, VenueEvent>;
-  experiences: Record<string, Experience>;
+  experiences: Record<string, Record<string, Table>>;
   parentVenue?: AnyVenue;
   playaVenues?: Record<string, AnyVenue>; // for the admin playa preview
   privatechats?: Record<string, PrivateChatMessage>;

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -152,8 +152,8 @@ export const privateChatsSelector = (state: RootState) =>
 export const chatUsersSelector = (state: RootState) =>
   state.firestore.data.chatUsers;
 
-export const experiencesSelector = (state: RootState) =>
-  state.firestore.data.experiences;
+export const experienceSelector = (state: RootState) =>
+  state.firestore.data.experience;
 
 export const venueSelector = (state: RootState) =>
   state.firestore.ordered.currentVenue


### PR DESCRIPTION
`experiences` were `undefined` because `venue.name` was `undefined` and the query was failing. `venueToUse` now is being used and `experiences` are fetched correctly. Types are also changed because the structure is different.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/199