### PR TITLE
add PLATFORM_BRAND_NAME + set page title in VenuePage based on current venue name

### DIFF
--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Redirect, useHistory } from "react-router-dom";
+import { useTitle } from "react-use";
 
 import { LOC_UPDATE_FREQ_MS } from "settings";
 
@@ -44,6 +45,8 @@ import { LoadingPage } from "components/molecules/LoadingPage/LoadingPage";
 import TemplateWrapper from "./TemplateWrapper";
 
 import { updateTheme } from "./helpers";
+
+import { PLATFORM_BRAND_NAME } from "settings";
 
 import "./VenuePage.scss";
 
@@ -112,6 +115,8 @@ const VenuePage: React.FC = () => {
 
     setLocationData({ userId, locationName: venueName });
   }, [userId, venueName]);
+
+  useTitle(`${PLATFORM_BRAND_NAME} - ${venueName}`);
 
   useEffect(() => {
     if (!userId) return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export const SPARKLEVERSE_TERMS_AND_CONDITIONS_URL =
   "https://sparklever.se/terms-and-conditions";
 export const SPARKLEVERSE_PRIVACY_POLICY =
   "https://sparklever.se/privacy-policy/";
+export const PLATFORM_BRAND_NAME = "Sparkle";
 
 export const HOMEPAGE_URL = IS_BURN
   ? SPARKLEVERSE_HOMEPAGE_URL


### PR DESCRIPTION
This greatly improves UX (User eXperience) by not only making page/tab
show the location, but also making browser history useful.  Without this
change you get the exciting "Sparkle" as the title (hardcoded in index.html)
for every page.

Joint work with @margulies where I was "git grep"ing and he was editing and trying it out.

Originally was sent (with vendoring) as #1386 against `env/ohbm`. This PR contains only the first commit from that PR (cherrypicked), without ohbm vendoring.