### PR TITLE
[scripts/get-badges] Get visits based on venue name

### DIFF
--- a/scripts/get-badges.ts
+++ b/scripts/get-badges.ts
@@ -9,6 +9,7 @@ import { UserVisit } from "../src/types/Firestore";
 import { User } from "../src/types/User";
 
 import { WithId, withId } from "../src/utils/id";
+import { formatSecondsAsDuration } from "../src/utils/time";
 
 import { initFirebaseAdminApp, makeScriptUsage } from "./lib/helpers";
 
@@ -112,7 +113,13 @@ interface UsersWithVisitsResult {
 
   // Display CSV headings
   console.log(
-    ["Email", "Party Name", "Venue Visited", "Time Spent"]
+    [
+      "Email",
+      "Party Name",
+      "Venue Visited",
+      "Time Spent (seconds)",
+      "Time Spent (formatted)",
+    ]
       .map((heading) => `"${heading}"`)
       .join(",")
   );
@@ -124,6 +131,7 @@ interface UsersWithVisitsResult {
       visit.partyName,
       visit.venueName,
       visit.timeSpent,
+      formatSecondsAsDuration(visit.timeSpent),
     ]
       .map((s) => `"${s}"`)
       .join(",");

--- a/scripts/get-badges.ts
+++ b/scripts/get-badges.ts
@@ -9,7 +9,6 @@ import { UserVisit } from "../src/types/Firestore";
 import { User } from "../src/types/User";
 
 import { WithId, withId } from "../src/utils/id";
-import { formatSecondsAsDuration } from "../src/utils/time";
 
 import { initFirebaseAdminApp, makeScriptUsage } from "./lib/helpers";
 
@@ -97,34 +96,35 @@ interface UsersWithVisitsResult {
         venueIdsArray.includes(visit.id.toLocaleLowerCase())
       );
     })
-    .map((userWithVisits) => {
+    .flatMap((userWithVisits) => {
       const { user, visits } = userWithVisits;
-      const { id, partyName, enteredVenueIds = [] } = user;
+      const { id, partyName } = user;
       const { email } = authUsersById[id] ?? {};
 
-      const visitsTimeSpent = visits.map(
-        (visit) => `${visit.id} (${formatSecondsAsDuration(visit.timeSpent)})`
-      );
-
-      return {
+      return visits.map((visit) => ({
         id,
         email,
         partyName,
-        enteredVenueIds: enteredVenueIds.sort().join(", "),
-        visitsTimeSpent: visitsTimeSpent.sort().join(", "),
-      };
+        venueName: visit.id,
+        timeSpent: visit.timeSpent,
+      }));
     });
 
   // Display CSV headings
   console.log(
-    ["Email", "Party Name", "Entered Venues (Time Spent)"]
+    ["Email", "Party Name", "Venue Visited", "Time Spent"]
       .map((heading) => `"${heading}"`)
       .join(",")
   );
 
   // Display CSV lines
-  result.forEach((user) => {
-    const csvLine = [user.email, user.partyName, user.visitsTimeSpent]
+  result.forEach((visit) => {
+    const csvLine = [
+      visit.email,
+      visit.partyName,
+      visit.venueName,
+      visit.timeSpent,
+    ]
       .map((s) => `"${s}"`)
       .join(",");
 


### PR DESCRIPTION
There were several users on the OG prod environment (emails available upon request please ask me) who were missing the `enteredVenueIds` key from their user record in Firestore.

This caused a recent event's analytics to misleadingly and incorrectly show as being attended by 10% of the believed attendance.

This change requires you to specify the venue name, but it will filter ALL users and ALL visits for those venue names.

With this, we were able to see a lot more data.

This is part of the solution that resolves https://github.com/sparkletown/internal-sparkle-issues/issues/294