### PR TITLE
refactor event fetching for performance/efficiency (part 2)

### DIFF
--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+
+import { useSelector } from "./useSelector";
+import { useVenueId } from "./useVenueId";
+import { useFirestoreConnect, isLoaded } from "./useFirestoreConnect";
+import { useSovereignVenueId } from "./useSovereignVenueId";
+
+export const useConnectWorldEvents = () => {
+  const venueId = useVenueId();
+
+  const { sovereignVenueId, isSovereignVenueIdLoading } = useSovereignVenueId(
+    venueId
+  );
+
+  useFirestoreConnect(() => {
+    if (isSovereignVenueIdLoading || !sovereignVenueId) return [];
+
+    return [
+      {
+        collectionGroup: "events",
+        where: [["worldId", "==", sovereignVenueId]],
+        storeAs: "worldEvents",
+      },
+    ];
+  });
+};
+
+export const useWorldEvents = () => {
+  useConnectWorldEvents();
+
+  const selectedWorldEvents = useSelector(
+    (state) => state.firestore.ordered.worldEvents
+  );
+
+  return useMemo(
+    () => ({
+      worldEvents: selectedWorldEvents ?? [],
+      isWorldEventsLoaded: isLoaded(selectedWorldEvents),
+    }),
+    [selectedWorldEvents]
+  );
+};

