### PR TITLE
fix firebase onSnapshot listeners to unsubscribe when they are done

### DIFF
--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -174,13 +174,17 @@ export const Audience: React.FunctionComponent = () => {
   );
 
   useEffect(() => {
-    firebase
+    const unsubscribeListener = firebase
       .firestore()
       .collection("venues")
       .doc(venueId as string)
       .onSnapshot((doc) =>
         setIframeUrl(ConvertToEmbeddableUrl(doc.data()?.iframeUrl || "", true))
       );
+
+    return () => {
+      unsubscribeListener();
+    };
   }, [venueId]);
 
   const dispatch = useDispatch();

--- a/src/components/templates/Playa/AvatarLayer.tsx
+++ b/src/components/templates/Playa/AvatarLayer.tsx
@@ -112,11 +112,11 @@ const AvatarLayer: React.FunctionComponent<PropsType> = ({
   );
 
   useEffect(() => {
-    firebase
+    const unsubscribeListener = firebase
       .firestore()
       .collection(`experiences/playa/shouts`)
       .where("created_at", ">", new Date().getTime())
-      .onSnapshot(function (snapshot) {
+      .onSnapshot((snapshot) => {
         snapshot.docChanges().forEach(function (change) {
           if (change.type === "added") {
             const newShout = change.doc.data() as Shout;
@@ -129,6 +129,10 @@ const AvatarLayer: React.FunctionComponent<PropsType> = ({
           }
         });
       });
+
+    return () => {
+      unsubscribeListener();
+    };
   }, [firebase, setShouts]);
 
   const wsInitedRef = useRef(false);

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -11,7 +11,7 @@ export const useReactions = (venueId?: string) => {
   useEffect(() => {
     if (!venueId) return;
 
-    firebase
+    const unsubscribeListener = firebase
       .firestore()
       .collection("experiences")
       .doc(venueId)
@@ -31,6 +31,10 @@ export const useReactions = (venueId?: string) => {
           }
         });
       });
+
+    return () => {
+      unsubscribeListener();
+    };
   }, [firebase, setReactions, venueId]);
 
   return reactions;


### PR DESCRIPTION
There were a few places that we were using firebase `.onSnapshot` listeners to get realtime updates (outside of our currently more standard `useConnect` redux pattern), but it seems we weren't actually ever unsubscribing these. While I don't have any direct data to 'prove' this, I am wondering if this is causing multiple multiple new listeners to be created, that are never closed down; which may explain why the platform seems to degrade in performance over time, seemingly even when it's not even 'doing much'.

Since the `useReactions` hook is used within `src/components/molecules/UserProfilePicture/UserProfilePicture.tsx` (which is rendered in multiple places in the app, and rendered for each person in each of those places.. which can lead to a LOT of instances of this being run; see https://github.com/sparkletown/internal-sparkle-issues/issues/459 about separating these). It would also explain why the number of 'snapshot listeners' count seems to rise exponentially as we have more 'active connected users' on the platform (see https://github.com/sparkletown/internal-sparkle-issues/issues/284#issuecomment-779566318 for some stats on this)

## Further Reading

- https://firebase.google.com/docs/firestore/query-data/listen#detach_a_listener
  - > When you are no longer interested in listening to your data, you must detach your listener so that your event callbacks stop getting called. This allows the client to stop using bandwidth to receive updates. 