### PR TITLE
wrap "Enter" into <a> to be able to open new tab/window from RoomModal

### DIFF
--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
@@ -108,6 +108,7 @@ export const RoomModalContent: React.FC<RoomModalContentProps> = ({
         <RoomModalOngoingEvent
           roomEvents={roomEvents}
           onRoomEnter={enterRoomWithSound}
+          roomUrl={room.url}
         />
       </div>
 

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
@@ -15,12 +15,14 @@ import "./RoomModalOngoingEvent.scss";
 interface RoomModalOngoingEventProps {
   roomEvents: VenueEvent[];
   onRoomEnter: () => void;
+  roomUrl: string;
   joinButtonText?: string;
 }
 
 export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
   roomEvents,
   onRoomEnter,
+  roomUrl,
   joinButtonText,
 }) => {
   const dispatch = useDispatch();
@@ -65,7 +67,7 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
         className="btn btn-primary room-entry-button"
         onClick={onRoomEnter}
       >
-        {joinButtonText ?? "Enter"}
+        <a href={roomUrl}>{joinButtonText ?? "Enter"}</a>
       </button>
     </div>
   );


### PR DESCRIPTION
partially fixes https://github.com/sparkletown/sparkle/issues/1670

---

Such UX (ability to open a room in a new tab) is desperately needed, in particular
for poster rooms etc, since opening a room can take considerable time of a blue window
of sparkle.

I am not a web developer by any stretch so do not know if this is a best way (most likely not),
and I have not added any guards etc.  May be ideas on
https://stackoverflow.com/a/2906586/1265472
could provide a better solution (e.g. making <button> into <a> with button styling etc)

Please either take over or advise on how to proceed