### PR TITLE
fix updateVenue function to properly update iframeUrl + simplify implementation

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -553,6 +553,7 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
     updated.radioStations = [data.radioStations];
   }
 
+  // @debt this would currently allow any value to be set in this field, not just booleans
   updated.requiresDateOfBirth = data.requiresDateOfBirth || false;
 
   switch (updated.template) {

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -560,6 +560,8 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
     case VenueTemplate.performancevenue:
     case VenueTemplate.artpiece:
     case VenueTemplate.audience:
+    case VenueTemplate.embeddable:
+    case VenueTemplate.firebarrel:
       if (data.iframeUrl) {
         updated.iframeUrl = data.iframeUrl;
       }

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -28,7 +28,7 @@ const VenueTemplate = {
 };
 
 const DEFAULT_PRIMARY_COLOR = "#bc271a";
-const VALID_TEMPLATES = [
+const VALID_CREATE_TEMPLATES = [
   VenueTemplate.jazzbar,
   VenueTemplate.friendship,
   VenueTemplate.partymap,
@@ -58,7 +58,7 @@ const checkUserIsAdminOrOwner = async (venueId, uid) => {
 };
 
 const createVenueData = (data, context) => {
-  if (!VALID_TEMPLATES.includes(data.template)) {
+  if (!VALID_CREATE_TEMPLATES.includes(data.template)) {
     throw new HttpsError(
       "invalid-argument",
       `Template ${data.template} unknown`

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -30,19 +30,21 @@ const VenueTemplate = {
 };
 
 const DEFAULT_PRIMARY_COLOR = "#bc271a";
+
+// These templates are allowed to be used with createVenueData (they should remain alphabetically sorted)
 const VALID_CREATE_TEMPLATES = [
-  VenueTemplate.jazzbar,
-  VenueTemplate.friendship,
-  VenueTemplate.partymap,
-  VenueTemplate.zoomroom,
-  VenueTemplate.themecamp,
-  VenueTemplate.artpiece,
   VenueTemplate.artcar,
+  VenueTemplate.artpiece,
   VenueTemplate.audience,
-  VenueTemplate.performancevenue,
-  VenueTemplate.firebarrel,
   VenueTemplate.conversationspace,
   VenueTemplate.embeddable,
+  VenueTemplate.firebarrel,
+  VenueTemplate.friendship,
+  VenueTemplate.jazzbar,
+  VenueTemplate.partymap,
+  VenueTemplate.performancevenue,
+  VenueTemplate.themecamp,
+  VenueTemplate.zoomroom,
 ];
 
 // These templates use iframeUrl (they should remain alphabetically sorted)

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -58,6 +58,13 @@ const IFRAME_TEMPLATES = [
   VenueTemplate.performancevenue,
 ];
 
+// These templates use zoomUrl (they should remain alphabetically sorted)
+// @debt Refactor this constant into types/venues + create an actual custom type grouping for it
+export const ZOOM_URL_TEMPLATES = [
+  VenueTemplate.artcar,
+  VenueTemplate.zoomroom,
+];
+
 const PlacementState = {
   SelfPlaced: "SELF_PLACED",
   AdminPlaced: "ADMIN_PLACED",
@@ -139,17 +146,16 @@ const createVenueData = (data, context) => {
     venueData.iframeUrl = data.iframeUrl;
   }
 
+  if (ZOOM_URL_TEMPLATES.includes(data.template)) {
+    venueData.zoomUrl = data.zoomUrl;
+  }
+
   switch (data.template) {
     case VenueTemplate.partymap:
     case VenueTemplate.themecamp:
       venueData.rooms = data.rooms;
       venueData.roomVisibility = data.roomVisibility;
       venueData.showGrid = data.showGrid ? data.showGrid : false;
-      break;
-
-    case VenueTemplate.zoomroom:
-    case VenueTemplate.artcar:
-      venueData.zoomUrl = data.zoomUrl;
       break;
 
     case VenueTemplate.playa:
@@ -570,16 +576,8 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
     updated.iframeUrl = data.iframeUrl;
   }
 
-  switch (updated.template) {
-    case VenueTemplate.zoomroom:
-    case VenueTemplate.artcar:
-      if (data.zoomUrl) {
-        updated.zoomUrl = data.zoomUrl;
-      }
-      break;
-
-    default:
-      break;
+  if (ZOOM_URL_TEMPLATES.includes(updated.template) && data.zoomUrl) {
+    updated.zoomUrl = data.zoomUrl;
   }
 
   await admin.firestore().collection("venues").doc(venueId).update(updated);

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -142,7 +142,7 @@ const createVenueData = (data, context) => {
     }
   }
 
-  if (IFRAME_TEMPLATES.includes(venueData.template)) {
+  if (IFRAME_TEMPLATES.includes(data.template)) {
     venueData.iframeUrl = data.iframeUrl;
   }
 
@@ -572,7 +572,7 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
   // @debt this would currently allow any value to be set in this field, not just booleans
   updated.requiresDateOfBirth = data.requiresDateOfBirth || false;
 
-  if (IFRAME_TEMPLATES.includes(venueData.template) && data.iframeUrl) {
+  if (IFRAME_TEMPLATES.includes(updated.template) && data.iframeUrl) {
     updated.iframeUrl = data.iframeUrl;
   }
 

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -48,6 +48,7 @@ const VALID_CREATE_TEMPLATES = [
 ];
 
 // These templates use iframeUrl (they should remain alphabetically sorted)
+// @debt unify this with IFRAME_TEMPLATES in src/settings.ts + share the same code between frontend/backend
 const IFRAME_TEMPLATES = [
   VenueTemplate.artpiece,
   VenueTemplate.audience,

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -5,21 +5,23 @@ const { HttpsError } = require("firebase-functions/lib/providers/https");
 const PLAYA_VENUE_ID = "jamonline";
 const MAX_TRANSIENT_EVENT_DURATION_HOURS = 6;
 
+// These represent all of our venue templates (they should remain alphabetically sorted, deprecated should be separate from the rest)
+// @debt unify this with VenueTemplate in src/types/venues.ts + share the same code between frontend/backend
 const VenueTemplate = {
-  jazzbar: "jazzbar",
-  friendship: "friendship",
-  partymap: "partymap",
-  zoomroom: "zoomroom",
-  themecamp: "themecamp",
-  artpiece: "artpiece",
   artcar: "artcar",
-  performancevenue: "performancevenue",
-  preplaya: "preplaya",
-  playa: "playa",
+  artpiece: "artpiece",
   audience: "audience",
-  firebarrel: "firebarrel",
   conversationspace: "conversationspace",
   embeddable: "embeddable",
+  firebarrel: "firebarrel",
+  friendship: "friendship",
+  jazzbar: "jazzbar",
+  partymap: "partymap",
+  performancevenue: "performancevenue",
+  playa: "playa",
+  preplaya: "preplaya",
+  themecamp: "themecamp",
+  zoomroom: "zoomroom",
 
   /**
    * @deprecated Legacy template removed, perhaps try VenueTemplate.partymap instead?

--- a/functions/venue.js
+++ b/functions/venue.js
@@ -43,6 +43,16 @@ const VALID_CREATE_TEMPLATES = [
   VenueTemplate.embeddable,
 ];
 
+// These templates use iframeUrl (they should remain alphabetically sorted)
+const IFRAME_TEMPLATES = [
+  VenueTemplate.artpiece,
+  VenueTemplate.audience,
+  VenueTemplate.embeddable,
+  VenueTemplate.firebarrel,
+  VenueTemplate.jazzbar,
+  VenueTemplate.performancevenue,
+];
+
 const PlacementState = {
   SelfPlaced: "SELF_PLACED",
   AdminPlaced: "ADMIN_PLACED",
@@ -120,16 +130,11 @@ const createVenueData = (data, context) => {
     }
   }
 
-  switch (data.template) {
-    case VenueTemplate.jazzbar:
-    case VenueTemplate.performancevenue:
-    case VenueTemplate.audience:
-    case VenueTemplate.artpiece:
-    case VenueTemplate.embeddable:
-    case VenueTemplate.firebarrel:
-      venueData.iframeUrl = data.iframeUrl;
-      break;
+  if (IFRAME_TEMPLATES.includes(venueData.template)) {
+    venueData.iframeUrl = data.iframeUrl;
+  }
 
+  switch (data.template) {
     case VenueTemplate.partymap:
     case VenueTemplate.themecamp:
       venueData.rooms = data.rooms;
@@ -556,17 +561,11 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
   // @debt this would currently allow any value to be set in this field, not just booleans
   updated.requiresDateOfBirth = data.requiresDateOfBirth || false;
 
+  if (IFRAME_TEMPLATES.includes(venueData.template) && data.iframeUrl) {
+    updated.iframeUrl = data.iframeUrl;
+  }
+
   switch (updated.template) {
-    case VenueTemplate.jazzbar:
-    case VenueTemplate.performancevenue:
-    case VenueTemplate.artpiece:
-    case VenueTemplate.audience:
-    case VenueTemplate.embeddable:
-    case VenueTemplate.firebarrel:
-      if (data.iframeUrl) {
-        updated.iframeUrl = data.iframeUrl;
-      }
-      break;
     case VenueTemplate.zoomroom:
     case VenueTemplate.artcar:
       if (data.zoomUrl) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,6 +140,7 @@ export const ZOOM_URL_TEMPLATES = [
   VenueTemplate.zoomroom,
 ];
 
+// These templates use iframeUrl (they should remain alphabetically sorted)
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it
 // @debt unify this with IFRAME_TEMPLATES in functions/venue.js + share the same code between frontend/backend
 export const IFRAME_TEMPLATES = [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -139,6 +139,7 @@ export const ZOOM_URL_TEMPLATES = [
 ];
 
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it
+// @debt unify this with IFRAME_TEMPLATES in functions/venue.js + share the same code between frontend/backend
 export const IFRAME_TEMPLATES = [
   VenueTemplate.artpiece,
   VenueTemplate.audience,
@@ -171,6 +172,7 @@ export const PLACEABLE_VENUE_TEMPLATES = [
   VenueTemplate.themecamp,
   VenueTemplate.zoomroom,
 ];
+
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it
 export const PLAYA_TEMPLATES = [VenueTemplate.playa, VenueTemplate.preplaya];
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -132,10 +132,12 @@ export const IFRAME_ALLOW =
 export const ENABLE_SUSPECTED_LOCATION = false;
 export const ENABLE_PLAYA_ADDRESS = false;
 
+// These templates use zoomUrl (they should remain alphabetically sorted)
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it
+// @debt unify this with ZOOM_URL_TEMPLATES in functions/venue.js + share the same code between frontend/backend
 export const ZOOM_URL_TEMPLATES = [
-  VenueTemplate.zoomroom,
   VenueTemplate.artcar,
+  VenueTemplate.zoomroom,
 ];
 
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -10,21 +10,23 @@ import { UpcomingEvent } from "./UpcomingEvent";
 import { VenueAccessMode } from "./VenueAcccess";
 import { VideoAspectRatio } from "./VideoAspectRatio";
 
+// These represent all of our templates (they should remain alphabetically sorted, deprecated should be separate from the rest)
+// @debt unify this with VenueTemplate in functions/venue.js + share the same code between frontend/backend
 export enum VenueTemplate {
-  jazzbar = "jazzbar",
-  friendship = "friendship",
-  partymap = "partymap",
-  zoomroom = "zoomroom",
-  themecamp = "themecamp",
-  artpiece = "artpiece",
   artcar = "artcar",
-  performancevenue = "performancevenue",
-  preplaya = "preplaya",
-  playa = "playa",
+  artpiece = "artpiece",
   audience = "audience",
   conversationspace = "conversationspace",
-  firebarrel = "firebarrel",
   embeddable = "embeddable",
+  firebarrel = "firebarrel",
+  friendship = "friendship",
+  jazzbar = "jazzbar",
+  partymap = "partymap",
+  performancevenue = "performancevenue",
+  playa = "playa",
+  preplaya = "preplaya",
+  themecamp = "themecamp",
+  zoomroom = "zoomroom",
 
   /**
    * @deprecated Legacy template removed, perhaps try VenueTemplate.partymap instead?


### PR DESCRIPTION
When attempting to edit an `embeddable`/`firebarrel` venue, the backend `updateVenue` function wasn't correctly updating the `iframeUrl` value.

This was likely due to the disparate locations that needed to be updated in our backend functions when adding new functionality. I did a minimal cleanup refactor on some of this to reduce the likelihood of this sort of issue occurring in future; + added some extra related comments/debt comments/etc.

As a workaround, it was still possible to update the `iframeUrl` via the `/in/:venueId/admin` endpoint.

- fixes https://github.com/sparkletown/internal-sparkle-issues/issues/580
- fixes https://github.com/sparkletown/internal-sparkle-issues/issues/206