### PR TITLE
Bump firebase from 7.14.2 to 8.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,13 +3180,6 @@
           "requires": {
             "yallist": "^4.0.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -3376,13 +3369,6 @@
             "yallist": "^4.0.0"
           }
         },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true,
-          "optional": true
-        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3475,12 +3461,6 @@
             "semver": "^6.0.0",
             "walkdir": "^0.4.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
         }
       }
     },
@@ -3562,13 +3542,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true,
-          "optional": true
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
           "dev": true,
           "optional": true
         },
@@ -12448,47 +12421,15 @@
           "version": "0.1.18",
           "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
           "integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-          "dev": true,
           "requires": {
             "@firebase/util": "0.3.1",
             "tslib": "^1.11.1"
           }
-        },
-        "@firebase/database": {
-          "version": "0.6.11",
-          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
-          "integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
-          "dev": true,
-          "requires": {
-            "@firebase/auth-interop-types": "0.1.5",
-            "@firebase/component": "0.1.18",
-            "@firebase/database-types": "0.5.2",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "0.3.1",
-            "faye-websocket": "0.11.3",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/database-types": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-          "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-          "dev": true,
-          "requires": {
-            "@firebase/app-types": "0.6.1"
-          }
-        },
-        "@firebase/logger": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-          "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-          "dev": true
         },
         "@firebase/util": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
           "integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-          "dev": true,
           "requires": {
             "tslib": "^1.11.1"
           }
@@ -13227,12 +13168,6 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
         }
       }
     },
@@ -13367,13 +13302,6 @@
           "requires": {
             "yallist": "^4.0.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true,
-          "optional": true
         },
         "pumpify": {
           "version": "2.0.1",
@@ -13612,12 +13540,6 @@
           "requires": {
             "semver": "^6.2.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
         }
       }
     },
@@ -26029,13 +25951,6 @@
         "uuid": "^8.0.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true,
-          "optional": true
-        },
         "uuid": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,40 +2768,16 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.10.tgz",
-      "integrity": "sha512-dLOAfeHYKkt1mhFNzrST6X0W5Og/VKhH7VP03YlUwz1STKtPve/KV32IynjMEBgnI6DC1NIAX3V0jYK6KBum4A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
+      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.5.0",
-        "@firebase/installations": "0.4.26",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.1.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/analytics-types": {
@@ -2810,78 +2786,46 @@
       "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.21.tgz",
-      "integrity": "sha512-SpWXdy/U06gTOEofSjhcsFGUtYmZim7ty6U4eMUQH0ObtymeVdTiK4tJcohMT5XoihQw4CLS2YvDySwx3+BlWg==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
+      "integrity": "sha512-FH++PaoyTzfTAVuJ0gITNYEIcjT5G+D0671La27MU8Vvr6MTko+5YUZ4xS9QItyotSeRF4rMJ1KR7G8LSyySiA==",
       "requires": {
-        "@firebase/app-types": "0.6.2",
-        "@firebase/component": "0.5.0",
+        "@firebase/app-types": "0.6.1",
+        "@firebase/component": "0.1.19",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.1.0",
+        "@firebase/util": "0.3.2",
         "dom-storage": "2.1.0",
-        "tslib": "^2.1.0",
+        "tslib": "^1.11.1",
         "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "@firebase/app-types": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
-          "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
-        },
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
       }
     },
     "@firebase/app-types": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
-      "dev": true
+      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.5.tgz",
-      "integrity": "sha512-Cgs/TlVot2QkbJyEphvKmu+2qxYlNN+Q2+29aqZwryrnn1eLwlC7nT89K6O91/744HJRtiThm02bMj2Wh61E3Q==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
+      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
       "requires": {
-        "@firebase/auth-types": "0.10.3"
+        "@firebase/auth-types": "0.10.1"
       }
     },
     "@firebase/auth-interop-types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
-      "dev": true
+      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
     },
     "@firebase/auth-types": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.3.tgz",
-      "integrity": "sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
+      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
     },
     "@firebase/component": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.19.tgz",
       "integrity": "sha512-L0S3g8eqaerg8y0zox3oOHSTwn/FE8RbcRHiurnbESvDViZtP5S5WnhuAPd7FnFxa8ElWK0z1Tr3ikzWDv1xdQ==",
-      "dev": true,
       "requires": {
         "@firebase/util": "0.3.2",
         "tslib": "^1.11.1"
@@ -2891,7 +2835,6 @@
       "version": "0.6.13",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
       "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
-      "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
         "@firebase/component": "0.1.19",
@@ -2906,131 +2849,58 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
       "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-      "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.3.0.tgz",
-      "integrity": "sha512-0RXEPVODLDYfAvt3wJaxXnDKFaO29OFCMpQ0s5rVjvYKs5ijpzf/FYu78i10HVYoDbjh8ZaZT+EVoxUNZiFq1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
+      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/firestore-types": "2.3.0",
+        "@firebase/component": "0.1.19",
+        "@firebase/firestore-types": "1.14.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "1.1.0",
-        "@firebase/webchannel-wrapper": "0.4.1",
+        "@firebase/util": "0.3.2",
+        "@firebase/webchannel-wrapper": "0.4.0",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
         "node-fetch": "2.6.1",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.3.0.tgz",
-      "integrity": "sha512-QTW7NP7nDL0pgT/X53lyj+mIMh4nRQBBTBlRNQBt7eSyeqBf3ag3bxdQhCg358+5KbjYTC2/O6QtX9DlJZmh1A=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
+      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw=="
     },
     "@firebase/functions": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.8.tgz",
