### PR TITLE
Minor tweaks to Auditorium styles + related cleanup

### DIFF
--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -31,6 +31,8 @@ $spacing: calc(1 * min(var(--seat-size), var(--seat-size-min)));
     justify-content: center;
     align-items: center;
 
+    pointer-events: none;
+
     .video-container {
       margin-top: calc(1 * min(var(--seat-size), var(--seat-size-min)));
       padding: calc(1.5 * min(var(--seat-size), var(--seat-size-min)));
@@ -184,10 +186,6 @@ $spacing: calc(1 * min(var(--seat-size), var(--seat-size-min)));
 
     .seat {
       background-color: rgba(255, 255, 255, 0.2);
-
-      .add-participant-button {
-        z-index: z(audience-participant-add-button);
-      }
 
       &:hover {
         background-color: rgba(255, 255, 255, 0.4);

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -481,9 +481,7 @@ export const Audience: React.FunctionComponent = () => {
                                 />
                               </div>
                             )}
-                            {seat && !seatedPartygoer && (
-                              <span className="add-participant-button">+</span>
-                            )}
+                            {seat && !seatedPartygoer && <>+</>}
                           </div>
                         );
                       }

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -63,10 +63,6 @@ $z-layers: (
   admin-placement: 10,
   admin-venue-header-after: 2,
   admin-venue-header: -1,
-  // Audience
-  audience-emoji-reaction: 1000,
-  audience-video: 2,
-  audience-participant-add-button: 1,
   // JazzBar
   jazzbar-participant-profile-icon: 1,
   // Chat


### PR DESCRIPTION
Follow on to https://github.com/sparkletown/sparkle/pull/1237 that cleans up a few more little bits and pieces.

@mike-lvov It seems this will allow the seats and everything to still be clickable, without us needing to use an explicit `z-index`/etc.

Related reading:

- https://css-tricks.com/almanac/properties/p/pointer-events/
- https://caniuse.com/pointer-events
- https://stackoverflow.com/questions/3680429/click-through-div-to-underlying-elements/26799885#26799885