### PR TITLE
fix unsupported ES6 syntax in backend functions

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -60,10 +60,7 @@ const IFRAME_TEMPLATES = [
 
 // These templates use zoomUrl (they should remain alphabetically sorted)
 // @debt Refactor this constant into types/venues + create an actual custom type grouping for it
-export const ZOOM_URL_TEMPLATES = [
-  VenueTemplate.artcar,
-  VenueTemplate.zoomroom,
-];
+const ZOOM_URL_TEMPLATES = [VenueTemplate.artcar, VenueTemplate.zoomroom];
 
 const PlacementState = {
   SelfPlaced: "SELF_PLACED",


### PR DESCRIPTION
Fix bug introduced in https://github.com/sparkletown/sparkle/pull/1274

```
Error: Error occurred while parsing your function triggers.

/home/circleci/project/functions/venue.js:63
export const ZOOM_URL_TEMPLATES = [
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1063:16)
    at Module._compile (internal/modules/cjs/loader.js:1111:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Module.require (internal/modules/cjs/loader.js:1036:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/home/circleci/project/functions/index.js:36:15)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
```