### PR TITLE
Move InputField ref from div to input

### DIFF
--- a/src/components/atoms/InputField/InputField.tsx
+++ b/src/components/atoms/InputField/InputField.tsx
@@ -38,7 +38,7 @@ const renderIcon = (
 };
 
 const InputField: React.ForwardRefRenderFunction<
-  HTMLDivElement,
+  HTMLInputElement,
   InputFieldProps
 > = (
   {
@@ -62,8 +62,8 @@ const InputField: React.ForwardRefRenderFunction<
   const inputClassNames = classNames("input-field__input", inputClassName);
 
   return (
-    <div ref={ref} className={containerClassNames}>
-      <input className={inputClassNames} {...extraInputProps} />
+    <div className={containerClassNames}>
+      <input ref={ref} className={inputClassNames} {...extraInputProps} />
 
       {iconStart && renderIcon(iconStart, "input-field__icon--start")}
       {iconEnd && renderIcon(iconEnd, "input-field__icon--end")}


### PR DESCRIPTION
based on discussions I decided to quickly move `ref` of the `InputField` component from `div` to `input` direclty
https://github.com/sparkletown/sparkle/pull/1343#discussion_r623564823
https://github.com/sparkletown/sparkle/pull/1299#discussion_r623554069