### PR TITLE
fix audience avatars and route paths

### DIFF
--- a/src/components/molecules/Chatbox/Chatbox.scss
+++ b/src/components/molecules/Chatbox/Chatbox.scss
@@ -7,6 +7,7 @@ $dark: #19181a;
 $border-radius: 28px;
 
 .chat-container {
+  z-index: z(chat-container);
   height: calc(100% - #{$chat-input-height + $footer-height});
   flex-direction: column;
   align-items: flex-end;

--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 $light: #ffffff;
 
 .audience-container {
@@ -10,6 +12,7 @@ $light: #ffffff;
   -ms-flex: 1;
 
   .video-container {
+    z-index: z(audience-video);
     position: fixed;
     left: 50%;
     top: 28%;

--- a/src/components/templates/Audience/AudienceRouter.tsx
+++ b/src/components/templates/Audience/AudienceRouter.tsx
@@ -8,8 +8,8 @@ export const AudienceRouter: React.FunctionComponent = () => {
 
   return (
     <Switch>
-      <Route path={`${match.url}/admin`} component={VideoAdmin} />
-      <Route path={`${match.url}/`} component={Audience} />
+      <Route path={`${match.path}/admin`} component={VideoAdmin} />
+      <Route path={`${match.path}`} component={Audience} />
     </Switch>
   );
 };

--- a/src/components/templates/AvatarGrid/Router.tsx
+++ b/src/components/templates/AvatarGrid/Router.tsx
@@ -10,8 +10,8 @@ export const AvatarRouter: FC = () => {
 
   return (
     <Switch>
-      <Route exact path={`${match.url}/admin`} component={AvatarAdmin} />
-      <Route path={`${match.url}/`} component={AvatarGrid} />
+      <Route exact path={`${match.path}/admin`} component={AvatarAdmin} />
+      <Route path={`${match.path}/`} component={AvatarGrid} />
     </Switch>
   );
 };

--- a/src/components/templates/Camp/Router.tsx
+++ b/src/components/templates/Camp/Router.tsx
@@ -12,9 +12,9 @@ export const CampRouter: React.FunctionComponent = () => {
 
   return (
     <Switch>
-      <Route exact path={`${match.url}/admin`} component={CampAdmin} />
-      <Route path={`${match.url}/:roomTitle`} render={() => <Camp />} />
-      <Route path={`${match.url}/`} render={() => <Camp />} />
+      <Route exact path={`${match.path}/admin`} component={CampAdmin} />
+      <Route path={`${match.path}/:roomTitle`} component={Camp} />
+      <Route path={`${match.path}/`} component={Camp} />
     </Switch>
   );
 };

--- a/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
+++ b/src/components/templates/Jazzbar/JazzbarRouter/JazzbarRouter.tsx
@@ -9,9 +9,9 @@ export const JazzbarRouter: React.FC = () => {
 
   return (
     <Switch>
-      <Route path={`${match.url}/band`} component={ReactionPage} />
-      <Route path={`${match.url}/admin`} component={VideoAdmin} />
-      <Route path={`${match.url}/`} component={JazzBar} />
+      <Route path={`${match.path}/band`} component={ReactionPage} />
+      <Route path={`${match.path}/admin`} component={VideoAdmin} />
+      <Route path={`${match.path}/`} component={JazzBar} />
     </Switch>
   );
 };

--- a/src/components/templates/PartyMap/PartyMapRouter.tsx
+++ b/src/components/templates/PartyMap/PartyMapRouter.tsx
@@ -10,9 +10,9 @@ export const PartyMapRouter: FC = () => {
 
   return (
     <Switch>
-      <Route exact path={`${match.url}/admin`} component={PartyMapAdmin} />
-      <Route path={`${match.url}/:roomTitle`} component={PartyMap} />
-      <Route path={`${match.url}/`} component={PartyMap} />
+      <Route exact path={`${match.path}/admin`} component={PartyMapAdmin} />
+      <Route path={`${match.path}/:roomTitle`} component={PartyMap} />
+      <Route path={`${match.path}/`} component={PartyMap} />
     </Switch>
   );
 };

--- a/src/components/templates/Playa/Router.tsx
+++ b/src/components/templates/Playa/Router.tsx
@@ -10,9 +10,9 @@ export const PlayaRouter: React.FunctionComponent = () => {
 
   return (
     <Switch>
-      <Route exact path={`${match.url}/admin`} component={PlayaAdmin} />
-      <Route path={`${match.url}/:camp`} component={Playa} />
-      <Route path={`${match.url}/`} component={Playa} />
+      <Route exact path={`${match.path}/admin`} component={PlayaAdmin} />
+      <Route path={`${match.path}/:camp`} component={Playa} />
+      <Route path={`${match.path}/`} component={Playa} />
     </Switch>
   );
 };

--- a/src/hooks/useVenueId.ts
+++ b/src/hooks/useVenueId.ts
@@ -1,14 +1,18 @@
 import { useParams } from "react-router-dom";
 
+interface ParamsTypes {
+  venueId?: string;
+}
+
 /**
  * Retrieve the venueId from the URL path.
  *
  * @see https://reactrouter.com/web/api/Hooks/useparams
  */
 export const useVenueId: () => string | undefined = () => {
-  const { venueId } = useParams();
+  const { venueId } = useParams() as ParamsTypes;
 
-  if (typeof venueId === "string") return venueId;
+  if (venueId && typeof venueId === "string") return venueId;
 
   return undefined;
 };

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -49,6 +49,8 @@ $z-layers: (
   schedule-backdrop: 3,
   map-back-button: 3,
   sidebar: 2,
+  audience-video: 2,
+  chat-container: 2,
 );
 
 @function z($layer) {


### PR DESCRIPTION
Fixes the z-index in the audience template, avatars are now showing up underneath the video.

Fixes the route paths, they were using `match.url` instead of `match.path`. Example:
If path is `venue/:venueId` and url is `venue/denismusic` then the url replaces the path, and the params object is empty because path now looks like this: `venue/denismusic` and the venueId param doesn't exist anymore. Which then means that `useVenueId` returns `undefined` which is missleading.  This is necessary change and made here on purpose because audience templates were not working because of this issue.

Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/201