### PR TITLE
refactor scss z-index's to use z() helper + fix user avatar 'sidebar' layering issues

### DIFF
--- a/src/components/atoms/Legend/Legend.styles.ts
+++ b/src/components/atoms/Legend/Legend.styles.ts
@@ -18,6 +18,7 @@ export const Legend = styled.div<LegendProps>`
   position: absolute;
   top: 0;
   ${({ position }) => (position === "left" ? legendLeft : legendRight)};
+  // @debt convert this to scss then use our z-index layer helper here
   z-index: 5;
 
   background: rgba(0, 0, 0, 0.4);

--- a/src/components/molecules/Chatbox/Chatbox.scss
+++ b/src/components/molecules/Chatbox/Chatbox.scss
@@ -7,7 +7,7 @@ $dark: #19181a;
 $border-radius: 28px;
 
 .chat-container {
-  z-index: z(chat-container);
+  z-index: z(chatbox-chat-container);
   height: calc(100% - #{$chat-input-height + $footer-height});
   flex-direction: column;
   align-items: flex-end;

--- a/src/components/molecules/ChatsList/ChatsList.scss
+++ b/src/components/molecules/ChatsList/ChatsList.scss
@@ -93,7 +93,7 @@ $primary: #005ee5;
 }
 
 .private-container-back-btn {
-  z-index: 1;
+  z-index: z(chatslist-private-container-back-button);
   position: absolute;
   background-size: cover;
   background-position: center;

--- a/src/components/molecules/LoadingPage/loading.scss
+++ b/src/components/molecules/LoadingPage/loading.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 $side-padding: 30px;
 $primary: #7c46fb;
 $black: #000000;
@@ -41,7 +43,7 @@ body {
   .loading-sparkle-2 {
     position: absolute;
     display: block;
-    z-index: 10;
+    z-index: z(loading-page-sparkle);
     height: 23px;
     width: 15px;
     opacity: 1;

--- a/src/components/molecules/NavSearchBar/NavSearchBar.scss
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.scss
@@ -18,7 +18,7 @@
   .nav-search-close-icon {
     position: absolute;
     align-self: center;
-    z-index: 1;
+    z-index: z(nav-search-close-icon);
     cursor: pointer;
     right: 5px;
     height: 30px;
@@ -38,7 +38,7 @@
     display: none;
     content: "";
     position: absolute;
-    z-index: 1;
+    z-index: z(nav-search-input-close-btn);
     cursor: pointer;
     right: 5px;
     top: 5px;

--- a/src/components/molecules/PrivateRecipientSearchInput/PrivateRecipientSearchInput.scss
+++ b/src/components/molecules/PrivateRecipientSearchInput/PrivateRecipientSearchInput.scss
@@ -1,4 +1,4 @@
-@import "scss/constants.scss";
+@import "scss/constants";
 
 .private-recipient-search-input-container {
   .private-recipient {
@@ -20,7 +20,7 @@
   .floating-dropdown {
     position: absolute;
     background: $dark;
-    z-index: 1;
+    z-index: z(private-recipient-search-input-dropdown);
     width: 100%;
     border: 2px solid $light-grey;
   }

--- a/src/components/molecules/Sidebar/Sidebar.scss
+++ b/src/components/molecules/Sidebar/Sidebar.scss
@@ -40,7 +40,7 @@ $dark: #19181a;
   .sidebar-slide-btn {
     position: absolute;
     top: 0;
-    z-index: -1;
+    z-index: z(sidebar-slide-btn);
     left: -50px;
     height: 52px;
     width: 50px;

--- a/src/components/molecules/UserProfilePicture/UserProfilePicture.scss
+++ b/src/components/molecules/UserProfilePicture/UserProfilePicture.scss
@@ -41,7 +41,7 @@ $borderWidth: 5px;
     position: absolute;
     top: -25px;
     right: -20px;
-    z-index: 1000;
+    z-index: z(user-profile-picture-reaction);
 
     font-size: 50px;
 
@@ -50,7 +50,7 @@ $borderWidth: 5px;
 
   .heart {
     fill: red;
-    z-index: 99999;
+    z-index: z(user-profile-picture-heart);
   }
 
   @keyframes expand-bounce {

--- a/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
+++ b/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
@@ -34,6 +34,7 @@ export const Reaction = styled.div<ReactionProps>`
   ${({ reactionPosition }) =>
     reactionPosition === "right" ? reactionRight : reactionLeft};
   top: -25px;