--- a/src/hooks/useSovereignVenueId.ts
+++ b/src/hooks/useSovereignVenueId.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { fetchSovereignVenueId } from "api/sovereignVenue";
 
 import {
@@ -10,10 +11,8 @@ import { sovereignVenueIdSelector } from "utils/selectors";
 
 import { useDispatch } from "./useDispatch";
 import { useSelector } from "./useSelector";
-import { useVenueId } from "./useVenueId";
 
-export const useSovereignVenueId = () => {
-  const venueId = useVenueId();
+export const useSovereignVenueId = (venueId?: string) => {
   const dispatch = useDispatch();
 
   const {
@@ -22,8 +21,11 @@ export const useSovereignVenueId = () => {
     errorMsg,
   } = useSelector(sovereignVenueIdSelector);
 
-  // NOTE: Force to fetch it only once
-  if (!sovereignVenueId && !isSovereignVenueIdLoading && !errorMsg && venueId) {
+  useEffect(() => {
+    // The change of venueId will not trigger the fetching of sovereignVenueId
+    if (sovereignVenueId || isSovereignVenueIdLoading || errorMsg || !venueId)
+      return;
+
     dispatch(setSovereignVenueIdIsLoading(true));
     fetchSovereignVenueId(venueId)
       .then((sovereignVenueId) => {
@@ -36,7 +38,13 @@ export const useSovereignVenueId = () => {
       .finally(() => {
         dispatch(setSovereignVenueIdIsLoading(false));
       });
-  }
+  }, [
+    sovereignVenueId,
+    isSovereignVenueIdLoading,
+    errorMsg,
+    venueId,
+    dispatch,
+  ]);
 
   return {
     sovereignVenueId,

--- a/src/hooks/users.ts
+++ b/src/hooks/users.ts
@@ -17,7 +17,9 @@ import { useSovereignVenueId } from "./useSovereignVenueId";
 export const useConnectWorldUsers = () => {
   const venueId = useVenueId();
 
-  const { sovereignVenueId, isSovereignVenueIdLoading } = useSovereignVenueId();
+  const { sovereignVenueId, isSovereignVenueIdLoading } = useSovereignVenueId(
+    venueId
+  );
 
   useFirestoreConnect(() => {
     if (isSovereignVenueIdLoading || !sovereignVenueId || !venueId) return [];

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -56,6 +56,7 @@ import { useQuery } from "hooks/useQuery";
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 import { useVenueId } from "hooks/useVenueId";
+import { useSovereignVenueId } from "hooks/useSovereignVenueId";
 
 import { PlayaContainer } from "pages/Account/Venue/VenueMapEdition";
 
@@ -83,7 +84,7 @@ const VenueList: React.FC<VenueListProps> = ({
 }) => {
   const venues = useSelector(orderedVenuesSelector);
 
-  if (!venues) return <>Loading...</>;
+  if (!venues) return <span>Loading...</span>;
 
   return (
     <>
@@ -131,6 +132,9 @@ type VenueDetailsProps = {
 const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
   const { url: matchUrl } = useRouteMatch();
   const { pathname: urlPath } = useLocation();
+  const { sovereignVenueId, isSovereignVenueIdLoading } = useSovereignVenueId(
+    venueId
+  );
 
   const venueSelector = useCallback(
     (state) => makeVenueSelector(venueId)(state),
@@ -166,7 +170,15 @@ const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
   }, [matchUrl, venue]);
 
   if (!venue) {
-    return <>{"Oops, seems we can't find your venue!"}</>;
+    return <span>Oops, seems we can't find your venue!</span>;
+  }
+
+  if (isSovereignVenueIdLoading) {
+    return <span>Loading world venue</span>;
+  }
+
+  if (!sovereignVenueId) {
+    return <span>Oops, seems we can't find the world venue</span>;
   }
 
   return (
@@ -188,6 +200,7 @@ const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
           <Route path={`${matchUrl}/events`}>
             <EventsComponent
               venue={venue}
+              worldId={sovereignVenueId}
               showCreateEventModal={showCreateEventModal}
               setShowCreateEventModal={setShowCreateEventModal}
               editedEvent={editedEvent}
@@ -212,6 +225,7 @@ const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
         show={showCreateEventModal}
         onHide={adminEventModalOnHide}
         venueId={venueId}
+        worldId={sovereignVenueId}
         event={editedEvent}
         template={venue.template}
         setEditedEvent={setEditedEvent}
@@ -253,6 +267,9 @@ const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
   const history = useHistory();
   const match = useRouteMatch();
   const placementDivRef = useRef<HTMLDivElement>(null);
+  const { sovereignVenueId, isSovereignVenueIdLoading } = useSovereignVenueId(
+    venue.id
+  );
 
   useEffect(() => {
     const clientWidth = placementDivRef.current?.clientWidth ?? 0;
@@ -278,6 +295,14 @@ const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
   // @debt Refactor this mapping/customisation into settings, or types/templates, or similar?
   const deleteText =
     venue.template === VenueTemplate.themecamp ? "Delete camp" : "Delete venue";
+
+  if (isSovereignVenueIdLoading) {
+    return <span>Loading world venue</span>;
+  }
+
+  if (!sovereignVenueId) {
+    return <span>Oops, seems we can't find the world venue</span>;
+  }
 
   return (
     <>
@@ -430,6 +455,7 @@ const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
           setEditedEvent(undefined);
         }}
         venueId={venue.id}
+        worldId={sovereignVenueId}
         event={editedEvent}
         template={venue.template}
         setEditedEvent={setEditedEvent}

--- a/src/pages/Admin/AdminEventModal.tsx
+++ b/src/pages/Admin/AdminEventModal.tsx
@@ -19,6 +19,7 @@ interface PropsType {
   show: boolean;
   onHide: () => void;
   venueId: string;
+  worldId: string;
   event?: WithId<VenueEvent>;
   template?: VenueTemplate;
   setEditedEvent: Function | undefined;
@@ -58,6 +59,7 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
   show,
   onHide,
   venueId,
+  worldId,
   event,
   template,
   setEditedEvent,
@@ -104,6 +106,8 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
         price: 0,
         collective_price: 0,
         host: data.host,
+        venueId,
+        worldId,
       };
       if (template && HAS_ROOMS_TEMPLATES.includes(template))
         formEvent.room = data.room;
@@ -114,7 +118,7 @@ const AdminEventModal: React.FunctionComponent<PropsType> = ({
       }
       onHide();
     },
-    [event, onHide, venueId, template]
+    [event, onHide, venueId, template, worldId]
   );
 
   return (

--- a/src/pages/Admin/EventsComponent.tsx
+++ b/src/pages/Admin/EventsComponent.tsx
@@ -11,6 +11,7 @@ import VenueEventDetails from "./VenueEventDetails";
 
 export type EventsComponentProps = {
   venue: WithId<AnyVenue>;
+  worldId: string;
   roomIndex?: number;
   showCreateEventModal: boolean;
   setShowCreateEventModal: Function;
@@ -20,6 +21,7 @@ export type EventsComponentProps = {
 
 const EventsComponent: React.FC<EventsComponentProps> = ({
   venue,
+  worldId,
   showCreateEventModal,
   setShowCreateEventModal,
   editedEvent,
@@ -123,6 +125,7 @@ const EventsComponent: React.FC<EventsComponentProps> = ({
           setEditedEvent && setEditedEvent(undefined);
         }}
         venueId={venue.id}
+        worldId={worldId}
         event={editedEvent}
         template={venue.template}
         setEditedEvent={setEditedEvent}

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -97,6 +97,7 @@ export interface FirestoreOrdered {
   privateChatMessages?: Array<WithId<PrivateChatMessage>>;
   posterVenues?: WithId<PosterPageVenue>[];
   worldUsers?: Array<WithId<User>>;
+  worldEvents?: Array<WithId<VenueEvent>>;
   venueChatMessages?: Array<WithId<VenueChatMessage>>;
   venueEvents?: Array<WithId<VenueEvent>>;
   venues?: Array<WithId<AnyVenue>>;

--- a/src/types/Firestore.ts
+++ b/src/types/Firestore.ts
@@ -97,7 +97,7 @@ export interface FirestoreOrdered {
   privateChatMessages?: Array<WithId<PrivateChatMessage>>;
   posterVenues?: WithId<PosterPageVenue>[];
   worldUsers?: Array<WithId<User>>;
-  worldEvents?: Array<WithId<VenueEvent>>;
+  worldEvents?: WithId<VenueEvent>[];
   venueChatMessages?: Array<WithId<VenueChatMessage>>;
   venueEvents?: Array<WithId<VenueEvent>>;
   venues?: Array<WithId<AnyVenue>>;

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -309,6 +309,8 @@ export interface VenueEvent {
   host: string;
   room?: string;
   id?: string;
+  venueId?: string;
+  worldId?: string;
 }
 
 export const isVenueWithRooms = (venue: AnyVenue): venue is PartyMapVenue =>


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/699

~~**Edit by @0xdevalias**: Note: We should probably merge https://github.com/sparkletown/sparkle/pull/1368 first, and then use aspects of it in this PR.~~ this is merged into `staging` now, so this PR just needs to be updated with it.

---

After a few rounds of thinking on how to approach it, I came to a conclusion that we should reuse the architecture of users (which will be changed, once the `world architecture concept` is finally implemented).

A few things to consider:

- the API will be similar to `useConnectRelatedVenues` and will be derived from `worldEvents` (filtered by `venueId`),
- the venues are already fetched and used across the app (for checking if it is a venue or external link) and as a temporary solution, we can reuse it)
- there can be a problem with `sovereignId` on the admin side and I'm open to suggestions on how to implement in
- we probably need to write a script to add the missing bits of data to every event
- add `worldId`/`venueId` to every place, where event can be created (admin v1, admin v2)
- anything else???

![image](https://user-images.githubusercontent.com/63194656/117367673-29ee2880-aecb-11eb-9f37-680a06088d44.png)
