### PR TITLE
fix reactions + back button layering issues

### DIFF
--- a/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
+++ b/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
@@ -32,12 +32,12 @@ type ReactionProps = {
 };
 
 export const Reaction = styled.div<ReactionProps>`
+  position: relative;
   // @debt convert this to scss then use our z-index layer helper here
   z-index: 10;
 
   width: 50px;
 
-  position: absolute;
   ${({ reactionPosition }) =>
     reactionPosition === "right" ? reactionRight : reactionLeft};
   top: -25px;
@@ -49,8 +49,6 @@ export const Reaction = styled.div<ReactionProps>`
 
 // --- Reaction Container
 export const Container = styled.div`
-  position: relative;
-
   // @debt convert this to scss then use our z-index layer helper here
   z-index: 11;
 
@@ -120,6 +118,7 @@ const messageRight = css`
 
 export const ShoutOutMessage = styled.div<ReactionProps>`
   bottom: 0;
+  position: relative;
 
   // @debt convert this to scss then use our z-index layer helper here
   z-index: 12;
@@ -128,7 +127,6 @@ export const ShoutOutMessage = styled.div<ReactionProps>`
   max-width: 20em;
   padding: 6px 10px;
 
-  position: absolute;
   ${({ reactionPosition }) =>
     reactionPosition === "right" ? messageRight : messageLeft};
 

--- a/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
+++ b/src/components/molecules/UserProfilePicture/UserProfilePicture.styles.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PROFILE_IMAGE } from "settings";
 type AvatarProps = {
   backgroundImage?: string;
 };
+
 export const Avatar = styled.div<AvatarProps>`
   background-position: center;
   background-size: cover;
@@ -17,9 +18,11 @@ export const Avatar = styled.div<AvatarProps>`
 
 // --- Reaction
 const reactionOffset = "-20px";
+
 const reactionLeft = css`
   left: ${reactionOffset};
 `;
+
 const reactionRight = css`
   right: ${reactionOffset};
 `;
@@ -27,15 +30,17 @@ const reactionRight = css`
 type ReactionProps = {
   reactionPosition?: "right" | "left" | undefined;
 };
+
 export const Reaction = styled.div<ReactionProps>`
+  // @debt convert this to scss then use our z-index layer helper here
+  z-index: 10;
+
   width: 50px;
 
   position: absolute;
   ${({ reactionPosition }) =>
     reactionPosition === "right" ? reactionRight : reactionLeft};
   top: -25px;
-  // @debt convert this to scss then use our z-index layer helper here
-  z-index: 10;
 
   font-size: 50px;
 
@@ -44,13 +49,15 @@ export const Reaction = styled.div<ReactionProps>`
 
 // --- Reaction Container
 export const Container = styled.div`
-  height: 100%;
   position: relative;
+
+  // @debt convert this to scss then use our z-index layer helper here
+  z-index: 11;
+
+  height: 100%;
 
   background-position: center;
   background-size: cover;
-  // @debt convert this to scss then use our z-index layer helper here
-  z-index: 11;
 
   ${Avatar} {
     border-radius: 10rem;
@@ -66,6 +73,7 @@ export const Container = styled.div`
 
 // --- Shout-out message
 const translateXOffset = "5vh"; // 5vh = imageWidth (4vh) + 1v (padding)
+
 const expandBounceRight = keyframes`
   0%,
   100% {
@@ -81,6 +89,7 @@ const expandBounceRight = keyframes`
     transform: scale(1) translateX(${translateXOffset});
   }
 `;
+
 const expandBounceLeft = keyframes`
   0%,
   100% {
@@ -102,6 +111,7 @@ const messageLeft = css`
   transform-origin: right center;
   animation: ${expandBounceLeft} 5s ease;
 `;
+
 const messageRight = css`
   left: 0;
   transform-origin: 2vh center;
@@ -109,19 +119,20 @@ const messageRight = css`
 `;
 
 export const ShoutOutMessage = styled.div<ReactionProps>`
+  bottom: 0;
+
+  // @debt convert this to scss then use our z-index layer helper here
+  z-index: 12;
+
   width: max-content;
   max-width: 20em;
   padding: 6px 10px;
 
   position: absolute;
-  bottom: 0;
-
   ${({ reactionPosition }) =>
     reactionPosition === "right" ? messageRight : messageLeft};
 
   background-color: rgba(255, 255, 255, 1);
-  // @debt convert this to scss then use our z-index layer helper here
-  z-index: 12;
 
   color: #000;
   font-size: 20px;

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -76,7 +76,7 @@ $z-layers: (
   user-search-input-close-btn: 1,
   user-search-results: 380,
   // Nav
-  navbar-map-back-button: 3,
+  navbar-map-back-button: $z-layer-sidebar,
   navbar-nav-search-results: 380,
   navbar-schedule-backdrop: $z-layer-live-schedule,
   navbar-schedule: $z-layer-live-schedule,


### PR DESCRIPTION
We initially attempted a fix for this in https://github.com/sparkletown/sparkle/pull/1268, but it seems that in certain cases the layering issue still existed.

This PR fixes that by ensuring that all of the reactions are within the same 'stacking context', so that their layering applies as expected: 

- Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/551
- Supercedes https://github.com/sparkletown/sparkle/pull/1317

We also ensure that the back button sits above the user's avatar pictures:

- Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/607

---

## Screenshots

> **Note:** In these screenshots below, I have hacked the code so that my user is 'sitting in every seat', to simplify showing many reactions/shoutouts/etc 'at once', and viewing how they overlap with one another, etc.
> 
> Currently (notice that avatar pictures go over the top of reactions):
> 
> ![image](https://user-images.githubusercontent.com/753891/114360062-f663fb00-9bb7-11eb-9821-8479c08a7cc3.png)
> 
> After changing the following in `/UserProfilePicture.styles.ts`:
> 
> * changed `Reaction` from `position: absolute;` to `position: relative;`
> * changed `ShoutOutMessage` from `position: absolute;` to `position: relative;`
> * removed `position: relative;` from `Container`
> 
> Just reactions (notice that all of the reactions are sitting 'above' the avatar pictures):
> ![image](https://user-images.githubusercontent.com/753891/114360316-3925d300-9bb8-11eb-89a3-78007a458978.png)
> 
> Reactions + Shout Outs (notice that all of the shout outs sit above all of the reactions):
> ![image](https://user-images.githubusercontent.com/753891/114360697-ab96b300-9bb8-11eb-8797-a16a0a75a323.png)
> 
_Originally posted by @0xdevalias in https://github.com/sparkletown/internal-sparkle-issues/issues/551#issuecomment-817583562_