### PR TITLE
add venue details information card + showInfo setting

### DIFF
--- a/src/components/molecules/InformationCard/InformationCard.tsx
+++ b/src/components/molecules/InformationCard/InformationCard.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import "./InformationCard.scss";
 
 export interface InformationCardProps {
-  title: string;
+  title?: string;
   children: React.ReactNode;
   className?: string;
 }
@@ -15,7 +15,7 @@ const InformationCard: React.FC<InformationCardProps> = ({
   className,
 }) => (
   <div className={classNames("information-card-container", className)}>
-    <h4 className="title">{title}</h4>
+    {title && <h4 className="title">{title}</h4>}
     <div className="information-card-text">{children}</div>
   </div>
 );

--- a/src/components/organisms/WithInformationCard/WithInformationCard.scss
+++ b/src/components/organisms/WithInformationCard/WithInformationCard.scss
@@ -1,0 +1,10 @@
+.information-title {
+  font-size: 22px;
+  font-weight: bold;
+}
+.information-subtitle {
+  font-size: 18px;
+}
+.information-description {
+  font-size: 18px;
+}

--- a/src/components/organisms/WithInformationCard/WithInformationCard.tsx
+++ b/src/components/organisms/WithInformationCard/WithInformationCard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { AnyVenue } from "types/venues";
+
+import { InformationLeftColumn } from "components/organisms/InformationLeftColumn";
+import InformationCard from "components/molecules/InformationCard";
+
+import "./WithInformationCard.scss";
+
+interface PropsType {
+  venue: AnyVenue;
+  showInfo?: boolean;
+}
+
+export const WithInformationCard: React.FunctionComponent<PropsType> = ({
+  venue,
+  showInfo = false,
+}) => (
+  <>
+    {showInfo && (
+      <InformationLeftColumn iconNameOrPath={venue?.host?.icon || "info"}>
+        <InformationCard>
+          <p className="information-title">{venue.name}</p>
+          {venue.config?.landingPageConfig.subtitle && (
+            <p className="information-subtitle">
+              {venue.config?.landingPageConfig.subtitle}
+            </p>
+          )}
+          {venue.config?.landingPageConfig.description && (
+            <p className="information-description">
+              {venue.config?.landingPageConfig.description}
+            </p>
+          )}
+        </InformationCard>
+      </InformationLeftColumn>
+    )}
+  </>
+);

--- a/src/components/organisms/WithInformationCard/index.ts
+++ b/src/components/organisms/WithInformationCard/index.ts
@@ -1,0 +1,1 @@
+export { WithInformationCard } from "./WithInformationCard";

--- a/src/pages/VenuePage/TemplateWrapper.tsx
+++ b/src/pages/VenuePage/TemplateWrapper.tsx
@@ -24,6 +24,7 @@ import { ReactionPage } from "components/templates/ReactionPage";
 import { ChatSidebar } from "components/organisms/ChatSidebar";
 import { UserProfileModal } from "components/organisms/UserProfileModal";
 import { WithNavigationBar } from "components/organisms/WithNavigationBar";
+import { WithInformationCard } from "components/organisms/WithInformationCard";
 
 import { AnnouncementMessage } from "components/molecules/AnnouncementMessage";
 
@@ -142,6 +143,7 @@ const TemplateWrapper: React.FC<TemplateWrapperProps> = ({ venue }) => {
     <ReactionsProvider venueId={venue.id}>
       <WithNavigationBar fullscreen={fullscreen} hasBackButton={hasBackButton}>
         <AnnouncementMessage message={venue.bannerMessage} />
+        <WithInformationCard venue={venue} showInfo={venue?.showInfo} />
         {template}
         <ChatSidebar />
         <UserProfileModal />

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -145,6 +145,7 @@ export interface BaseVenue {
   hideVideo?: boolean;
   showLiveSchedule?: boolean;
   showGrid?: boolean;
+  showInfo?: boolean;
   roomVisibility?: RoomVisibility;
   rooms?: Room[];
   width: number;


### PR DESCRIPTION
This allows the option for each venue to show a left column information card. This is relevent to the env/ohbm educational courses, but I made the PR to staging as it is a general feature. Just let me know if the PR branch should be changed