### PR TITLE
Bump typescript from 3.9.3 to 4.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20744,9 +20744,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
-      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "gifwrap": "^0.9.2",
     "phin": "^3.5.0",
     "ts-node": "^9.1.1",
-    "typescript": "^3.9.3",
+    "typescript": "^4.2.4",
     "uuidv4": "^6.2.3"
   }
 }

--- a/src/components/templates/Playa/Playa.tsx
+++ b/src/components/templates/Playa/Playa.tsx
@@ -376,14 +376,14 @@ const Playa = () => {
     return Math.hypot(venuePlacement.x - x, venuePlacement.y - y);
   };
 
-  const { camp } = useParams();
+  const { camp } = useParams<{ camp?: string }>();
   useEffect(() => {
     if (camp) {
       const campVenue = venues?.find((venue) => venue.id === camp);
       if (campVenue && !PLAYA_TEMPLATES.includes(campVenue.template)) {
-        if (camp.placement) {
-          setCenterX(camp.placement.x);
-          setCenterY(camp.placement.y);
+        if (campVenue.placement !== undefined) {
+          setCenterX(campVenue.placement.x);
+          setCenterY(campVenue.placement.y);
         }
         showVenue(campVenue);
       }

--- a/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
+++ b/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
@@ -16,7 +16,7 @@ import { showZendeskWidget } from "utils/zendesk";
 export const VenueEntrancePage: React.FunctionComponent<{}> = () => {
   const { user, profile } = useUser();
   const history = useHistory();
-  const { step } = useParams();
+  const { step } = useParams<{ step?: string }>();
   const venueId = useVenueId();
   useConnectCurrentVenue();
   const venue = useSelector(currentVenueSelectorData);
@@ -32,6 +32,7 @@ export const VenueEntrancePage: React.FunctionComponent<{}> = () => {
   }
 
   if (
+    step === undefined ||
     !(parseInt(step) > 0) ||
     !venue.entrance ||
     !venue.entrance.length ||


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/160

---

We're currently using `"typescript": "^3.9.3"`:

- https://github.com/sparkletown/sparkle/blob/staging/package.json#L156

The latest version is `4.2.4`:

- https://github.com/microsoft/TypeScript/releases/tag/v4.2.4

There have been a number of releases since our current version, each adding new features, and their own 'breaking changes' categories:

- https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/ (this is the version we are currently on)
  - ⚠️ ⚠️ ⚠️ **https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/#breaking-changes (so these probably don't matter here)**
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/
  - **https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#breaking-changes**
    - Nothing much that sounds like it will impact us
  - Notable new features
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#variadic-tuple-types
      - Useful
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#labeled-tuple-elements
      - Also useful for better dev efficiency/documentation/usability
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#class-property-inference
      - Could help us avoid situations where the typing becomes an 'implicit `any`'
      - If we don't already, we should enable `noImplicitAny`
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#short-circuiting-assignment-operators
      - While we don't really use mutable state very often as a 'rule', this could have it's uses
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#unknown-on-catch
      - This would be a good feature to use to prevent errors in our error handlers
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories
      - Probably not all that useful for us, but interesting to note
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#build-and-noemitonerror
      - Not sure if this relates to how we use it, but good to know in case it does
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#noemit-and-incremental
      - Not sure if this relates to how we use it, but good to know in case it does
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-1
  - ⚠️ ⚠️ ⚠️  **https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#breaking-changes**
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#any-unknown-are-propagated-in-falsy-positions
      - This one is worth paying attention to. Not sure if it would impact our code at all.. but calling it out in case. 
  - Notable new features
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#template-literal-types
      - This could come in handy
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#key-remapping-in-mapped-types
      - Also could be quite useful
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#recursive-conditional-types
      - And this
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#checked-indexed-accesses-nouncheckedindexedaccess
      - This is going to be SUPER useful, and remove a whole bunch of potential bugs without us needing to be overly verbose with our typing
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#paths-without-baseurl
      - This will be useful to check/enable (if it isn't on by default)
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#react-17-jsx-factories
      - I believe this was probably one of the blockers stopping us from upgrading `create-react-app` to latest (see #1102)
      - We probably want to look into this a little, and update our config for it (see also https://github.com/microsoft/TypeScript/pull/39199)
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#editor-support-for-the-jsdoc-see-tag
      - Useful for improving our comments/usability of them within IDEs
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-2
  - ⚠️ ⚠️ ⚠️  **https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#breaking-changes**
    - Nothing much that sounds like it will impact us
  - Notable new features
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#smarter-type-alias-preservation
      - This will likely make it MUCH easier to understand type errors!
    - https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#unused-destructured
      - This is also a nice improvement