### PR TITLE
use React.Fragment instead of span in getLinkFromText

### DIFF
--- a/src/utils/getLinkFromText.tsx
+++ b/src/utils/getLinkFromText.tsx
@@ -19,6 +19,6 @@ export const getLinkFromText = (text: string) => {
           {word}{" "}
         </a>
       );
-    else return <span key={index}>{word} </span>;
+    else return <React.Fragment key={index}>{word} </React.Fragment>;
   });
 };


### PR DESCRIPTION
use `React.Fragment` instead of `span` in `getLinkFromText`, as previously it would create some really ugly HTML output that was hard to play around with when tweaking styling/etc in devtools.

## Before

![image](https://user-images.githubusercontent.com/753891/108931876-88618400-769c-11eb-8a85-bbc08d29a569.png)


## After

![image](https://user-images.githubusercontent.com/753891/108931813-6a941f00-769c-11eb-8800-de738b12f2c9.png)
