### PR TITLE
[ENV/KOTR] wait till auth is loaded before loading custom sounds

### DIFF
--- a/src/api/sounds.ts
+++ b/src/api/sounds.ts
@@ -24,7 +24,9 @@ export const fetchSoundConfigs = async (): Promise<SoundConfigMap> => {
       });
     });
 
-    throw err;
+    console.error(err);
+
+    return {};
   }
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -258,11 +258,11 @@ render(
           <Provider store={store}>
             <ReactReduxFirebaseProvider {...rrfProps}>
               <CustomLoadersProvider>
-                <CustomSoundsProvider>
-                  <AuthIsLoaded>
+                <AuthIsLoaded>
+                  <CustomSoundsProvider>
                     <AppRouter />
-                  </AuthIsLoaded>
-                </CustomSoundsProvider>
+                  </CustomSoundsProvider>
+                </AuthIsLoaded>
               </CustomLoadersProvider>
             </ReactReduxFirebaseProvider>
           </Provider>


### PR DESCRIPTION
(technically this fix would be better made to `staging`, then deployed through our full chain to `master` and then `env/kotr`, as this will be an issue for everywhere that uses the new custom sounds feature, and technically probably just everywhere since it loads the sounds regardless of whether the venue uses them or not currently)

---

This is a follow on to https://github.com/sparkletown/internal-sparkle-issues/issues/388 / 
https://github.com/sparkletown/sparkle/pull/1269 to fix a minor bug.

---

Currently the app is trying to fetch the sounds straight away, but the firestore security rules prevent loading them unless you're logged in, resulting in errors such as:

- https://app.bugsnag.com/sparkle/sparkle-platform/errors/6040d30b803da5001819af2c?event_id=6052010d0073ab2e806c0000&i=sk&m=nw

```
FirebaseError Missing or insufficient permissions. 
    ../node_modules/@firebase/firestore/dist/index.cjs.js:160:22 new n
    ../node_modules/@firebase/firestore/dist/index.cjs.js:3312:15 t.ni
    ../node_modules/@firebase/firestore/dist/index.cjs.js:3471:194 t.pi
    ../node_modules/@firebase/firestore/dist/index.cjs.js:9972:32 n.onMessage
    ../node_modules/@firebase/firestore/dist/index.cjs.js:9925:25 
    ../node_modules/@firebase/firestore/dist/index.cjs.js:9956:36 
    ../node_modules/@firebase/firestore/dist/index.cjs.js:7884:30 
```

By moving `CustomSoundsProvider` beneath `AuthIsLoaded` in the 'render hierarchy', this should resolve this issue.

I believe that since we only try and fetch the sounds once on app load, this will likely prevent the sounds from working for any user that isn't already logged in when they access the app. Though since we do 'full page reloads' between venues currently, that would sort of end up working around the issue once they leave the partymap/return to it.