### PR TITLE
fix scripts/get-badges typing to properly handle potentially missing users + exit on errors properly

### DIFF
--- a/scripts/get-badges.ts
+++ b/scripts/get-badges.ts
@@ -90,7 +90,10 @@ interface UsersWithVisitsResult {
     })
   ).then((result) => result.flat());
 
-  const authUsersById: Record<string, admin.auth.UserRecord> = authUsers.reduce(
+  const authUsersById: Record<
+    string,
+    admin.auth.UserRecord | undefined
+  > = authUsers.reduce(
     (acc, authUser) => ({ ...acc, [authUser.uid]: authUser }),
     {}
   );
@@ -99,7 +102,7 @@ interface UsersWithVisitsResult {
   const result = usersWithVisits.map((userWithVisits) => {
     const { user, visits } = userWithVisits;
     const { id, partyName, enteredVenueIds = [] } = user;
-    const { email } = authUsersById[id];
+    const { email } = authUsersById[id] ?? {};
 
     const visitsTimeSpent = visits.map(
       (visit) => `${visit.id} (${formatSecondsAsDuration(visit.timeSpent)})`

--- a/scripts/get-badges.ts
+++ b/scripts/get-badges.ts
@@ -132,6 +132,11 @@ interface UsersWithVisitsResult {
 
     console.log(csvLine);
   });
-
-  process.exit(0);
-})();
+})()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    process.exit(0);
+  });


### PR DESCRIPTION
When running this script it seems that there was a user that couldn't be looked up, resulting in not having an entry in `usersById`. Due to the TypeScript typing on this, it implied that there could never be an undefined value for any given `userId` (which is incorrect). This also surfaced an issue where we weren't properly handling errors thrown within promises.

Before fixing these bugs, the error output looked like:

```
(node:95053) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'email' of undefined
    at /Users/devalias/dev/sparkle/sparkle/scripts/get-badges.ts:102:40
    at Array.map (<anonymous>)
    at /Users/devalias/dev/sparkle/sparkle/scripts/get-badges.ts:99:34
    at step (/Users/devalias/dev/sparkle/sparkle/scripts/get-badges.ts:44:23)
    at Object.next (/Users/devalias/dev/sparkle/sparkle/scripts/get-badges.ts:25:53)
    at fulfilled (/Users/devalias/dev/sparkle/sparkle/scripts/get-badges.ts:16:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

(node:95053) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

(node:95053) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```