-      "integrity": "sha512-Dttm53M6z31X6RfPPPMR4tkxSEIdIEcPmxEzABIdIjecSWuRpnDbEX3EmaTxjyRBn1g5TCAIsaEpGM17xh4UHw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
+      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/functions-types": "0.4.0",
+        "@firebase/component": "0.1.19",
+        "@firebase/functions-types": "0.3.17",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/functions-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
-      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
+      "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.26.tgz",
-      "integrity": "sha512-bHc6jlV8p1cX+GK38key4BooeZZ42//nKPmf3POWren0bACjnfHJuMnOBDuyw22ss3z6wUdiFNQjeUxvD4btGg==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.17.tgz",
+      "integrity": "sha512-AE/TyzIpwkC4UayRJD419xTqZkKzxwk0FLht3Dci8WI2OEKHSwoZG9xv4hOBZebe+fDzoV2EzfatQY8c/6Avig==",
       "requires": {
-        "@firebase/component": "0.5.0",
+        "@firebase/component": "0.1.19",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "1.1.0",
+        "@firebase/util": "0.3.2",
         "idb": "3.0.2",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/installations-types": {
@@ -3044,40 +2914,16 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/messaging": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.10.tgz",
-      "integrity": "sha512-Z5ui3kc1GbPf2+kwNvr0HjguBbi0xTkR7/BHodHHGpz0ycuY/J2/Cl9SgwhEuB52kme4ca9sKwV1g0Ln2/iARw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.1.tgz",
+      "integrity": "sha512-iev/ST9v0xd/8YpGYrZtDcqdD9J6ZWzSuceRn8EKy5vIgQvW/rk2eTQc8axzvDpQ36ZfphMYuhW6XuNrR3Pd2Q==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/installations": "0.4.26",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
         "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "1.1.0",
+        "@firebase/util": "0.3.2",
         "idb": "3.0.2",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/messaging-types": {
@@ -3086,40 +2932,16 @@
       "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
     },
     "@firebase/performance": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.12.tgz",
-      "integrity": "sha512-dFV0OR5IpHZwfOLFkEZuUVFmaJQresmS5G4UNFGk1E0VwU4feZ3roq75dJVYehclJxmbzgMM9M/U1bZ1/9wt3g==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
+      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/installations": "0.4.26",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "1.1.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/performance-types": {
@@ -3138,40 +2960,16 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.37.tgz",
-      "integrity": "sha512-SYjDOsEoUeqX1CYnUtXqVtM8MpVm2qx2Dp8NLRlLcPp/FieEza/mjRNVHBojMKuFjmyQp/RdPG8R0I9xDJ4PsQ==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.28.tgz",
+      "integrity": "sha512-4zSdyxpt94jAnFhO8toNjG8oMKBD+xTuBIcK+Nw8BdQWeJhEamgXlupdBARUk1uf3AvYICngHH32+Si/dMVTbw==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/installations": "0.4.26",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "1.1.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/remote-config-types": {
@@ -3180,58 +2978,33 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.5.2.tgz",
-      "integrity": "sha512-D2lZixL6E2iXE4jObtlA3UnAbcMd3657erotiuZt5ap95m1fogiPV/gIq3KLIaT5sFdfbbDQn9mm6hVKhobYHA==",
+      "version": "0.3.43",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
+      "integrity": "sha512-Jp54jcuyimLxPhZHFVAhNbQmgTu3Sda7vXjXrNpPEhlvvMSq4yuZBR6RrZxe/OrNVprLHh/6lTCjwjOVSo3bWA==",
       "requires": {
-        "@firebase/component": "0.5.0",
-        "@firebase/storage-types": "0.4.1",
-        "@firebase/util": "1.1.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "@firebase/component": "0.1.19",
+        "@firebase/storage-types": "0.3.13",
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/storage-types": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.1.tgz",
-      "integrity": "sha512-IM4cRzAnQ6QZoaxVZ5MatBzqXVcp47hOlE28jd9xXw1M9V7gfjhmW0PALGFQx58tPVmuUwIKyoEbHZjV4qRJwQ=="
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
+      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
     },
     "@firebase/util": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.2.tgz",
       "integrity": "sha512-Dqs00++c8rwKky6KCKLLY2T1qYO4Q+X5t+lF7DInXDNF4ae1Oau35bkD+OpJ9u7l1pEv7KHowP6CUKuySCOc8g==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
-      "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
+      "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
@@ -12611,80 +12384,24 @@
       }
     },
     "firebase": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.5.0.tgz",
