### PR TITLE
fix grabbing events from venues instead of rooms

### DIFF
--- a/src/components/molecules/Schedule/Schedule.tsx
+++ b/src/components/molecules/Schedule/Schedule.tsx
@@ -4,7 +4,7 @@ import { format, fromUnixTime, getUnixTime } from "date-fns";
 import { range } from "lodash";
 import { useCss } from "react-use";
 
-import { RoomWithEvents, ScheduleProps } from "./Schedule.types";
+import { VenueWithEvents, ScheduleProps } from "./Schedule.types";
 
 import { calcStartPosition } from "./Schedule.utils";
 
@@ -26,9 +26,9 @@ export const Schedule: React.FC<ScheduleProps> = ({ scheduleDay }) => {
     [scheduleDay]
   );
 
-  const roomStartHour = useCallback(
-    (room: RoomWithEvents) =>
-      room.events?.reduce(
+  const venueStartHour = useCallback(
+    (venue: VenueWithEvents) =>
+      venue.events?.reduce(
         (acc, event) => Math.min(acc, getStartHour(event.start_utc_seconds)),
         MAX_SCHEDULE_START_HOUR
       ) ?? MAX_SCHEDULE_START_HOUR,
@@ -38,10 +38,10 @@ export const Schedule: React.FC<ScheduleProps> = ({ scheduleDay }) => {
   const scheduleStartHour = useMemo(
     () =>
       Math.min(
-        ...scheduleDay.rooms.map((room) => roomStartHour(room)),
+        ...scheduleDay.venues.map((venue) => venueStartHour(venue)),
         MAX_SCHEDULE_START_HOUR
       ),
-    [scheduleDay, roomStartHour]
+    [scheduleDay, venueStartHour]
   );
 
   const hours = useMemo(
@@ -56,7 +56,7 @@ export const Schedule: React.FC<ScheduleProps> = ({ scheduleDay }) => {
   );
 
   const containerVars = useCss({
-    "--room-count": scheduleDay.rooms.length + 1,
+    "--room-count": scheduleDay.venues.length + 1,
     "--current-time--position": calcStartPosition(
       Math.floor(getUnixTime(Date.now())),
       scheduleStartHour
@@ -78,11 +78,11 @@ export const Schedule: React.FC<ScheduleProps> = ({ scheduleDay }) => {
             {scheduleDay.personalEvents.length} events
           </span>
         </div>
-        {scheduleDay.rooms.map((room) => (
-          <div key={room.title} className="ScheduledEvents__room">
-            <p className="ScheduledEvents__room-title">{room.title}</p>
+        {scheduleDay.venues.map((venue) => (
+          <div key={venue.name} className="ScheduledEvents__room">
+            <p className="ScheduledEvents__room-title">{venue.name}</p>
             <span className="ScheduledEvents__events-count">
-              {room.events?.length || 0} events
+              {venue.events?.length || 0} events
             </span>
           </div>
         ))}
@@ -108,9 +108,9 @@ export const Schedule: React.FC<ScheduleProps> = ({ scheduleDay }) => {
             scheduleStartHour={scheduleStartHour}
           />
         </div>
-        {scheduleDay.rooms.map((room) => (
+        {scheduleDay.venues.map((room) => (
           <ScheduleRoomEvents
-            key={room.title}
+            key={room.name}
             events={room.events}
             scheduleStartHour={scheduleStartHour}
           />

--- a/src/components/molecules/Schedule/Schedule.types.ts
+++ b/src/components/molecules/Schedule/Schedule.types.ts
@@ -1,8 +1,8 @@
-import { Room } from "types/rooms";
+import { AnyVenue } from "types/venues";
 import { PersonalizedVenueEvent } from "types/venues";
 import { WithVenueId } from "utils/id";
 
-export type RoomWithEvents = Room & {
+export type VenueWithEvents = AnyVenue & {
   events: WithVenueId<PersonalizedVenueEvent>[];
 };
 
@@ -10,7 +10,7 @@ export interface ScheduleDay {
   isToday: boolean;
   weekday: string;
   dayStartUtcSeconds: number;
-  rooms: RoomWithEvents[];
+  venues: VenueWithEvents[];
   personalEvents: WithVenueId<PersonalizedVenueEvent>[];
 }
 

--- a/src/components/molecules/ScheduleEvent/ScheduleEvent.tsx
+++ b/src/components/molecules/ScheduleEvent/ScheduleEvent.tsx
@@ -15,7 +15,7 @@ import { PersonalizedVenueEvent } from "types/venues";
 
 import { WithVenueId } from "utils/id";
 import { isTruthy } from "utils/types";
-import { isEventLive } from "utils/event";
+// import { isEventLive } from "utils/event";
 
 import { ONE_HOUR_IN_MINUTES } from "utils/time";
 
@@ -49,9 +49,9 @@ export const ScheduleEvent: React.FC<ScheduleEventProps> = ({
     () =>
       classNames(
         "ScheduleEvent",
-        {
-          "ScheduleEvent--live": isEventLive(event),
-        },
+        // {
+        //   "ScheduleEvent--live": isEventLive(event),
+        // },
         { "ScheduleEvent--users": isTruthy(isUsers) }
       ),
     [event, isUsers]

--- a/src/components/organisms/SchedulePageModal/utils.ts
+++ b/src/components/organisms/SchedulePageModal/utils.ts
@@ -8,15 +8,15 @@ import {
   startOfDay,
 } from "date-fns";
 
-import { Room } from "types/rooms";
+import { AnyVenue } from "types/venues";
 import { PersonalizedVenueEvent, VenueEvent } from "types/venues";
 import { MyPersonalizedSchedule } from "types/User";
 
-import { WithVenueId } from "utils/id";
+import { WithVenueId, WithId } from "utils/id";
 import { eventEndTime, eventStartTime } from "utils/event";
 import { isTruthy } from "utils/types";
 
-import { RoomWithEvents } from "components/molecules/Schedule/Schedule.types";
+import { VenueWithEvents } from "components/molecules/Schedule/Schedule.types";
 
 export const isEventLaterThisDay = (date: number | Date) => (
   event: VenueEvent
@@ -26,15 +26,16 @@ export const isEventLaterThisDay = (date: number | Date) => (
     end: eventEndTime(event),
   });
 
-export const extendRoomsWithDaysEvents = (
-  rooms: Room[],
+export const extendVenuesWithDaysEvents = (
+  venues: WithId<AnyVenue>[],
   daysEvents: WithVenueId<PersonalizedVenueEvent>[]
-): RoomWithEvents[] => {
-  return rooms.map((room) => {
+): VenueWithEvents[] => {
+  //@ts-ignore
+  return venues.map((venue) => {
     const events: WithVenueId<PersonalizedVenueEvent>[] = daysEvents.filter(
-      (event) => event?.room === room?.title
+      (event) => event?.venueId === venue.id
     );
-    return { ...room, events };
+    return { ...venue, events };
   });
 };
 

--- a/src/types/UpcomingEvent.ts
+++ b/src/types/UpcomingEvent.ts
@@ -1,4 +1,5 @@
 export interface UpcomingEvent {
+  start_utc_seconds: number;
   ts_utc: firebase.firestore.Timestamp;
   url: string;
   name: string;


### PR DESCRIPTION
There is still an issue with the isEventLive in ScheduleEvents throwing an error (commented out in order to run here), but this is my quick and dirty fix to switch the new schedule from only using rooms to using venues. Thought there might be something useful in it for fixing up the new schedule UI...