### PR TITLE
fix NavSearchBar search result key stability + allow vertical scrolling

### DIFF
--- a/src/components/molecules/NavSearchBar/NavSearchBar.scss
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.scss
@@ -1,3 +1,5 @@
+@import "scss/constants.scss";
+
 .nav-search-links {
   display: flex;
   position: relative;
@@ -68,12 +70,17 @@
 }
 
 .nav-search-results {
-  position: absolute;
-  min-width: 290px;
+  z-index: z(nav-search-results);
+
   position: fixed;
-  z-index: 380;
   top: 60px;
+
+  min-width: 290px;
+
   height: auto;
+  max-height: 75vh;
+  overflow-y: auto;
+
   padding: 20px;
   box-shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.5);
   border-radius: 0 0 24px 24px;

--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -20,14 +20,17 @@ interface SearchResult {
 
 const NavSearchBar = () => {
   const [searchQuery, setSearchQuery] = useState("");
+
   const [searchResult, setSearchResult] = useState<SearchResult>({
     rooms: [],
     users: [],
     events: [],
   });
+
   const [selectedUserProfile, setSelectedUserProfile] = useState<
     WithId<User>
   >();
+
   const [selectedRoom, setSelectedRoom] = useState<CampRoomData>();
 
   const venue = useSelector(currentVenueSelectorData);
@@ -79,72 +82,78 @@ const NavSearchBar = () => {
     <div className="nav-search-links">
       <div className="nav-search-icon" />
       <NavSearchBarInput value={searchQuery} onChange={setSearchQuery} />
+
       {isTruthy(searchQuery) && (
         <div className="nav-search-close-icon" onClick={clearSearchQuery} />
       )}
-      {isTruthy(numberOfSearchResults) && (
-        <>
-          <div className="nav-search-results">
-            <div className="nav-search-result-number">
-              <b>{numberOfSearchResults}</b> search results
-            </div>
-            {searchResult.rooms.map((room, index) => {
-              return (
-                <div
-                  className="row"
-                  key={`room-${index}`}
-                  onClick={() => setSelectedRoom(room)}
-                >
-                  <div
-                    className="result-avatar"
-                    style={{
-                      backgroundImage: `url(${room.image_url})`,
-                    }}
-                  ></div>
-                  <div className="result-info">
-                    <div className="result-title">{room.title}</div>
-                    <div>Room</div>
-                  </div>
-                </div>
-              );
-            })}
-            {searchResult.events.map((event, index) => {
-              return (
-                <div className="row" key={`event-${index}`}>
-                  <div>
-                    <div>{event.name}</div>
-                    <div>Event</div>
-                  </div>
-                </div>
-              );
-            })}
-            {searchResult.users.map((user, index) => {
-              return (
-                <div
-                  className="row"
-                  key={`room-${index}`}
-                  onClick={() => setSelectedUserProfile(user)}
-                >
-                  <div
-                    className="result-avatar"
-                    style={{
-                      backgroundImage: `url(${user.pictureUrl})`,
-                    }}
-                  ></div>
-                  <div className="result-info">
-                    <div key={`user-${index}`}>{user.partyName}</div>
-                  </div>
-                </div>
-              );
-            })}
+
+      {numberOfSearchResults > 0 && (
+        <div className="nav-search-results">
+          <div className="nav-search-result-number">
+            <b>{numberOfSearchResults}</b> search results
           </div>
-        </>
+
+          {/* @debt we really shouldn't be using the index as part of the key here, it's unstable.. but rooms don't have a unique identifier */}
+          {searchResult.rooms.map((room, index) => {
+            return (
+              <div
+                className="row"
+                key={`room-${room.title}-${index}`}
+                onClick={() => setSelectedRoom(room)}
+              >
+                <div
+                  className="result-avatar"
+                  style={{
+                    backgroundImage: `url(${room.image_url})`,
+                  }}
+                />
+                <div className="result-info">
+                  <div className="result-title">{room.title}</div>
+                  <div>Room</div>
+                </div>
+              </div>
+            );
+          })}
+
+          {searchResult.events.map((event) => {
+            return (
+              <div className="row" key={`event-${event.id ?? event.name}`}>
+                <div>
+                  <div>{event.name}</div>
+                  <div>Event</div>
+                </div>
+              </div>
+            );
+          })}
+
+          {searchResult.users.map((user) => {
+            return (
+              <div
+                className="row"
+                key={`user-${user.id}`}
+                onClick={() => setSelectedUserProfile(user)}
+              >
+                <div
+                  className="result-avatar"
+                  style={{
+                    backgroundImage: `url(${user.pictureUrl})`,
+                  }}
+                />
+                <div className="result-info">
+                  <div>{user.partyName}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       )}
+
       <UserProfileModal
         userProfile={selectedUserProfile}
         show={selectedUserProfile !== undefined}
         onHide={() => setSelectedUserProfile(undefined)}
       />
+
       <RoomModal
         show={isTruthy(selectedRoom)}
         room={selectedRoom}

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -42,6 +42,7 @@ $playa-venue-live: rgb(125, 223, 194);
 $profile-image-bg-color: #999999;
 
 $z-layers: (
+  nav-search-results: 380,
   header: 5,
   footer: 5,
   announcement: 3,


### PR DESCRIPTION
- Ensure we don't use `index` for React component's `key` property.
  - Because it doesn't uniquely identify the individual result, it causes issues when the item changes (but still has the same array index), which causes update issues (in this case, user profile pictures were showing for the wrong user, as it wasn't updated when the person in that 'search result slot' changed)
- Sets a max-height on `.nav-search-results` + enable scrolling

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/209
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/210