### PR TITLE
[env/ohbm] set venuePage HTML document title basing off PLATFORM_BRAND_NAME

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,7 +26,7 @@ export const SPARKLEVERSE_TERMS_AND_CONDITIONS_URL =
   "https://sparklever.se/terms-and-conditions";
 export const SPARKLEVERSE_PRIVACY_POLICY =
   "https://sparklever.se/privacy-policy/";
-export const PLATFORM_BRAND_NAME = "Sparkle";
+export const PLATFORM_BRAND_NAME = "OHBM2021";
 
 export const HOMEPAGE_URL = IS_BURN
   ? SPARKLEVERSE_HOMEPAGE_URL


### PR DESCRIPTION
This greatly improves UX (User eXperience) by not only making page/tab
show the location, but also making browser history useful.  Without this
change you get the exciting "Sparkle" as the title (hardcoded in index.html)
for every page.

Joint work with @margulies where I was "git grep"ing and he was editing and trying it out.

1st commit is generic and could be applied (cherrypicked) to the main code base.  2nd commit is OHBM vendoring. Let me know if there is another/better way to vendor it.