### PR TITLE
[scripts] add venue rename + --dry-run mode to scripts/clone-data-across-firebase-projects

### DIFF
--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -75,10 +75,16 @@ const replaceSourceDomainReferences = (
     );
 
     console.log(
-      `Found a reference to ${SOURCE_DOMAIN} in ${objectType} ${objectIdentifier}, key ${key}.`,
-      `Value: ${obj[key]}`,
-      `Replacing with: ${replacementValue}`
+      "  Rewriting reference to",
+      SOURCE_DOMAIN,
+      "in",
+      `'${objectType}'`,
+      `'${objectIdentifier}'`,
+      "with key",
+      `'${key}'`
     );
+    console.log("    Before :", obj[key]);
+    console.log("    After  :", replacementValue);
 
     obj[key] = replacementValue;
   }
@@ -101,6 +107,25 @@ const replaceSourceDomainReferences = (
 
   console.log("total venues:", allSourceVenues.length);
   console.log("wanted venues:", wantedSourceVenues.length, VENUES_TO_CLONE);
+  console.log();
+
+  console.log(
+    "Will copy",
+    wantedSourceVenues.length,
+    "venues from",
+    sourceApp.options.projectId,
+    "to",
+    destApp.options.projectId
+  );
+  console.log(
+    "  source venues      :",
+    wantedSourceVenues.map((venue) => venue.id)
+  );
+  console.log(
+    "  destination venues :",
+    wantedSourceVenues.map((venue) => VENUE_RENAME_MAP[venue.id] ?? venue.id)
+  );
+  console.log();
 
   // TODO: we should save backups before we potentially overwrite things..
   // const saveToBackupFile = makeSaveToBackupFile(
@@ -126,7 +151,7 @@ const replaceSourceDomainReferences = (
 
     destAppBatch.set(destVenueRef, venueData);
 
-    console.log("added venue to batch:", venue.name);
+    console.log("added venue to batch:", destinationVenueId, `(${venue.name})`);
   });
 
   if (!isDryRun) {

--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -151,9 +151,11 @@ const replaceSourceDomainReferences = (
       .collection("venues")
       .doc(destinationVenueId);
 
+    // @debt will there ever even be any URLs that need rewriting in these 'root venue keys'?
     Object.keys(venue).forEach((key) => {
       replaceSourceDomainReferences(venue, key, "venue", venue.id);
     });
+
     if (venue.rooms) {
       venue.rooms.forEach((room) => {
         Object.keys(room).forEach((key) => {

--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -137,4 +137,12 @@ const replaceSourceDomainReferences = (
       "[DRY-RUN] Not committing transaction. Nothing has been changed."
     );
   }
-})();
+})()
+  .then(() => {
+    console.log("Finished!");
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.log("Failed: ", error);
+    process.exit(1);
+  });

--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -23,6 +23,10 @@ const DEST_DOMAIN = "staging.sparkle.space";
 
 const VENUES_TO_CLONE = ["wayspace"];
 
+const VENUE_RENAME_MAP: Partial<Record<string, string>> = {
+  foo: "bar",
+};
+
 // ---------------------------------------------------------
 // HERE THERE BE DRAGONS (edit below here at your own risk)
 // ---------------------------------------------------------
@@ -56,6 +60,7 @@ const destApp = initFirebaseAdminApp(DEST_PROJECT_ID, {
 // TODO: do we need to copy roles across?
 // TODO: venues (owners will need to be changed)
 // TODO: check if venue already exists (be safe, don't overwrite!)
+// TODO: use VENUE_RENAME_MAP when rewriting room/etc urls (in case we renamed the venue)
 
 const replaceSourceDomainReferences = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,6 +112,7 @@ const replaceSourceDomainReferences = (
 
   console.log("total venues:", allSourceVenues.length);
   console.log("wanted venues:", wantedSourceVenues.length, VENUES_TO_CLONE);
+  console.log("venue renames:", VENUE_RENAME_MAP);
   console.log();
 
   console.log(
@@ -136,7 +142,14 @@ const replaceSourceDomainReferences = (
 
   wantedSourceVenues.forEach((venue) => {
     const { id, ...venueData } = venue;
-    const destVenueRef = destApp.firestore().collection("venues").doc(id);
+
+    // Rename the destinationVenueId if required
+    const destinationVenueId = VENUE_RENAME_MAP[id] ?? id;
+
+    const destVenueRef = destApp
+      .firestore()
+      .collection("venues")
+      .doc(destinationVenueId);
 
     Object.keys(venue).forEach((key) => {
       replaceSourceDomainReferences(venue, key, "venue", venue.id);

--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -28,17 +28,20 @@ const VENUES_TO_CLONE = ["wayspace"];
 // ---------------------------------------------------------
 
 const CONFIRM_VALUE = "i-have-edited-the-script-and-am-sure";
+const DRY_RUN = "--dry-run";
 
 const usage = makeScriptUsage({
   description: "Clone venue(s) between different firebase projects.",
-  usageParams: CONFIRM_VALUE,
-  exampleParams: CONFIRM_VALUE,
+  usageParams: `${CONFIRM_VALUE} [${DRY_RUN}]`,
+  exampleParams: `${CONFIRM_VALUE} [${DRY_RUN}]`,
 });
 
-const [confirmationCheck] = process.argv.slice(2);
+const [confirmationCheck, dryRun] = process.argv.slice(2);
 if (confirmationCheck !== CONFIRM_VALUE) {
   usage();
 }
+
+const isDryRun = dryRun === DRY_RUN;
 
 const sourceApp = initFirebaseAdminApp(SOURCE_PROJECT_ID, {
   appName: "sourceApp",
@@ -126,6 +129,12 @@ const replaceSourceDomainReferences = (
     console.log("added venue to batch:", venue.name);
   });
 
-  const writeResult = await destAppBatch.commit();
-  console.log(writeResult);
+  if (!isDryRun) {
+    const writeResult = await destAppBatch.commit();
+    console.log(writeResult);
+  } else {
+    console.log(
+      "[DRY-RUN] Not committing transaction. Nothing has been changed."
+    );
+  }
 })();


### PR DESCRIPTION
- add `--dry-run` mode
- ensure async errors are properly handled
- improve logging output
- add ability to rename venueIds during clone

partially fixes https://github.com/sparkletown/internal-sparkle-issues/issues/16

## TODO

- [ ] fix issue called out ini https://github.com/sparkletown/sparkle/pull/1227#issuecomment-789694290