### PR TITLE
Fix input value clearing on x-icon click

### DIFF
--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -33,6 +33,7 @@ const emptyEventsArray: VenueEvent[] = [];
 const DEBOUNCE_TIME = 200; // ms
 
 const NavSearchBar = () => {
+  const [searchInputValue, setSearchInputValue] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
 
   const debouncedSearch = useMemo(
@@ -46,12 +47,14 @@ const NavSearchBar = () => {
   const onSearchInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
+      setSearchInputValue(value);
       debouncedSearch(value);
     },
     [debouncedSearch]
   );
 
   const clearSearchQuery = useCallback(() => {
+    setSearchInputValue("");
     setSearchQuery("");
   }, []);
 
@@ -170,6 +173,7 @@ const NavSearchBar = () => {
       </div>
 
       <InputField
+        value={searchInputValue}
         inputClassName="NavSearchBar__search-input"
         onChange={onSearchInputChange}
         placeholder="Search for people, rooms, events..."

--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useState, ChangeEvent, useMemo } from "react";
+import React, {
+  useCallback,
+  useState,
+  ChangeEvent,
+  useMemo,
+  useEffect,
+} from "react";
 import classNames from "classnames";
 import { debounce } from "lodash";
 
@@ -46,17 +52,18 @@ const NavSearchBar = () => {
 
   const onSearchInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      setSearchInputValue(value);
-      debouncedSearch(value);
+      setSearchInputValue(e.target.value);
     },
-    [debouncedSearch]
+    []
   );
 
   const clearSearchQuery = useCallback(() => {
     setSearchInputValue("");
-    setSearchQuery("");
   }, []);
+
+  useEffect(() => {
+    debouncedSearch(searchInputValue);
+  }, [debouncedSearch, searchInputValue]);
 
   const [selectedRoom, setSelectedRoom] = useState<Room>();
   const hasSelectedRoom = !!selectedRoom;


### PR DESCRIPTION
closes: https://github.com/sparkletown/internal-sparkle-issues/issues/678

There are 2 variables for search query: 
1. `searchInputValue` which is synchronized with the text that is written in the input field.
2. `searchQuery` which is changed with a delay (debounced `searchInputValue`) to reduce the number of search requests.

