### PR TITLE
fix account creation when venue access is missing

### DIFF
--- a/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
+++ b/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
@@ -2,12 +2,9 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import { useFirebase } from "react-redux-firebase";
 
-import { checkAccess } from "api/auth";
-
 import { useSelector } from "hooks/useSelector";
 
 import { venueSelector } from "utils/selectors";
-import { setLocalStorageToken } from "utils/localStorage";
 
 import { VenueAccessMode } from "types/VenueAcccess";
 
@@ -62,34 +59,6 @@ const LoginForm: React.FunctionComponent<PropsType> = ({
     if (!venue) return;
     try {
       await signIn(data);
-
-      let result = null;
-
-      switch (venue.access) {
-        case VenueAccessMode.Codes:
-          result = await checkAccess({
-            venueId: venue.id,
-            code: data.code,
-          });
-          break;
-        case VenueAccessMode.Emails:
-          result = await checkAccess({
-            venueId: venue.id,
-            email: data.email,
-          });
-          break;
-
-        default:
-          break;
-      }
-
-      if (result?.data === false) {
-        throw new Error("access denied");
-      }
-
-      if (result?.data?.token) {
-        setLocalStorageToken(venue.id, result.data.token);
-      }
 
       afterUserIsLoggedIn && afterUserIsLoggedIn();
 

--- a/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
+++ b/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
@@ -83,13 +83,13 @@ const LoginForm: React.FunctionComponent<PropsType> = ({
           break;
       }
 
-      if (!result) return;
-
-      if (result.data === false) {
+      if (result?.data === false) {
         throw new Error("access denied");
       }
 
-      setLocalStorageToken(venue.id, result.data.token);
+      if (result?.data?.token) {
+        setLocalStorageToken(venue.id, result.data.token);
+      }
 
       afterUserIsLoggedIn && afterUserIsLoggedIn();
 

--- a/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
+++ b/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
@@ -3,15 +3,12 @@ import firebase from "firebase/app";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 
-import { checkAccess } from "api/auth";
-
 import { SPARKLE_TERMS_AND_CONDITIONS_URL } from "settings";
 
 import { VenueAccessMode } from "types/VenueAcccess";
 
 import { venueSelector } from "utils/selectors";
 import { isTruthy } from "utils/types";
-import { setLocalStorageToken } from "utils/localStorage";
 
 import { useSelector } from "hooks/useSelector";
 
@@ -93,34 +90,6 @@ const RegisterForm: React.FunctionComponent<PropsType> = ({
     try {
       setShowLoginModal(false);
       const auth = await signUp(data);
-
-      let result = null;
-
-      switch (venue.access) {
-        case VenueAccessMode.Codes:
-          result = await checkAccess({
-            venueId: venue.id,
-            code: data.code,
-          });
-          break;
-        case VenueAccessMode.Emails:
-          result = await checkAccess({
-            venueId: venue.id,
-            email: data.email,
-          });
-          break;
-
-        default:
-          break;
-      }
-
-      if (result?.data === false) {
-        throw new Error("access denied");
-      }
-
-      if (result?.data?.token) {
-        setLocalStorageToken(venue.id, result.data.token);
-      }
 
       if (auth.user && venue.requiresDateOfBirth) {
         updateUserPrivate(auth.user.uid, {

--- a/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
+++ b/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
@@ -114,13 +114,13 @@ const RegisterForm: React.FunctionComponent<PropsType> = ({
           break;
       }
 
-      if (!result) return;
-
-      if (result.data === false) {
+      if (result?.data === false) {
         throw new Error("access denied");
       }
 
-      setLocalStorageToken(venue.id, result.data.token);
+      if (result?.data?.token) {
+        setLocalStorageToken(venue.id, result.data.token);
+      }
 
       if (auth.user && venue.requiresDateOfBirth) {
         updateUserPrivate(auth.user.uid, {


### PR DESCRIPTION
The guards were checking if result exists and were preventing the logic from finishing. Result is missing when venue access is not set and this is expected. Token won't be set if the venue access is missing (open) because everyone can join the party/event. Password on the other hand is tricky and needs further discussion. Because when you are creating an account, you don't have an input field for venue password and this might be a problem. The UX is the following:
Create account -> /in/ -> No Access -> /v/ -> Type password

We should probably redirect people to /v/ instead of /in/ when `venue.access` exists.

Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/338