### PR TITLE
Validate room name length

### DIFF
--- a/src/pages/Admin/Details/ValidationSchema.ts
+++ b/src/pages/Admin/Details/ValidationSchema.ts
@@ -74,6 +74,7 @@ export const validationSchema_v2 = Yup.object()
     name: Yup.string()
       .required("Name is required!")
       .min(3, ({ min }) => `Name must be at least ${min} characters`)
+      .max(20, ({ max }) => `Name must be less than ${max} characters`)
       .when(
         "$editing",
         (editing: boolean, schema: Yup.StringSchema) =>
@@ -136,7 +137,8 @@ export const roomCreateSchema = Yup.object().shape<RoomSchemaShape>({
       is: false,
       then: Yup.string()
         .required("Venue name is required")
-        .min(3, ({ min }) => `Name must be at least ${min} characters`),
+        .min(3, ({ min }) => `Name must be at least ${min} characters`)
+        .max(20, ({ max }) => `Name must be less than ${max} characters`),
     })
     .when("useUrl", (useUrl: boolean, schema: Yup.StringSchema) =>
       !useUrl

--- a/src/pages/Admin/Venue/DetailsValidationSchema.ts
+++ b/src/pages/Admin/Venue/DetailsValidationSchema.ts
@@ -59,6 +59,7 @@ export const validationSchema = Yup.object()
     name: Yup.string()
       .required("Required")
       .min(1, "Required")
+      .max(20, ({ max }) => `Name must be less than ${max} characters`)
       .when(
         "$editing",
         (editing: boolean, schema: Yup.StringSchema) =>


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/476 
(only partly fixes because the existing over 20 character room names in the database need to be changed/handled)

How it looks:
<img width="674" alt="Screen Shot 2021-03-25 at 9 40 47 PM" src="https://user-images.githubusercontent.com/51083763/112547706-06579e80-8db3-11eb-8ac7-ce70bfb2aa67.png">