-      "integrity": "sha512-dsyONwJ6y4f7OL7MjqzFtRwbkwkni2Xx4pubzPqSyYEjLfqJOrUNIhUf6U7G7fsTLqBI71hdRmUEMt/Bukl8QA==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
+      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
       "requires": {
-        "@firebase/analytics": "0.6.10",
-        "@firebase/app": "0.6.21",
-        "@firebase/app-types": "0.6.2",
-        "@firebase/auth": "0.16.5",
-        "@firebase/database": "0.10.0",
-        "@firebase/firestore": "2.3.0",
-        "@firebase/functions": "0.6.8",
-        "@firebase/installations": "0.4.26",
-        "@firebase/messaging": "0.7.10",
-        "@firebase/performance": "0.4.12",
+        "@firebase/analytics": "0.6.0",
+        "@firebase/app": "0.6.11",
+        "@firebase/app-types": "0.6.1",
+        "@firebase/auth": "0.15.0",
+        "@firebase/database": "0.6.13",
+        "@firebase/firestore": "1.18.0",
+        "@firebase/functions": "0.5.1",
+        "@firebase/installations": "0.4.17",
+        "@firebase/messaging": "0.7.1",
+        "@firebase/performance": "0.4.2",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.37",
-        "@firebase/storage": "0.5.2",
-        "@firebase/util": "1.1.0"
-      },
-      "dependencies": {
-        "@firebase/app-types": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
-          "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
-        },
-        "@firebase/auth-interop-types": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-          "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
-        },
-        "@firebase/component": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
-          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
-          "requires": {
-            "@firebase/util": "1.1.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/database": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.0.tgz",
-          "integrity": "sha512-GsHvuES83Edtboij2h3txKg+yV/TD4b5Owc01SgXEQtvj1lulkHt4Ufmd9OZz1WreWQJMIqKpbVowIDHjlkZJQ==",
-          "requires": {
-            "@firebase/auth-interop-types": "0.1.6",
-            "@firebase/component": "0.5.0",
-            "@firebase/database-types": "0.7.2",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "1.1.0",
-            "faye-websocket": "0.11.3",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@firebase/database-types": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
-          "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
-          "requires": {
-            "@firebase/app-types": "0.6.2"
-          }
-        },
-        "@firebase/util": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
-          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-        }
+        "@firebase/remote-config": "0.1.28",
+        "@firebase/storage": "0.3.43",
+        "@firebase/util": "0.3.2"
       }
     },
     "firebase-admin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,6 +6011,7 @@
       "version": "0.63.37",
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.37.tgz",
       "integrity": "sha512-xr9SZG7tQQBKT6840tAGaWEC65D2gjyxZtuZxz631UgeW1ofItuu9HMVhoyYqot2hRSa6Q4YC8FYkRVUpM53/w==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -6096,6 +6097,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.4.tgz",
       "integrity": "sha512-78f5Zuy0v/LTQNOYfpH+CINHpchzMMmAt9amY2YNtSgsk1TmlKm8L2Wijss/mtTrsUAVTm2CdGB8VOM65vA8xg==",
+      "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -6106,7 +6108,8 @@
         "csstype": {
           "version": "3.0.5",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,16 +2768,40 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
-      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.10.tgz",
+      "integrity": "sha512-dLOAfeHYKkt1mhFNzrST6X0W5Og/VKhH7VP03YlUwz1STKtPve/KV32IynjMEBgnI6DC1NIAX3V0jYK6KBum4A==",
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.4.26",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/analytics-types": {
@@ -2786,46 +2810,78 @@
       "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
-      "integrity": "sha512-FH++PaoyTzfTAVuJ0gITNYEIcjT5G+D0671La27MU8Vvr6MTko+5YUZ4xS9QItyotSeRF4rMJ1KR7G8LSyySiA==",
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.21.tgz",
+      "integrity": "sha512-SpWXdy/U06gTOEofSjhcsFGUtYmZim7ty6U4eMUQH0ObtymeVdTiK4tJcohMT5XoihQw4CLS2YvDySwx3+BlWg==",
       "requires": {
-        "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.19",
+        "@firebase/app-types": "0.6.2",
+        "@firebase/component": "0.5.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "1.1.0",
         "dom-storage": "2.1.0",
-        "tslib": "^1.11.1",
+        "tslib": "^2.1.0",
         "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@firebase/app-types": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+          "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
+        },
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/app-types": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+      "dev": true
     },
     "@firebase/auth": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
-      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.5.tgz",
+      "integrity": "sha512-Cgs/TlVot2QkbJyEphvKmu+2qxYlNN+Q2+29aqZwryrnn1eLwlC7nT89K6O91/744HJRtiThm02bMj2Wh61E3Q==",
       "requires": {
-        "@firebase/auth-types": "0.10.1"
+        "@firebase/auth-types": "0.10.3"
       }
     },
     "@firebase/auth-interop-types": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
+      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+      "dev": true
     },
     "@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.3.tgz",
+      "integrity": "sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA=="
     },
     "@firebase/component": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.19.tgz",
       "integrity": "sha512-L0S3g8eqaerg8y0zox3oOHSTwn/FE8RbcRHiurnbESvDViZtP5S5WnhuAPd7FnFxa8ElWK0z1Tr3ikzWDv1xdQ==",
+      "dev": true,
       "requires": {
         "@firebase/util": "0.3.2",
         "tslib": "^1.11.1"
@@ -2835,6 +2891,7 @@
       "version": "0.6.13",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
       "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
+      "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
         "@firebase/component": "0.1.19",
@@ -2849,58 +2906,131 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
       "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
+      "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
-      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.3.0.tgz",
+      "integrity": "sha512-0RXEPVODLDYfAvt3wJaxXnDKFaO29OFCMpQ0s5rVjvYKs5ijpzf/FYu78i10HVYoDbjh8ZaZT+EVoxUNZiFq1w==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/firestore-types": "1.14.0",
+        "@firebase/component": "0.5.0",
+        "@firebase/firestore-types": "2.3.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
-        "@firebase/webchannel-wrapper": "0.4.0",
+        "@firebase/util": "1.1.0",
+        "@firebase/webchannel-wrapper": "0.4.1",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
         "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
-      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.3.0.tgz",
+      "integrity": "sha512-QTW7NP7nDL0pgT/X53lyj+mIMh4nRQBBTBlRNQBt7eSyeqBf3ag3bxdQhCg358+5KbjYTC2/O6QtX9DlJZmh1A=="
     },
     "@firebase/functions": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
