### PR TITLE
fix Auditorium video container to be properly centred + some related cleanup

### DIFF
--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -2,39 +2,42 @@
 
 $light: #ffffff;
 
+$spacing: 30px;
+
+// If you change this, make sure to also change it in Audience.tsx's SEAT_SIZE
+$seat-size: 4vh;
+
 .audience-container {
   background-attachment: fixed;
   background-position: center 46%;
+
   position: relative;
   display: flex;
   flex: 1;
-  -webkit-flex: 1;
-  -ms-flex: 1;
+
+  overflow: auto;
+  width: 100%;
+  height: 100%;
 
   .video-container {
-    z-index: z(audience-video);
-    position: fixed;
-    left: 50%;
-    top: 28%;
-    width: 45%;
-    top: 50%;
-    left: 50%;
+    position: absolute;
+    // note: this is positioned using inline styles within the Audience component
 
-    transform: translate(-50%, -50%);
+    margin: $spacing;
+    padding: $spacing;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     .video {
-      position: relative;
       width: 100%;
-      padding-bottom: 50%;
-      float: left;
-      height: 0;
+      height: 100%;
 
       .frame {
         width: 100%;
         height: 100%;
-        position: absolute;
-        left: 0;
-        border-width: 1px black;
+        border: 1px black;
         border-radius: 15px;
         box-shadow: 2px 2px 20px $light;
       }
@@ -47,27 +50,20 @@ $light: #ffffff;
 
     .reaction-container {
       display: flex;
-      position: fixed;
-      flex: 1;
-      left: 20%;
-      width: 60%;
-      bottom: -50px;
-      height: 50px;
+      flex-direction: column;
+      justify-content: space-around;
+      text-align: center;
+
+      // these are fairly arbitrary figures
+      min-width: 495px;
+      max-width: 60%;
+      min-height: 105px;
+      padding: 15px;
+
       border-bottom-left-radius: 20px;
       border-bottom-right-radius: 20px;
       box-shadow: 2px 2px 20px $light;
       background-color: #1a1d24;
-      flex-direction: column;
-      justify-content: space-around;
-
-      .instructions {
-        align-self: center;
-      }
-
-      &.seated {
-        bottom: -100px;
-        height: 100px;
-      }
 
       .emoji-container {
         display: flex;
@@ -78,11 +74,8 @@ $light: #ffffff;
           background-color: transparent;
           border-color: transparent;
           font-size: 33px;
-          top: -25px;
-          right: -20px;
           width: 50px;
           animation: sway 2200ms 1200ms ease-in-out;
-          z-index: z(audience-emoji-reaction);
         }
 
         .leave-seat-button {
@@ -95,13 +88,12 @@ $light: #ffffff;
           transition: all 400ms cubic-bezier(0.23, 1, 0.32, 1);
           line-height: 1.5;
           border: 1px solid transparent;
-          color: #000000;
           transform: translateY(0);
           cursor: pointer;
           padding: 4px 10px;
           margin: 6px;
           background: rgb(0, 0, 0);
-          color: white;
+          color: $white;
 
           &:hover {
             background-color: rgba(255, 255, 255, 0.5);
@@ -148,12 +140,13 @@ $light: #ffffff;
   .audience {
     display: flex;
     flex: 1;
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-top: 30px;
-    padding-bottom: 30px;
     flex-direction: column;
     justify-content: space-between;
+
+    padding: $spacing;
+
+    width: fit-content;
+    height: fit-content;
 
     .seat-row {
       display: flex;
@@ -163,8 +156,8 @@ $light: #ffffff;
     .seat {
       display: flex;
       border-radius: 100%;
-      width: 4vh;
-      height: 4vh;
+      width: $seat-size;
+      height: $seat-size;
       justify-content: center;
       align-content: center;
       background-color: rgba(255, 255, 255, 0.2);
@@ -190,8 +183,8 @@ $light: #ffffff;
     .not-seat {
       display: flex;
       border-radius: 100%;
-      width: 4vh;
-      height: 4vh;
+      width: $seat-size;
+      height: $seat-size;
       justify-content: center;
       align-content: center;
       background-color: rgba(0, 0, 0, 0);
@@ -213,8 +206,8 @@ $light: #ffffff;
   }
 
   .user {
-    width: 4vh;
-    height: 4vh;
+    width: $seat-size;
+    height: $seat-size;
   }
 
   .profile-avatar {

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -5,38 +5,34 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import firebase, { UserInfo } from "firebase/app";
 
+import { IFRAME_ALLOW, REACTION_TIMEOUT } from "settings";
+
+import { addReaction } from "store/actions/Reactions";
+
 import { makeUpdateUserGridLocation } from "api/profile";
 
-// Components
+import { User } from "types/User";
+import { VideoAspectRatio } from "types/VideoAspectRatio";
+
+import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
+import { WithId } from "utils/id";
 import {
   EmojiReactionType,
   Reactions,
   TextReactionType,
 } from "utils/reactions";
+import { currentVenueSelectorData } from "utils/selectors";
 
-import UserProfileModal from "components/organisms/UserProfileModal";
-import UserProfilePicture from "components/molecules/UserProfilePicture";
-
-// Hooks
 import { useDispatch } from "hooks/useDispatch";
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 import { useVenueId } from "hooks/useVenueId";
 import { useRecentVenueUsers } from "hooks/users";
 
-// Utils | Settings | Constants
-import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
-import { IFRAME_ALLOW, REACTION_TIMEOUT } from "settings";
-import { WithId } from "utils/id";
-import { currentVenueSelectorData } from "utils/selectors";
+import UserProfileModal from "components/organisms/UserProfileModal";
+import UserProfilePicture from "components/molecules/UserProfilePicture";
 
-// Typings
-import { User } from "types/User";
-
-// Styles
 import "./Audience.scss";
-import { VideoAspectRatio } from "types/VideoAspectRatio";
-import { addReaction } from "store/actions/Reactions";
 
 type ReactionType =
   | { reaction: EmojiReactionType }


### PR DESCRIPTION
The 'center' video in the Auditorium would 'break out' of its 'container' and overlap seats. It seems its position was set based on the viewport of the browser, rather than it's containing parent.

It also seemed that when there were more seats than would fit on screen at one time, we weren't able to scroll around them.

And to top it off, the 'carved out section' in the middle always felt way too big/space wasting for the size of the video that was normally embedded within it.

I fixed all of the above + cleaned up a few things along the way. Since it's now possible for the 'seats' to extend outside of the window (requiring scrolling), I also auto-focus the central video container when the component is first rendered, so that the user starts off seeing that, rather than the top-left corner of the auditorium seats.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/326

## Notes

- I purposefully didn't clean up the majority of this component/styles, including BEM naming patterns, to minimise the changes is this PR. The focus was on fixing the bug in the most minimal way.
- We can theoretically tweak the overall 'size feeling' of the auditorium seats by changing the `SEAT_SIZE` variable in `Audience.tsx` and `$seat-size` in `Audience.scss` (they must be set to the same value); though I haven't tested this and it will almost certainly require tweaks to other styles to do so.

## Before

![image](https://user-images.githubusercontent.com/753891/109760445-cb929880-7c42-11eb-8a3a-4e23b31a782b.png)

![image](https://user-images.githubusercontent.com/753891/109761092-f4675d80-7c43-11eb-9c08-9d3ded70d704.png)

## After

![image](https://user-images.githubusercontent.com/753891/109760776-655a4580-7c43-11eb-962f-44d61754af70.png)

![image](https://user-images.githubusercontent.com/753891/109760801-7014da80-7c43-11eb-817d-66db99a19d47.png)