### PR TITLE
add support for emojis in chat using react-emoji-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18963,8 +18963,7 @@
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "2.4.1",
@@ -22831,6 +22830,25 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-emoji-render": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-emoji-render/-/react-emoji-render-1.2.4.tgz",
+      "integrity": "sha512-AqktVXV38uDpgf02BoCXrzLYFsHAsxfdWwjrLexSJ22l1JgB01y1KejjxW/zTuCzod6O7BZfiMS866LEEfMHmA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "emoji-regex": "^6.4.1",
+        "lodash.flatten": "^4.4.0",
+        "prop-types": "^15.5.8",
+        "string-replace-to-array": "^1.0.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+          "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+        }
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -25398,6 +25416,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
       "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw=="
+    },
+    "string-replace-to-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string-replace-to-array/-/string-replace-to-array-1.0.3.tgz",
+      "integrity": "sha1-yT66mZpe4k1zGuu69auja18Y978=",
+      "requires": {
+        "invariant": "^2.2.1",
+        "lodash.flatten": "^4.2.0",
+        "lodash.isstring": "^4.0.1"
+      }
     },
     "string-width": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-mic": "^12.4.6",
     "react-redux": "^7.2.0",
     "react-redux-firebase": "^3.10.0",
+    "react-emoji-render": "^1.2.4",
     "react-resize-detector": "^5.0.7",
     "react-router-dom": "^5.1.2",
     "react-scripts": "4.0.3",

--- a/src/components/atoms/ChatMessage/ChatMessage.tsx
+++ b/src/components/atoms/ChatMessage/ChatMessage.tsx
@@ -12,6 +12,8 @@ import { useShowHide } from "hooks/useShowHide";
 import { ChatMessageInfo } from "components/atoms/ChatMessageInfo";
 import { TextButton } from "components/atoms/TextButton";
 
+import Emoji from "react-emoji-render";
+
 import "./ChatMessage.scss";
 
 export interface ChatProps {
@@ -42,7 +44,7 @@ export const ChatMessage: React.FC<ChatProps> = ({
     () =>
       replies?.map((reply) => (
         <div key={reply.id} className="ChatMessage__reply">
-          {reply.text}
+          <Emoji text={reply.text} />
           <ChatMessageInfo
             message={reply}
             deleteMessage={() => deleteMessage(reply.id)}
@@ -68,8 +70,9 @@ export const ChatMessage: React.FC<ChatProps> = ({
     <div className={containerStyles}>
       <div className="ChatMessage__bulb">
         <div className="ChatMessage__text-content">
-          <div className="ChatMessage__text">{text}</div>
-
+          <div className="ChatMessage__text">
+            <Emoji text={text} />
+          </div>
           <div className="ChatMessage__reply-icon">
             <FontAwesomeIcon
               icon={faReply}


### PR DESCRIPTION
Closes #1393 

This PR introduces base support, no completions/shortcuts etc for emoji's - just rendering.

https://www.npmjs.com/package/react-emoji-render says license MIT but didn't check licenses of the libraries it uses.

<details>
<summary>
example on ohbm instance:
</summary> 

![image](https://user-images.githubusercontent.com/39889/118313790-45f05c00-b4c1-11eb-9e79-40801fe64dc5.png)

</details>

not sure if this would be an optimal solution if decided to proceed with emoji-picker (#1395) but may be they could be made to play together nicely.