+  // @debt convert this to scss then use our z-index layer helper here
   z-index: 10;
 
   font-size: 50px;
@@ -48,7 +49,7 @@ export const Container = styled.div`
 
   background-position: center;
   background-size: cover;
-  // @debt Since this is not a css file, I can't use constants here
+  // @debt convert this to scss then use our z-index layer helper here
   z-index: 10;
 
   ${Avatar} {

--- a/src/components/molecules/UserSearchBar/UserSearchBar.scss
+++ b/src/components/molecules/UserSearchBar/UserSearchBar.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 .user-search-links {
   display: flex;
   position: relative;
@@ -16,7 +18,7 @@
   .user-search-close-icon {
     position: absolute;
     align-self: center;
-    z-index: 1;
+    z-index: z(user-search-close-icon);
     cursor: pointer;
     right: 5px;
     height: 30px;
@@ -36,7 +38,7 @@
     display: none;
     content: "";
     position: absolute;
-    z-index: 1;
+    z-index: z(user-search-input-close-btn);
     cursor: pointer;
     right: 5px;
     top: 5px;
@@ -70,7 +72,7 @@
 .user-search-results {
   position: absolute;
   width: 100%;
-  z-index: 380;
+  z-index: z(user-search-results);
   top: 105%;
   height: auto;
   padding: 20px;

--- a/src/components/organisms/ChatDrawer/ChatDrawer.scss
+++ b/src/components/organisms/ChatDrawer/ChatDrawer.scss
@@ -1,7 +1,7 @@
-@import "scss/constants.scss";
+@import "scss/constants";
 
 .chat-drawer-container {
-  z-index: 2;
+  z-index: z(chat-drawer-container);
   display: flex;
   flex-direction: column;
   transition: all 0.2s linear;

--- a/src/components/organisms/Chatbox/Chatbox.scss
+++ b/src/components/organisms/Chatbox/Chatbox.scss
@@ -65,7 +65,7 @@
 }
 
 .chat-submit-button {
-  z-index: 1;
+  z-index: z(chatbox-submit-button);
   background-color: #000000;
   border: none;
   padding: 10px 15px;

--- a/src/components/organisms/DustStorm/DustStorm.scss
+++ b/src/components/organisms/DustStorm/DustStorm.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 $side-padding: 30px;
 $primary: #7c46fb;
 $black: #000000;
@@ -16,7 +18,7 @@ $sand: #937c63;
 
 .duststorm-container {
   position: absolute;
-  z-index: 100;
+  z-index: z(duststorm-container);
   display: flex;
   align-items: center;
   overflow: hidden;
@@ -81,7 +83,7 @@ $sand: #937c63;
   }
 
   .modal-content {
-    z-index: 220;
+    z-index: z(duststorm-modal-content);
     width: calc(100% - 20px);
     max-width: $modal-max-width;
     margin: 0 auto;

--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -82,7 +82,7 @@ $light: #ffffff;
           right: -20px;
           width: 50px;
           animation: sway 2200ms 1200ms ease-in-out;
-          z-index: 1000;
+          z-index: z(audience-emoji-reaction);
         }
 
         .leave-seat-button {

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.scss
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.scss
@@ -129,7 +129,7 @@
         width: 25px;
         height: 25px;
         border-radius: 188%;
-        z-index: 1;
+        z-index: z(jazzbar-participant-profile-icon);
       }
 
       .mute-container {

--- a/src/components/templates/PartyMap/components/Map/Map.scss
+++ b/src/components/templates/PartyMap/components/Map/Map.scss
@@ -1,4 +1,5 @@
-@import "scss/constants.scss";
+@import "scss/constants";
+
 $sand: #937c63;
 $white: #ffffff;
 $border-radius: 28px;
@@ -186,7 +187,7 @@ $border-radius: 28px;
   position: fixed;
   top: 70px;
   left: 0px;
-  z-index: 2;
+  z-index: z(left-column);
 }
 
 .info-drawer-camp {

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -1,4 +1,5 @@
 @import "scss/constants";
+
 $sand: #937c63;
 
 $top-margin: 20px;
@@ -171,7 +172,7 @@ $page-max-width: 1240px;
 .profile-picture-preview-container {
   display: flex;
   justify-content: center;
-  z-index: 1;
+  z-index: z(account-profile-picture-preview);
 }
 
 .profile-picture-input {

--- a/src/pages/Admin/Admin.scss
+++ b/src/pages/Admin/Admin.scss
@@ -19,7 +19,7 @@ $page-max-width: 1240px;
 
   .navbar {
     position: fixed;
-    z-index: 100;
+    z-index: z(admin-navbar);
     top: 0;
     left: 0;
     width: 100%;
@@ -173,7 +173,7 @@ $page-max-width: 1240px;
         .page-container-adminpanel-content,
         .page-container-adminpanel-placement {
           position: relative;
-          z-index: 10;
+          z-index: z(admin-placement);
           overflow-y: scroll;
 
           .edit-rooms-container {
@@ -196,7 +196,7 @@ $page-max-width: 1240px;
           .venue-header {
             position: absolute;
             top: 0;
-            z-index: -1;
+            z-index: z(admin-venue-header);
             background-color: $black;
             width: 100%;
             height: 500px;
@@ -206,7 +206,7 @@ $page-max-width: 1240px;
             &:after {
               content: "";
               position: absolute;
-              z-index: 2;
+              z-index: z(admin-venue-header-after);
               left: 0;
               width: 100%;
               height: 500px;

--- a/src/pages/Admin/Room/Modal/RoomModal.styles.ts
+++ b/src/pages/Admin/Room/Modal/RoomModal.styles.ts
@@ -8,6 +8,7 @@ export const Wrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
+  // @debt convert this to scss then use our z-index layer helper here
   z-index: 101;
 
   background: rgba(0, 0, 0, 0.5);

--- a/src/pages/VenuePage/VenuePage.scss
+++ b/src/pages/VenuePage/VenuePage.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 .preview-indication {
   position: absolute;
   top: 50px;
@@ -10,5 +12,5 @@
   width: 100%;
   display: flex;
   justify-content: center;
-  z-index: 1;
+  z-index: z(venuepage-preview-indication);
 }

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -47,6 +47,7 @@ $room-info-bg: #005ee5;
 //   pages/Admin/Room/Modal/RoomModal.styles.ts (z-index: 101)
 //   components/molecules/UserProfilePicture/UserProfilePicture.styles.ts (z-index: 10)
 //   components/atoms/Legend/Legend.styles.ts (z-index: 5)
+$z-layer-sidebar: 15;
 $z-layers: (
   // Admin
   admin-navbar: 100,
@@ -59,8 +60,8 @@ $z-layers: (
   // JazzBar
   jazzbar-participant-profile-icon: 1,
   // Chat
-  chat-container: 2,
-  chat-drawer-container: 2,
+  chatbox-chat-container: $z-layer-sidebar,
+  chat-drawer-container: $z-layer-sidebar,
   chatbox-submit-button: 1,
   chatslist-private-container-back-button: 1,
   user-search-close-icon: 1,
@@ -74,8 +75,8 @@ $z-layers: (
   schedule-backdrop: 3,
   // Sidebars + similar
   sidebar-slide-btn: -1,
-  sidebar: 2,
-  left-column: 2,
+  sidebar: $z-layer-sidebar,
+  left-column: $z-layer-sidebar,
   // Map
   map-back-button: 3,
   map-room-hovered: 3,
@@ -86,8 +87,8 @@ $z-layers: (
   duststorm-modal-content: 220,
   header: 5,
   // Unsorted
-  announcement: 3,
-  footer: 5,
+  announcement: $z-layer-sidebar,
+  footer: $z-layer-sidebar,
   global-profile-icon: 1,
   loading-page-sparkle: 10,
   private-recipient-search-input-dropdown: 1,

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -43,20 +43,57 @@ $playa-venue-live: rgb(125, 223, 194);
 $profile-image-bg-color: #999999;
 $room-info-bg: #005ee5;
 
+// @debt the following locations are using styled-components, so can't use our helper function yet
+//   pages/Admin/Room/Modal/RoomModal.styles.ts (z-index: 101)
+//   components/molecules/UserProfilePicture/UserProfilePicture.styles.ts (z-index: 10)
+//   components/atoms/Legend/Legend.styles.ts (z-index: 5)
 $z-layers: (
+  // Admin
+  admin-navbar: 100,
+  admin-placement: 10,
+  admin-venue-header-after: 2,
+  admin-venue-header: -1,
+  // Audience
+  audience-emoji-reaction: 1000,
+  audience-video: 2,
+  // JazzBar
+  jazzbar-participant-profile-icon: 1,
+  // Chat
+  chat-container: 2,
+  chat-drawer-container: 2,
+  chatbox-submit-button: 1,
+  chatslist-private-container-back-button: 1,
+  user-search-close-icon: 1,
+  user-search-input-close-btn: 1,
+  user-search-results: 380,
+  // Nav
+  nav-search-close-icon: 1,
+  nav-search-input-close-btn: 1,
   nav-search-results: 380,
-  header: 5,
-  footer: 5,
-  announcement: 3,
   schedule: 4,
   schedule-backdrop: 3,
+  // Sidebars + similar
+  sidebar-slide-btn: -1,
+  sidebar: 2,
+  left-column: 2,
+  // Map
   map-back-button: 3,
   map-room-hovered: 3,
   map-room: 2,
-  sidebar: 2,
-  audience-video: 2,
-  chat-container: 2,
-  left-column: 2,
+  // Legacy
+  account-profile-picture-preview: 1,
+  duststorm-container: 100,
+  duststorm-modal-content: 220,
+  header: 5,
+  // Unsorted
+  announcement: 3,
+  footer: 5,
+  global-profile-icon: 1,
+  loading-page-sparkle: 10,
+  private-recipient-search-input-dropdown: 1,
+  user-profile-picture-heart: 99999,
+  user-profile-picture-reaction: 1000,
+  venuepage-preview-indication: 1
 );
 
 @function z($layer) {

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -473,7 +473,7 @@ h4 {
       bottom: 0;
       left: 0;
       border-radius: 188%;
-      z-index: 1;
+      z-index: z(global-profile-icon);
     }
 
     .mute-container {


### PR DESCRIPTION
The user avatar image was showing above the various 'sidebar-like' components. 

- refactored all scss `z-index` to use our `z()` helper (to centralise this logic, and reduce future layering issues)
- add `@debt` comments to `z-index` locations within `styled-components` (until we can 💥  all of the `styled-components` in favour of plain scss)
- update all of our 'sidebar-like' layers to use `z-index` `15`
  - fixes https://github.com/sparkletown/internal-sparkle-issues/issues/339

## Screenshots of bug before fix

![image](https://user-images.githubusercontent.com/753891/107743889-d5bd2780-6d65-11eb-96b2-f55b3b3ca0b8.png)
![image](https://user-images.githubusercontent.com/753891/107742875-f97f6e00-6d63-11eb-83c5-fafba31e842b.png)