-      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.8.tgz",
+      "integrity": "sha512-Dttm53M6z31X6RfPPPMR4tkxSEIdIEcPmxEzABIdIjecSWuRpnDbEX3EmaTxjyRBn1g5TCAIsaEpGM17xh4UHw==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/functions-types": "0.3.17",
+        "@firebase/component": "0.5.0",
+        "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/functions-types": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
-      "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
+      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.17.tgz",
-      "integrity": "sha512-AE/TyzIpwkC4UayRJD419xTqZkKzxwk0FLht3Dci8WI2OEKHSwoZG9xv4hOBZebe+fDzoV2EzfatQY8c/6Avig==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.26.tgz",
+      "integrity": "sha512-bHc6jlV8p1cX+GK38key4BooeZZ42//nKPmf3POWren0bACjnfHJuMnOBDuyw22ss3z6wUdiFNQjeUxvD4btGg==",
       "requires": {
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.5.0",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "1.1.0",
         "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/installations-types": {
@@ -2914,16 +3044,40 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/messaging": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.1.tgz",
-      "integrity": "sha512-iev/ST9v0xd/8YpGYrZtDcqdD9J6ZWzSuceRn8EKy5vIgQvW/rk2eTQc8axzvDpQ36ZfphMYuhW6XuNrR3Pd2Q==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.10.tgz",
+      "integrity": "sha512-Z5ui3kc1GbPf2+kwNvr0HjguBbi0xTkR7/BHodHHGpz0ycuY/J2/Cl9SgwhEuB52kme4ca9sKwV1g0Ln2/iARw==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.4.26",
         "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "1.1.0",
         "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/messaging-types": {
@@ -2932,16 +3086,40 @@
       "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
     },
     "@firebase/performance": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
-      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.12.tgz",
+      "integrity": "sha512-dFV0OR5IpHZwfOLFkEZuUVFmaJQresmS5G4UNFGk1E0VwU4feZ3roq75dJVYehclJxmbzgMM9M/U1bZ1/9wt3g==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.4.26",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.3.2",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/performance-types": {
@@ -2960,16 +3138,40 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.28.tgz",
-      "integrity": "sha512-4zSdyxpt94jAnFhO8toNjG8oMKBD+xTuBIcK+Nw8BdQWeJhEamgXlupdBARUk1uf3AvYICngHH32+Si/dMVTbw==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.37.tgz",
+      "integrity": "sha512-SYjDOsEoUeqX1CYnUtXqVtM8MpVm2qx2Dp8NLRlLcPp/FieEza/mjRNVHBojMKuFjmyQp/RdPG8R0I9xDJ4PsQ==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.4.26",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.3.2",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/remote-config-types": {
@@ -2978,33 +3180,58 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.3.43",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
-      "integrity": "sha512-Jp54jcuyimLxPhZHFVAhNbQmgTu3Sda7vXjXrNpPEhlvvMSq4yuZBR6RrZxe/OrNVprLHh/6lTCjwjOVSo3bWA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.5.2.tgz",
+      "integrity": "sha512-D2lZixL6E2iXE4jObtlA3UnAbcMd3657erotiuZt5ap95m1fogiPV/gIq3KLIaT5sFdfbbDQn9mm6hVKhobYHA==",
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/storage-types": "0.3.13",
-        "@firebase/util": "0.3.2",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.0",
+        "@firebase/storage-types": "0.4.1",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@firebase/storage-types": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.1.tgz",
+      "integrity": "sha512-IM4cRzAnQ6QZoaxVZ5MatBzqXVcp47hOlE28jd9xXw1M9V7gfjhmW0PALGFQx58tPVmuUwIKyoEbHZjV4qRJwQ=="
     },
     "@firebase/util": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.2.tgz",
       "integrity": "sha512-Dqs00++c8rwKky6KCKLLY2T1qYO4Q+X5t+lF7DInXDNF4ae1Oau35bkD+OpJ9u7l1pEv7KHowP6CUKuySCOc8g==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
-      "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
+      "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
@@ -12381,24 +12608,80 @@
       }
     },
     "firebase": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
-      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.5.0.tgz",
+      "integrity": "sha512-dsyONwJ6y4f7OL7MjqzFtRwbkwkni2Xx4pubzPqSyYEjLfqJOrUNIhUf6U7G7fsTLqBI71hdRmUEMt/Bukl8QA==",
       "requires": {
-        "@firebase/analytics": "0.6.0",
-        "@firebase/app": "0.6.11",
-        "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.15.0",
-        "@firebase/database": "0.6.13",
-        "@firebase/firestore": "1.18.0",
-        "@firebase/functions": "0.5.1",
-        "@firebase/installations": "0.4.17",
-        "@firebase/messaging": "0.7.1",
-        "@firebase/performance": "0.4.2",
+        "@firebase/analytics": "0.6.10",
+        "@firebase/app": "0.6.21",
+        "@firebase/app-types": "0.6.2",
+        "@firebase/auth": "0.16.5",
+        "@firebase/database": "0.10.0",
+        "@firebase/firestore": "2.3.0",
+        "@firebase/functions": "0.6.8",
+        "@firebase/installations": "0.4.26",
+        "@firebase/messaging": "0.7.10",
+        "@firebase/performance": "0.4.12",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.28",
-        "@firebase/storage": "0.3.43",
-        "@firebase/util": "0.3.2"
+        "@firebase/remote-config": "0.1.37",
+        "@firebase/storage": "0.5.2",
+        "@firebase/util": "1.1.0"
+      },
+      "dependencies": {
+        "@firebase/app-types": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+          "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
+        },
+        "@firebase/auth-interop-types": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+          "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
+        },
+        "@firebase/component": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+          "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+          "requires": {
+            "@firebase/util": "1.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/database": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.10.0.tgz",
+          "integrity": "sha512-GsHvuES83Edtboij2h3txKg+yV/TD4b5Owc01SgXEQtvj1lulkHt4Ufmd9OZz1WreWQJMIqKpbVowIDHjlkZJQ==",
+          "requires": {
+            "@firebase/auth-interop-types": "0.1.6",
+            "@firebase/component": "0.5.0",
+            "@firebase/database-types": "0.7.2",
+            "@firebase/logger": "0.2.6",
+            "@firebase/util": "1.1.0",
+            "faye-websocket": "0.11.3",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@firebase/database-types": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+          "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
+          "requires": {
+            "@firebase/app-types": "0.6.2"
+          }
+        },
+        "@firebase/util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+          "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "firebase-admin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,34 +2768,34 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.5.tgz",
-      "integrity": "sha512-p+h1s9A8EjGWfjAObu8ei46JoN2Ogbtl1RzqW7HjcPuclOIOmPTXKEXXCEXgO79OLxnzzezVeBtHPSx6r6gxJA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
+      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
       "requires": {
-        "@firebase/analytics-types": "0.3.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
+        "@firebase/analytics-types": "0.4.0",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/analytics-types": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.1.tgz",
-      "integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
+      "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.4.tgz",
-      "integrity": "sha512-E1Zw6yeZYdYYFurMnklKPvE+q/xleHXs7bmcVgyhgAEg3Gv6/qXI4+4GdWh+iF7wmQ3Liesh51xqfdpvHBwAMQ==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
+      "integrity": "sha512-FH++PaoyTzfTAVuJ0gITNYEIcjT5G+D0671La27MU8Vvr6MTko+5YUZ4xS9QItyotSeRF4rMJ1KR7G8LSyySiA==",
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.19",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.2",
         "dom-storage": "2.1.0",
-        "tslib": "1.11.1",
+        "tslib": "^1.11.1",
         "xmlhttprequest": "1.8.0"
       }
     },
