### PR TITLE
fix audience unclickable video controls

### DIFF
--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -41,6 +41,8 @@ $spacing: calc(1 * min(var(--seat-size), var(--seat-size-min)));
       flex-direction: column;
       align-items: center;
 
+      pointer-events: all;
+
       .video {
         width: 100%;
         height: 100%;


### PR DESCRIPTION
The video was inheriting the `pointer-events: none;` from the parent styles and the video was unclickable because of it.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/556