### PR TITLE
fix venue edit by venue id when name is changed

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -410,7 +410,7 @@ exports.toggleDustStorm = functions.https.onCall(async (_data, context) => {
 });
 
 exports.updateVenue = functions.https.onCall(async (data, context) => {
-  const venueId = getVenueId(data.name);
+  const venueId = data.id || getVenueId(data.name);
   checkAuth(context);
 
   await checkUserIsOwner(venueId, context.auth.token.user_id);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -10,6 +10,7 @@ import {
 } from "types/venues";
 import { RoomData_v2 } from "types/rooms";
 import { venueInsideUrl } from "utils/url";
+import { WithId } from "utils/id";
 
 export interface EventInput {
   name: string;
@@ -312,7 +313,10 @@ export const createVenue_v2 = async (input: VenueInput_v2, user: UserInfo) => {
   );
 };
 
-export const updateVenue = async (input: VenueInput, user: UserInfo) => {
+export const updateVenue = async (
+  input: WithId<VenueInput>,
+  user: UserInfo
+) => {
   const firestoreVenueInput = await createFirestoreVenueInput(input, user);
 
   return await firebase.functions().httpsCallable("venue-updateVenue")(

--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -131,11 +131,12 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
       if (!user) return;
       try {
         // unfortunately the typing is off for react-hook-forms.
-        if (!!venueId) await updateVenue(vals as VenueInput, user);
+        if (!!venueId)
+          await updateVenue({ ...(vals as VenueInput), id: venueId }, user);
         else await createVenue(vals as VenueInput, user);
 
         vals.name
-          ? history.push(`/admin/${createUrlSafeName(vals.name)}`)
+          ? history.push(`/admin/${createUrlSafeName(venueId ?? vals.name)}`)
           : history.push(`/admin`);
       } catch (e) {
         setFormError(true);


### PR DESCRIPTION
Passes the venueId from the params and uses it for venue update in admin v1. This is not a bug per-say but it was an edge case introduced by directly manipulating data in the database. The venue name was changed by someone and it was different than the venue id which was returning an error when trying to find the venue by it's name instead of ID. Which is a big no no and should never be done.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/495