@@ -2805,9 +2805,9 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.6.tgz",
-      "integrity": "sha512-7gaEUWhUubWBGfOXAZvpTpJqBJT9KyG83RXC6VnjSQIfNUaarHZ485WkzERil43A6KvIl+f4kHxfZShE6ZCK3A==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
+      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
       "requires": {
         "@firebase/auth-types": "0.10.1"
       }
@@ -2823,66 +2823,67 @@
       "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
     },
     "@firebase/component": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.12.tgz",
-      "integrity": "sha512-03w800MxR/EW1m7N0Q46WNcngwdDIHDWpFPHTdbZEI6U/HuLks5RJQlBxWqb1P73nYPkN8YP3U8gTdqrDpqY3Q==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.19.tgz",
+      "integrity": "sha512-L0S3g8eqaerg8y0zox3oOHSTwn/FE8RbcRHiurnbESvDViZtP5S5WnhuAPd7FnFxa8ElWK0z1Tr3ikzWDv1xdQ==",
       "requires": {
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/database": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.3.tgz",
-      "integrity": "sha512-gHoCISHQVLoq+rGu+PorYxMkhsjhXov3ocBxz/0uVdznNhrbKkAZaEKF+dIAsUPDlwSYeZuwWuik7xcV3DtRaw==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
+      "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.12",
-        "@firebase/database-types": "0.5.1",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.19",
+        "@firebase/database-types": "0.5.2",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.2",
         "faye-websocket": "0.11.3",
-        "tslib": "1.11.1"
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/database-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.1.tgz",
-      "integrity": "sha512-onQxom1ZBYBJ648w/VNRzUewovEDAH7lvnrrpCd69ukkyrMk6rGEO/PQ9BcNEbhlNtukpsqRS0oNOFlHs0FaSA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
+      "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.6.tgz",
-      "integrity": "sha512-9TfM4BFQAhyn+gmayX80wZEAO27bUBy471pba/oAYM9UrvPp1US9Bn/QzeuA/hxBSZXcN5zWNcs1Ibyt8eAreg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
+      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/firestore-types": "1.10.3",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
-        "@firebase/webchannel-wrapper": "0.2.41",
-        "@grpc/grpc-js": "0.8.1",
+        "@firebase/component": "0.1.19",
+        "@firebase/firestore-types": "1.14.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.2",
+        "@firebase/webchannel-wrapper": "0.4.0",
+        "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
-        "tslib": "1.11.1"
+        "node-fetch": "2.6.1",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.10.3.tgz",
-      "integrity": "sha512-DcYTJbva/gYK3i9q1Jw4tUkuSGQY5tXizSU/yytJgsRZNQrLEbrbHza9n6MAxcBbMSgcWZ24XzCGELtlKgMbSw=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
+      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw=="
     },
     "@firebase/functions": {
-      "version": "0.4.44",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.44.tgz",
-      "integrity": "sha512-Nbw+V/jYqfgq7wscsSDidqIzx8TrnmA2wRD1auCFNmf+gSJg8o+gNyCDdNHZI407jvrZcxp3nG1eMbqwmmnp7Q==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
+      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.19",
         "@firebase/functions-types": "0.3.17",
-        "@firebase/messaging-types": "0.4.5",
-        "isomorphic-fetch": "2.2.1",
-        "tslib": "1.11.1"
+        "@firebase/messaging-types": "0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/functions-types": {
@@ -2891,15 +2892,15 @@
       "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.10.tgz",
-      "integrity": "sha512-Nf7VK9++0eQzjdvBkBNNaOdxPjFiKD0EllLCIQycHozF97BmuFUqb2Ik5L2JaWspWg7vxLNacLHvW48nPGx4Zw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.17.tgz",
+      "integrity": "sha512-AE/TyzIpwkC4UayRJD419xTqZkKzxwk0FLht3Dci8WI2OEKHSwoZG9xv4hOBZebe+fDzoV2EzfatQY8c/6Avig==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.19",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.3.2",
         "idb": "3.0.2",
-        "tslib": "1.11.1"
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/installations-types": {
@@ -2908,39 +2909,39 @@
       "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q=="
     },
     "@firebase/logger": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.4.tgz",
-      "integrity": "sha512-akHkOU7izYB1okp/B5sxClGjjw6KvZdSHyjNM5pKd67Zg5W6PsbkI/GFNv21+y6LkUkJwDRbdeDgJoYXWT3mMA=="
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
+      "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/messaging": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.16.tgz",
-      "integrity": "sha512-TAPISK5y3xbxUw81HxLDP6YPsRryU6Nl8Z7AjNnem13BoN9LJ2/wCi9RDMfPnQhAn0h0N+mpxy/GB+0IlEARlg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.1.tgz",
+      "integrity": "sha512-iev/ST9v0xd/8YpGYrZtDcqdD9J6ZWzSuceRn8EKy5vIgQvW/rk2eTQc8axzvDpQ36ZfphMYuhW6XuNrR3Pd2Q==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/messaging-types": "0.4.5",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
+        "@firebase/messaging-types": "0.5.0",
+        "@firebase/util": "0.3.2",
         "idb": "3.0.2",
-        "tslib": "1.11.1"
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/messaging-types": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.4.5.tgz",
-      "integrity": "sha512-sux4fgqr/0KyIxqzHlatI04Ajs5rc3WM+WmtCpxrKP1E5Bke8xu/0M+2oy4lK/sQ7nov9z15n3iltAHCgTRU3Q=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
+      "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
     },
     "@firebase/performance": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.5.tgz",
