### PR TITLE
Disable autocomplete suggestions when writing a chat message, shoutout or other input

### DIFF
--- a/src/components/molecules/Chatbox/Chatbox.tsx
+++ b/src/components/molecules/Chatbox/Chatbox.tsx
@@ -72,6 +72,7 @@ export const Chatbox: React.FC<ChatboxProps> = ({
           ref={register({ required: true })}
           name="message"
           placeholder="Write your message..."
+          autoComplete="off"
         ></input>
         <button
           className="chatbox__submit-button"

--- a/src/components/molecules/IframeAdmin/IframeAdmin.tsx
+++ b/src/components/molecules/IframeAdmin/IframeAdmin.tsx
@@ -52,6 +52,7 @@ export const IframeAdmin: React.FC<IframeAdminProps> = ({ venueId, venue }) => {
                   setIframeUrl(e.target.value);
                 }}
                 placeholder="https://youtube.com/embed/..."
+                autoComplete="off"
               />
 
               {error && <span className="error">{error}</span>}

--- a/src/components/molecules/OnlineStats/OnlineStats.tsx
+++ b/src/components/molecules/OnlineStats/OnlineStats.tsx
@@ -189,6 +189,7 @@ const OnlineStats: React.FC = () => {
                     placeholder="Search venues"
                     onChange={(e) => setFilterVenueText(e.target.value)}
                     value={filterVenueText}
+                    autoComplete="off"
                   />
                   <PotLuckButton
                     venues={venuesWithAttendance.map((v) => v.venue)}
@@ -295,6 +296,7 @@ const OnlineStats: React.FC = () => {
                     placeholder="Search people"
                     onChange={(e) => setFilterUsersText(e.target.value)}
                     value={filterUsersText}
+                    autoComplete="off"
                   />
                 </div>
                 <div className="people">

--- a/src/components/molecules/UserSearchBar/UserSearchBarInput.tsx
+++ b/src/components/molecules/UserSearchBar/UserSearchBarInput.tsx
@@ -24,6 +24,7 @@ export const UserSearchBarInput: FC<UserSearchBarInputProps> = ({
       value={value}
       onChange={handleOnChange}
       placeholder="Search for people"
+      autoComplete="off"
     />
   );
 };

--- a/src/components/organisms/BannerAdmin/BannerAdmin.tsx
+++ b/src/components/organisms/BannerAdmin/BannerAdmin.tsx
@@ -59,6 +59,7 @@ export const BannerAdmin: React.FC<BannerAdminProps> = ({ venueId, venue }) => {
                 defaultValue={existingBannerMessage}
                 onChange={handleInputChange}
                 placeholder="Enter banner message here..."
+                autoComplete="off"
               />
 
               {error && <span className="error">{error}</span>}

--- a/src/components/organisms/ChatSidebar/components/PrivateChats/PrivateChats.tsx
+++ b/src/components/organisms/ChatSidebar/components/PrivateChats/PrivateChats.tsx
@@ -98,6 +98,7 @@ export const PrivateChats: React.FC<PrivateChatsProps> = ({
           placeholder="Search for online people"
           value={userSearchQuery}
           onChange={onInputChage}
+          autoComplete="off"
         />
         <div className="private-chats__search-icon">
           <FontAwesomeIcon icon={faSearch} size="1x" />

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -388,6 +388,7 @@ export const Audience: React.FunctionComponent = () => {
               placeholder="Shout out to the crowd"
               ref={register({ required: true })}
               disabled={isShoutSent}
+              autoComplete="off"
             />
             <input
               className={`shout-button ${isShoutSent ? "btn-success" : ""} `}

--- a/src/components/templates/Playa/Playa.tsx
+++ b/src/components/templates/Playa/Playa.tsx
@@ -1018,6 +1018,7 @@ const Playa = () => {
                 placeholder={`Shout across ${PLAYA_VENUE_NAME}...`}
                 value={shoutText}
                 onChange={(event) => setShoutText(event.target.value)}
+                autoComplete="off"
               />
             </form>
           </div>

--- a/src/pages/Account/Profile.tsx
+++ b/src/pages/Account/Profile.tsx
@@ -73,6 +73,7 @@ const Profile: React.FunctionComponent<PropsType> = ({ location }) => {
                 required: true,
                 maxLength: 16,
               })}
+              autoComplete="off"
             />
             <span className="input-info">
               This is your public name (max 16 characters)


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/571

> When I send chat messages, I get the 'suggestions' that I would get when filling out a form for the second/third time, but there aren't many cases when I would want to send the same text message multiple times (and it looks ugly)

---

> I believe the fix for this will just be adding  to the text field:
> 
> - https://css-tricks.com/snippets/html/autocomplete-off/
> 
> And if we want to 'scope creep' this issue a little bit, it might be nice to think about/enumerate all of the other places within our codebase where we would also not want these suggestions, and proactively add it to those as well.
> 
> _Originally posted by @0xdevalias in https://github.com/sparkletown/internal-sparkle-issues/issues/571#issuecomment-797129346_