### PR TITLE
add reporting dependencies to dependabot + fix reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     time: "05:00"
     timezone: Australia/Sydney
   reviewers:
-    - "sparkletown/tech-leads"
+    - "sparkletown/engineering-leads"
   open-pull-requests-limit: 2
   target-branch: staging
   versioning-strategy: auto
@@ -25,7 +25,21 @@ updates:
     time: "05:00"
     timezone: Australia/Sydney
   reviewers:
-    - "sparkletown/tech-leads"
+    - "sparkletown/engineering-leads"
+  open-pull-requests-limit: 2
+  target-branch: staging
+  versioning-strategy: auto
+
+# Sparkle Platform - Reporting Tools
+- package-ecosystem: npm
+  directory: "/reporting"
+  schedule:
+    interval: weekly
+    day: "monday"
+    time: "05:00"
+    timezone: Australia/Sydney
+  reviewers:
+    - "sparkletown/engineering-leads"
   open-pull-requests-limit: 2
   target-branch: staging
   versioning-strategy: auto


### PR DESCRIPTION
- the `reporting/` folder wasn't being tracked by dependabot, now it is
- we renamed `sparkletown/tech-leads` to `sparkletown/engineering-leads`, but this config was still using the old group name