### PR TITLE
fix z-index layering issues with NavBar, LiveSchedule, and SideBar

### DIFF
--- a/src/components/molecules/NavBar/NavBar.scss
+++ b/src/components/molecules/NavBar/NavBar.scss
@@ -394,7 +394,7 @@ $border-radius: 28px;
   position: fixed;
   left: 0;
   top: 0;
-  z-index: z(schedule-backdrop);
+  z-index: z(navbar-schedule-backdrop);
   width: 100%;
   height: 100%;
   background-color: rgba($black, 0.8);
@@ -413,7 +413,7 @@ $border-radius: 28px;
 .back-map-btn {
   position: fixed;
   top: 60px;
-  z-index: z(map-back-button);
+  z-index: z(navbar-map-back-button);
   left: 0px;
   height: 52px;
   width: auto;

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -344,14 +344,14 @@ const NavBar: React.FC<NavBarPropsType> = ({ redirectionUrl }) => {
         </div>
       </header>
 
-      <SchedulePageModal isVisible={isEventScheduleVisible} />
-
       <div
         className={`schedule-dropdown-backdrop ${
           isEventScheduleVisible ? "show" : ""
         }`}
         onClick={hideEventSchedule}
-      />
+      >
+        <SchedulePageModal isVisible={isEventScheduleVisible} />
+      </div>
 
       {venue?.parentId && parentVenue?.name && (
         <div className="back-map-btn">

--- a/src/components/molecules/NavBar/playa.scss
+++ b/src/components/molecules/NavBar/playa.scss
@@ -16,9 +16,10 @@ $page-max-width: 1240px;
 
 $sand: #937c63;
 
+// @debt Refactor the relevant parts of this file into ./NavBar.scss
 .navbar.navbar_playa {
   position: fixed;
-  z-index: z(header);
+  z-index: z(navbar);
   top: 0;
   left: 0;
   width: 100%;

--- a/src/components/molecules/NavSearchBar/NavSearchBar.scss
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.scss
@@ -18,7 +18,7 @@
   .nav-search-close-icon {
     position: absolute;
     align-self: center;
-    z-index: z(nav-search-close-icon);
+    z-index: z(navbar-nav-search-close-icon);
     cursor: pointer;
     right: 5px;
     height: 30px;
@@ -38,7 +38,7 @@
     display: none;
     content: "";
     position: absolute;
-    z-index: z(nav-search-input-close-btn);
+    z-index: z(navbar-nav-search-input-close-btn);
     cursor: pointer;
     right: 5px;
     top: 5px;
@@ -70,7 +70,7 @@
 }
 
 .nav-search-results {
-  z-index: z(nav-search-results);
+  z-index: z(navbar-nav-search-results);
 
   position: fixed;
   top: 60px;

--- a/src/components/molecules/Sidebar/Sidebar.scss
+++ b/src/components/molecules/Sidebar/Sidebar.scss
@@ -1,7 +1,5 @@
 @import "scss/constants";
 
-$black: #000000;
-$white: #fff;
 $dark: #19181a;
 
 .sidebar-container {

--- a/src/components/molecules/Sidebar/Sidebar.scss
+++ b/src/components/molecules/Sidebar/Sidebar.scss
@@ -1,4 +1,4 @@
-@import "scss/constants.scss";
+@import "scss/constants";
 
 $black: #000000;
 $white: #fff;
@@ -8,7 +8,7 @@ $dark: #19181a;
   position: fixed;
   z-index: z(sidebar);
   right: 0;
-  top: 60px;
+  top: $navbar-height;
   width: 360px;
   height: 100%;
   display: block;

--- a/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
+++ b/src/components/organisms/SchedulePageModal/SchedulePageModal.tsx
@@ -82,7 +82,10 @@ export const SchedulePageModal: FC<SchedulePageModalProps> = ({
         <li
           key={formatDate(day.dateDay.getTime())}
           className={`button ${idx === date ? "active" : ""}`}
-          onClick={() => setDate(idx)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setDate(idx);
+          }}
         >
           {formatDateToWeekday(day.dateDay.getTime() / 1000)}
         </li>

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -47,7 +47,8 @@ $room-info-bg: #005ee5;
 //   pages/Admin/Room/Modal/RoomModal.styles.ts (z-index: 101)
 //   components/molecules/UserProfilePicture/UserProfilePicture.styles.ts (z-index: 10)
 //   components/atoms/Legend/Legend.styles.ts (z-index: 5)
-$z-layer-navbar: 20;
+$z-layer-navbar: 30;
+$z-layer-live-schedule: 20;
 $z-layer-sidebar: 15;
 $z-layers: (
   // Admin
@@ -73,8 +74,8 @@ $z-layers: (
   navbar-nav-search-close-icon: 1,
   navbar-nav-search-input-close-btn: 1,
   navbar-nav-search-results: 380,
-  navbar-schedule-backdrop: 3,
-  navbar-schedule: 4,
+  navbar-schedule-backdrop: $z-layer-live-schedule,
+  navbar-schedule: $z-layer-live-schedule,
   navbar: $z-layer-navbar,
   // Sidebars + similar
   sidebar-slide-btn: -1,

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -68,24 +68,24 @@ $z-layers: (
   user-search-input-close-btn: 1,
   user-search-results: 380,
   // Nav
-  nav-search-close-icon: 1,
-  nav-search-input-close-btn: 1,
-  nav-search-results: 380,
-  schedule: 4,
-  schedule-backdrop: 3,
+  navbar-map-back-button: 3,
+  navbar-nav-search-close-icon: 1,
+  navbar-nav-search-input-close-btn: 1,
+  navbar-nav-search-results: 380,
+  navbar-schedule-backdrop: 3,
+  navbar-schedule: 4,
+  navbar: 5,
   // Sidebars + similar
   sidebar-slide-btn: -1,
   sidebar: $z-layer-sidebar,
   left-column: $z-layer-sidebar,
   // Map
-  map-back-button: 3,
   map-room-hovered: 3,
   map-room: 2,
   // Legacy
   account-profile-picture-preview: 1,
   duststorm-container: 100,
   duststorm-modal-content: 220,
-  header: 5,
   // Unsorted
   announcement: $z-layer-sidebar,
   footer: $z-layer-sidebar,

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -47,6 +47,7 @@ $room-info-bg: #005ee5;
 //   pages/Admin/Room/Modal/RoomModal.styles.ts (z-index: 101)
 //   components/molecules/UserProfilePicture/UserProfilePicture.styles.ts (z-index: 10)
 //   components/atoms/Legend/Legend.styles.ts (z-index: 5)
+$z-layer-navbar: 20;
 $z-layer-sidebar: 15;
 $z-layers: (
   // Admin
@@ -74,7 +75,7 @@ $z-layers: (
   navbar-nav-search-results: 380,
   navbar-schedule-backdrop: 3,
   navbar-schedule: 4,
-  navbar: 5,
+  navbar: $z-layer-navbar,
   // Sidebars + similar
   sidebar-slide-btn: -1,
   sidebar: $z-layer-sidebar,


### PR DESCRIPTION
This is a regression based on the changes I made to fix the z-index layering for the avatars in sparkletown/sparkle#1164:

- When searching for people in the `NavBar`, the search results list is 'behind' the `Sidebar`, so you can't see your results
  - fixes https://github.com/sparkletown/internal-sparkle-issues/issues/352
- When viewing the Live Schedule, it is shown 'behind' the `Sidebar`, so the details get cut off
  - fixes https://github.com/sparkletown/internal-sparkle-issues/issues/357
- When viewing the Live Schedule, the user's avatar was incorrectly shown on a layer 'above' it

The fixes here are, generally speaking, to ensure that each element is on an appropriate `z-index` layer, and that they are in the correct 'stacking context'. It's also worth noting that a child component can never 'exceed' its parent component's `z-index` layer, which was one of the bugs here (even though it had a higher `z-index`, its parent was 'keeping it down')

Further reading:

- https://www.freecodecamp.org/news/4-reasons-your-z-index-isnt-working-and-how-to-fix-it-coder-coder-6bc05f103e6c/

