### PR TITLE
Can still hear emojis even though they are muted 

### DIFF
--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -170,7 +170,9 @@ const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
                       key={reaction.name}
                       className="reaction"
                       onClick={() =>
-                        user && reactionClicked(user, reaction.type)
+                        user &&
+                        !isAudioEffectDisabled &&
+                        reactionClicked(user, reaction.type)
                       }
                       id={`send-reaction-${reaction.type}`}
                     >


### PR DESCRIPTION
Updated JazzTab with if isAudioEffectDisabled is true it will mute emoji audio.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/310

