### PR TITLE
fix npm-force-resolutions version issues

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1631,7 +1631,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.2",
@@ -4631,7 +4632,8 @@
     "json-format": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
-      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww="
+      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww=",
+      "dev": true
     },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
@@ -5405,6 +5407,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.3.tgz",
       "integrity": "sha512-xbIPAGzD3nrJHDLtnRFt/O83teTA8ju5pWTf8W6OKL4D0XD9EjdRNJhzg4bSXWuucE+l1HGdTpOJR/l1Mi1Ycg==",
+      "dev": true,
       "requires": {
         "json-format": "^1.0.1",
         "source-map-support": "^0.5.5"
@@ -5725,7 +5728,8 @@
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -6393,12 +6397,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx --no-install npm-force-resolutions",
     "lint": "prettier --write \"./**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
   },
   "engines": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,8 +13,6 @@
     "firebase": "^8.2.4",
     "firebase-admin": "^9.4.2",
     "firebase-functions": "^3.13.1",
-    "npm-force-resolutions": "0.0.3",
-    "prettier": "^2.2.1",
     "stripe": "^8.71.0",
     "twilio": "^3.45.0",
     "uuidv4": "^6.2.6"
@@ -23,7 +21,9 @@
     "eslint": "^7.19.0",
     "eslint-plugin-promise": "^4.0.1",
     "firebase-functions-test": "^0.2.3",
-    "firebase-tools": "^9.2.2"
+    "firebase-tools": "^9.2.2",
+    "npm-force-resolutions": "0.0.3",
+    "prettier": "^2.2.1"
   },
   "resolutions": {
     "websocket-extensions": "0.1.4"


### PR DESCRIPTION
It seems that `npm-force-resolutions' has a bug in the newly released `0.0.4` version, that broke our function deploys:

- https://github.com/rogeriochaves/npm-force-resolutions/issues/22
- https://app.circleci.com/pipelines/github/sparkletown/sparkle/4983/workflows/3c630071-ff39-437b-8da2-475072e9b1ee/jobs/8146
- https://app.circleci.com/pipelines/github/sparkletown/sparkle/4986/workflows/ee140806-607b-4060-b1ee-346c1084a557/jobs/8151
- https://app.circleci.com/pipelines/github/sparkletown/sparkle/4988/workflows/ac40b430-afb2-47e3-b3d4-3ab1036b62b4/jobs/8155

While we did have the `0.0.3` version pinned in our `package.json`, we were using `npx` without the `--no-install` flag, which will resolve/download/install/use things on it's own.

This PR adds the `--no-install` flag, and refactors some `dependencies` into `devDependencies`