### PR TITLE
fix error in CircleCI when SLACK_ACCESS_TOKEN missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@ notify-on-fail: &notify-on-fail
   when:
     condition: on_fail
     steps:
+      - run: |
+        if [ -z "$SLACK_ACCESS_TOKEN" ]; then
+          circleci-agent step halt
+        fi
       - slack/notify:
           event: fail
           custom: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,11 @@ notify-on-fail: &notify-on-fail
   when:
     condition: on_fail
     steps:
-      - run: |
-        if [ -z "$SLACK_ACCESS_TOKEN" ]; then
-          circleci-agent step halt
-        fi
+      - run:
+          command: |
+            if [ "$CIRCLE_BRANCH" = "develop" ]; then
+              circleci-agent step halt
+            fi
       - slack/notify:
           event: fail
           custom: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 notify-on-fail: &notify-on-fail
   when:
-    condition: always
+    condition: on_fail
     steps:
       - slack/notify:
           event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ notify-on-fail: &notify-on-fail
     steps:
       - run:
           command: |
-            if [ "$CIRCLE_BRANCH" = "develop" ]; then
+            if [ -z "$SLACK_ACCESS_TOKEN" ]; then
               circleci-agent step halt
             fi
       - slack/notify:


### PR DESCRIPTION
For PRs from forked repos, CircleCI slack integration fails to run as the environment secrets aren't available to it. This PR resolves that by skipping the notification when the secret isn't available.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/397

Further reading:

- https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute
- https://circleci.com/docs/2.0/configuration-reference/#run
- https://support.circleci.com/hc/en-us/articles/360015562253-Conditionally-end-a-running-job-gracefully