### PR TITLE
Ensure 'deploy preview environment' workflow runs when code is changed

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,7 +7,7 @@ on:
       - opened
       - reopened
       - synchronize
-      # Note: this is required to have deploys made when the base branch is changed.. but it
+      # Note: `edited` is required to have deploys made when the base branch is changed.. but it
       # also occurs whenever the description/title/etc are changed. Keeping commented here for
       # now, but I think we are probably fine without it.
       #- edited

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,7 +6,11 @@ on:
     types:
       - opened
       - reopened
-      - edited
+      - synchronize
+      # Note: this is required to have deploys made when the base branch is changed.. but it
+      # also occurs whenever the description/title/etc are changed. Keeping commented here for
+      # now, but I think we are probably fine without it.
+      #- edited
     branches:
       - staging
     paths:


### PR DESCRIPTION
We originally removed the `synchronize` event in https://github.com/sparkletown/sparkle/pull/1130 based on https://github.com/github/docs/issues/2257#issuecomment-772884922 + https://github.com/sparkletown/internal-sparkle-issues/issues/163#issuecomment-772206423

It seems that this had the unwanted side effect of not re-running when we push new code to a PR branch, which is sort of exactly when we want it to run.

Later in that thread (https://github.com/github/docs/issues/2257#issuecomment-799924192), someone shared a better resource, which clarifies further:

- https://github.community/t/what-is-a-pull-request-synchronize-event/14784/3
  - > Thanks for the follow up. What this implies is that if you push a new commit to the HEAD ref of a pull request then this “synchronize” event will be triggered. This is because the system is syncing the pull requests with the latest changes. **This will NOT trigger if the base ref is updated.**
- https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-do-workflows-trigger-on-pull_request
  - Contains far better descriptions of when these events are run
  - > `synchronize`: commit(s) pushed to the pull request
  - > `edited`: title, body, or the base branch of the PR is modified

---

This PR re-adds the `synchronize` event, as well as removing the `edited` event from the workflow triggers.