### PR TITLE
ensure unclickable rooms maintain their z-index onHover

### DIFF
--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -44,6 +44,8 @@ $label-visible: flex;
     z-index: z(map-room--unclickable);
 
     &:hover {
+      z-index: z(map-room--unclickable);
+
       transform: none;
 
       .maproom__image {

--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -14,8 +14,6 @@ $label-visible: flex;
 
   transition: transform 600ms cubic-bezier(0.23, 1, 0.32, 1);
 
-  cursor: pointer;
-
   &:hover {
     z-index: z(map-room--hovered);
     transform: scale(1.1);
@@ -40,8 +38,9 @@ $label-visible: flex;
   }
 
   &--unclickable {
-    cursor: default;
     z-index: z(map-room--unclickable);
+
+    cursor: default;
 
     &:hover {
       z-index: z(map-room--unclickable);


### PR DESCRIPTION
Unclickable rooms were added in https://github.com/sparkletown/sparkle/pull/1225, but it seems we missed an edgecase. When hovering over rooms, the `.maproom:hover` `z-index` was being applied.

Also cleaned up a duplicate style/etc.