-      "integrity": "sha512-FCUxK3IsJuthSosXzCA/B3Lz0o51QLjS1PuHFSxW4zwnMN2p5LrJBof47D2qB/ZYLey8xR4u2IGHOjvSDyKA9w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
+      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
+        "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/performance-types": {
@@ -2956,26 +2957,19 @@
         "core-js": "3.6.5",
         "promise-polyfill": "8.1.3",
         "whatwg-fetch": "2.0.4"
-      },
-      "dependencies": {
-        "whatwg-fetch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-        }
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.21.tgz",
-      "integrity": "sha512-EwDNU1mT+8Jn66IUwwNP5SM8AbaI7wmCXjp7djZtTXNrpPoh3xqzSRM1vTgp4Uu/mHffEDfbydsoJAIftADIfQ==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.28.tgz",
+      "integrity": "sha512-4zSdyxpt94jAnFhO8toNjG8oMKBD+xTuBIcK+Nw8BdQWeJhEamgXlupdBARUk1uf3AvYICngHH32+Si/dMVTbw==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.19",
+        "@firebase/installations": "0.4.17",
+        "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/remote-config-types": {
@@ -2984,33 +2978,33 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.3.34",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.34.tgz",
-      "integrity": "sha512-vuR1PpGdaCk25D2dT2trfmZZjpdfOn0rPTksvoqg7TAPLeoVsVoDyT2LgF3Arna/jqx52sAIRx1HLrlvzE1pgA==",
+      "version": "0.3.43",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
+      "integrity": "sha512-Jp54jcuyimLxPhZHFVAhNbQmgTu3Sda7vXjXrNpPEhlvvMSq4yuZBR6RrZxe/OrNVprLHh/6lTCjwjOVSo3bWA==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/storage-types": "0.3.12",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
+        "@firebase/component": "0.1.19",
+        "@firebase/storage-types": "0.3.13",
+        "@firebase/util": "0.3.2",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/storage-types": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.12.tgz",
-      "integrity": "sha512-DDV6Fs6aYoGw3w/zZZTkqiipxihnsvHf6znbeZYjIIHit3tr1uLJdGPDPiCTfZcTGPpg2ux6ZmvNDvVgJdHALw=="
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
+      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
     },
     "@firebase/util": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.47.tgz",
-      "integrity": "sha512-RjcIvcfswyxYhf0OMXod+qeI/933wl9FGLIszf0/O1yMZ/s8moXcse7xnOpMjmQPRLB9vHzCMoxW5X90kKg/bQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.2.tgz",
+      "integrity": "sha512-Dqs00++c8rwKky6KCKLLY2T1qYO4Q+X5t+lF7DInXDNF4ae1Oau35bkD+OpJ9u7l1pEv7KHowP6CUKuySCOc8g==",
       "requires": {
-        "tslib": "1.11.1"
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.41",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.41.tgz",
-      "integrity": "sha512-XcdMT5PSZHiuf7LJIhzKIe+RyYa25S3LHRRvLnZc6iFjwXkrSDJ8J/HWO6VT8d2ZTbawp3VcLEjRF/VN8glCrA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
+      "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
@@ -3618,11 +3612,11 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
-      "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.0.tgz",
+      "integrity": "sha512-fiL7ZaGg2HBiFtmv6m34d5jEgEtNXfctjzB3f7b3iuT7olBX4mHLMOqOBmGTTSOTfNRQJH5+vsyk6mEz3I0Q7Q==",
       "requires": {
-        "semver": "^6.2.0"
+        "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
@@ -10584,14 +10578,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -12422,24 +12408,24 @@
       }
     },
     "firebase": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.6.tgz",
-      "integrity": "sha512-W7nN57T+slfSYtUoCD7Jup/P+V8velhjbtJUlO4+gYXCG0TT83ah3B+89LlVwOrL3tVAl68GdA892vdXVsY6zQ==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
+      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
       "requires": {
-        "@firebase/analytics": "0.3.5",
-        "@firebase/app": "0.6.4",
+        "@firebase/analytics": "0.6.0",
+        "@firebase/app": "0.6.11",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.14.6",
-        "@firebase/database": "0.6.3",
-        "@firebase/firestore": "1.14.6",
-        "@firebase/functions": "0.4.44",
-        "@firebase/installations": "0.4.10",
-        "@firebase/messaging": "0.6.16",
-        "@firebase/performance": "0.3.5",
+        "@firebase/auth": "0.15.0",
+        "@firebase/database": "0.6.13",
+        "@firebase/firestore": "1.18.0",
+        "@firebase/functions": "0.5.1",
+        "@firebase/installations": "0.4.17",
+        "@firebase/messaging": "0.7.1",
+        "@firebase/performance": "0.4.2",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.21",
-        "@firebase/storage": "0.3.34",
-        "@firebase/util": "0.2.47"
+        "@firebase/remote-config": "0.1.28",
+        "@firebase/storage": "0.3.43",
+        "@firebase/util": "0.3.2"
       }
     },
     "firebase-admin": {
@@ -15058,15 +15044,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -19893,13 +19870,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.0",
@@ -28432,9 +28405,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/mousetrap": "^1.6.4",
     "@types/qs": "^6.9.3",
     "@types/react-resize-detector": "^4.2.0",
-    "@types/styled-components": "^5.1.4",
     "@types/ws": "^7.2.6",
     "@welldone-software/why-did-you-render": "^4.3.2",
     "bootstrap": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "date-fns": "^2.12.0",
     "dayjs": "^1.8.35",
     "esm": "^3.2.25",
-    "firebase": "^8.5.0",
+    "firebase": "^7.24.0",
     "fuse.js": "^6.4.1",
     "husky": "^4.2.5",
     "immutability-helper": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "date-fns": "^2.12.0",
     "dayjs": "^1.8.35",
     "esm": "^3.2.25",
-    "firebase": "^7.14.2",
+    "firebase": "^7.24.0",
     "fuse.js": "^6.4.1",
     "husky": "^4.2.5",
     "immutability-helper": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "date-fns": "^2.12.0",
     "dayjs": "^1.8.35",
     "esm": "^3.2.25",
-    "firebase": "^7.24.0",
+    "firebase": "^8.5.0",
     "fuse.js": "^6.4.1",
     "husky": "^4.2.5",
     "immutability-helper": "^3.1.1",


### PR DESCRIPTION
Bumps `firebase` from 7.14.2 to 7.24.0

Partially fixes sparkletown/internal-sparkle-issues#617

Partially fixes sparkletown/internal-sparkle-issues#645

### Release Notes

- **Old Version:** 7.14.2 (April 23, 2020): [release notes](https://firebase.google.com/support/release-notes/js#version_7142_-_april_23_2020)
- _a whole bunch of bug fixes, features, etc_ (only calling out some interesting/notable ones)
  - `7.14.6` (May 29, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7146_-_may_29_2020))
    - > Feature: Added support for calling `FirebaseFiresore.settings` with `{ ignoreUndefinedProperties: true }`. When this parameter is set, Cloud Firestore ignores undefined properties inside objects rather than rejecting the API call.
  - `7.16.0` (July 09, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7160_-_july_09_2020))
    - > Fixed: Clear timeout after a successful response or after the request is canceled
      - > Callable Function throw Deadline Exceeded Error even on successful response
  - `7.18.0` (August 13, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7180_-_august_13_2020))
    - > Fixed: The SDK no longer crashes with the error "The database connection is closing". Instead, the individual operations that cause this error may be rejected.
  - `7.19.0` (August 20, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7190_-_august_20_2020))
    - > Feature: Released `@firebase/rules-unit-testing` to replace the `@firebase/testing package`.
  - `7.21.0` (September 17, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7210_-_september_17_2020))
    - > Changed: The SDK now uses `FirestoreError` instead of Error in `onSnapshot*()` error callbacks.
  - `7.22.0` (October 1, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7220_-_october_1_2020))
    - > Feature: Users can now set a custom domain for callable functions.
  - `7.23.0` (October 8, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_7230_-_october_8_2020))
    - > Changed: Moved the `loggingEnabled` check to wait until performance initialization finishes, **which prevents the SDK from dropping custom traces** right after getting the performance object.
    - > Throws an exception when `startTime` or duration is not a positive value in the `trace.record()` API.
