### PR TITLE
autolink URLs in chat messages using getLinkFromText

### DIFF
--- a/src/components/atoms/ChatMessage/ChatMessage.tsx
+++ b/src/components/atoms/ChatMessage/ChatMessage.tsx
@@ -5,6 +5,8 @@ import { faReply } from "@fortawesome/free-solid-svg-icons";
 
 import { MessageToDisplay } from "types/chat";
 
+import { getLinkFromText } from "utils/getLinkFromText";
+
 import { WithId } from "utils/id";
 
 import { useShowHide } from "hooks/useShowHide";
@@ -42,7 +44,7 @@ export const ChatMessage: React.FC<ChatProps> = ({
     () =>
       replies?.map((reply) => (
         <div key={reply.id} className="ChatMessage__reply">
-          {reply.text}
+          {getLinkFromText(reply.text)}
           <ChatMessageInfo
             message={reply}
             deleteMessage={() => deleteMessage(reply.id)}
@@ -68,7 +70,7 @@ export const ChatMessage: React.FC<ChatProps> = ({
     <div className={containerStyles}>
       <div className="ChatMessage__bulb">
         <div className="ChatMessage__text-content">
-          <div className="ChatMessage__text">{text}</div>
+          <div className="ChatMessage__text">{getLinkFromText(text)}</div>
 
           <div className="ChatMessage__reply-icon">
             <FontAwesomeIcon


### PR DESCRIPTION
Thanks @margulies for the pointer to the existing function!

I have first tried to mess around on top of #1394 with ad-hoc function (pushed that mess to https://github.com/yarikoptic/sparkle/commit/0503b269ecfc6278ab776758ef75ab47e1b40991) but then @margulies pointed me to this one and the fix was trivial to implement.  Closes #1406 

Would conflict with #1394 and I am yet to see what is the best way to "merge" the two, and we are yet to decide on how to proceed with #1394.  In my personal preference I think emoji support is more "valuable" but I hope we will not need to choose one over another

edit: ha -- for emojis, adding Emoji instead of fragment right in that getLinkFromText works nicely:

<details>
<summary>the patch</summary> 

```diff
--- a/src/utils/getLinkFromText.tsx
+++ b/src/utils/getLinkFromText.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import Emoji from "react-emoji-render";
+
 import { isExternalUrl, getExtraLinkProps } from "./url";
 
 export const getLinkFromText = (text: string) => {
@@ -24,7 +26,7 @@ export const getLinkFromText = (text: string) => {
         </a>
       );
     } else {
-      return <React.Fragment key={index}>{word} </React.Fragment>;
+      return <Emoji text={word} />;
     }
   });
 };

```
</details>

<details>
<summary>the looks</summary> 

![image](https://user-images.githubusercontent.com/39889/118401832-34c85c00-b635-11eb-9b87-8c9174c4f661.png)

</details>
which show the defect -- absent space between words then, so slight tune up will be needed