### PR TITLE
Make scrollbars more visible

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -25,6 +25,26 @@ body {
   justify-content: center;
   font-family: "Rubik", sans-serif;
   overflow: auto;
+
+  &::-webkit-scrollbar-track {
+    border-radius: 3px;
+    background-color: rgba($black, 0);
+  }
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    background-color: rgba($black, 0);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba($white, 0.3);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: rgba($white, 0.5);
+  }
 }
 
 * {


### PR DESCRIPTION
closes sparkletown/internal-sparkle-issues#503
closes sparkletown/internal-sparkle-issues#592

Before: 
![image](https://user-images.githubusercontent.com/51083763/112061997-3440a700-8b57-11eb-8b9e-52a67364d346.png)
After: 
<img width="555" alt="Screen Shot 2021-03-22 at 9 40 27 PM" src="https://user-images.githubusercontent.com/51083763/112062024-3d317880-8b57-11eb-9329-7a2544b072ee.png">

Also, not sure how this is done but this needs to be deployed to Bigtop's environment asap