- `8.0.0` (October 26, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_800_-_october_26_2020), **BREAKING CHANGES**)
  - > Breaking change: browser fields in `package.json` files now point to ESM bundles instead of CJS bundles. Users who are using ESM imports must now use the default import instead of a namespace import.
    - > Before 8.0.0: `import * as firebase from 'firebase/app'`
    - > After 8.0.0: `import firebase from 'firebase/app'`
    - > Code that uses `require('firebase/app')` or `require('firebase')` will still work, but in order to get proper typings (for code completion, for example) users should change these require calls to `require('firebase/app').default` or `require('firebase').default`. This is because the SDK now uses typings for the ESM bundle, and the different bundles share one typings file.
  - > Breaking change: Removed deprecated `experimentalTabSynchronization` settings. To enable multi-tab synchronization, use `synchronizeTabs` instead.
  - > Breaking change: Removed the `timestampsInSnapshots` option from `FirestoreSettings`. Now, Cloud Firestore always returns `Timestamp` values for all timestamp values.
  - > Changed: This release removes runtime type validations that are covered by TypeScript. Developers can use our TypeScript types to validate API usage.
- _a whole bunch of bug fixes, features, etc_ (only calling out some interesting/notable ones)
  - `8.0.1` (November 5, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_801_-_november_5_2020))
    - > Feature: Added a `withFunctionTriggersDisabled` method which runs a user-provided setup function with emulated Cloud Functions triggers disabled. This can be used to import data into the Realtime Database or Cloud Firestore emulators without triggering locally emulated functions. This method only works with Firebase CLI version 8.13.0 or higher.
  - `8.0.2` (November 12, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_802_-_november_12_2020))
    - > The SDK now retries IndexedDB errors a fixed number of times to handle connection issues in mobile WebKit.
  - `8.1.2` (; [release notes](https://firebase.google.com/support/release-notes/js#version_812_-_december_3_2020))
    - > Fixed: Fixed a bug that prevented usage of `FieldPath` objects with multiple special characters.
  - `8.2.0` (December 11, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_820_-_december_11_2020))
    - > Feature: Released Firestore Bundles (pre-packaged Firestore data). For NPM users, this can be enabled via an additional import: `firebase/firestore/bundle`. For CDN usage, it is enabled by default.
    - > Changed: A write to a document that contains `FieldValue` transforms is no longer split up into two separate operations. This reduces the number of writes the backend performs and allows each `WriteBatch` to hold `500` writes regardless of how many `FieldValue` transformations are attached.
    - > Changed: Changed to dispatch no more than `1000` collected performance events for each network request. Events over the cap will be queued and sent with the next dispatch.
  - `8.2.1` (December 17, 2020; [release notes](https://firebase.google.com/support/release-notes/js#version_821_-_december_17_2020))
    - > Fixed: Fixed an issue that prevented the SDK from automatically retrieving custom claims for a `User`
  - `8.2.2` (January 7, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_822_-_january_7_2021))
    - > Fixed: Fixed an issue in the Transaction API that caused the SDK to return invalid DocumentReference objects through DocumentSnapshot.data() calls.
  - `8.2.4` (January 21, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_824_-_january_21_2021))
    - > Fixed: Fixed an error that caused `FirestoreDataConverter.fromFirestore()` to be called with an incorrect `QueryDocumentSnapshot` object.
  - `8.2.5` (January 28, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_825_-_january_28_2021))
    - > Fixed: Classes like `DocumentReference` and `Query` can now be serialized to `JSON`
  - `8.2.6` (February 04, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_826_-_february_04_2021))
    - > Fixed: Correctly handle `ignoreUndefinedProperties` in `set({ merge: true })`. Previously this would behave as if the undefined value were `FieldValue.delete()`, which wasn't intended.
  - `8.2.7` (February 11, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_827_-_february_11_2021))
    - > Fixed a bug where local cache inconsistencies were unnecessarily being resolved.
  - `8.2.8` (February 18, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_828_-_february_18_2021))
    - > Fixed a behavior causing `gtag.js` to be downloaded twice on Firebase Analytics initialization. 
  - `8.3.0` (March 10, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_830_-_march_10_2021))
    - > Feature: Added support to remove the `FirestoreDataConverter` on a `Firestore` reference by calling `withConverter(null)`
  - `8.4.0` (April 12, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_840_-_april_12_2021))
    - > Fixed a bug where decimal inputs to `Timestamp.fromMillis()` were calculated incorrectly due to floating point precision loss.
  - `8.4.2` (April 23, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_842_-_april_23_2021))
    - > Fixed an issue where errors from `grpc` are thrown directly to user code. Now they are wrapped in `FirestoreError`.
    - > Fixed the infinite recursion caused by the `FirebaseStorageError` message getter.
  - `8.5.0` (May 5, 2021; [release notes](https://firebase.google.com/support/release-notes/js#version_850_-_may_5_2021))
    - Note: This is the latest version listed in the Firebase JavaScript SDK Release Notes at this time (though it's not the latest version that exists)
- `9.0.0` (beta) (**BREAKING CHANGES**)
  - Note: Being a beta version, this will still likely have bugs/issues with it, eg.
    - https://github.com/firebase/firebase-js-sdk/issues/4799
  - Release Announcement: https://github.com/firebase/firebase-js-sdk/issues/332#issuecomment-825034318
    - > We are pleased to announce that the version 9 of the Firebase JS SDK is now available in beta! 🎉🔥 Version 9 is fully modular and tree shakable, so I think we can finally close this issue.
  - Upgrading from v8: https://firebase.google.com/docs/web/modular-upgrade
  - https://firebase.google.com/docs/web/learn-more#modular-version
  - Setup docs: https://firebase.google.com/docs/web/setup?sdk_version=v9
  - API Reference: https://firebase.google.com/docs/reference/js/v9
  - Some notes on size differences using `firestore/lite` (which doesn't support subscriptions/snapshot listeners/etc): https://github.com/firebase/firebase-js-sdk/issues/332#issuecomment-832542169

## PR Notes

- Let's not upgrade to the `9.0.0` beta in this PR (though i'm super keen for it's final release, as it introduces modular code/tree shakeable code!)
- Seemingly can't upgrade to `8.5.0` at the moment due to dependency version incompatibilities between `firebase` and `firebase-admin` (see https://github.com/sparkletown/sparkle/pull/1362#issuecomment-833438685)

## See Also

- https://github.com/sparkletown/sparkle/pull/1430