### PR TITLE
add support for custom default avatars

### DIFF
--- a/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
+++ b/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
@@ -42,6 +42,7 @@ const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = (
   const firebase = useFirebase();
   const uploadRef = useRef<HTMLInputElement>(null);
 
+  // @debt Replace fetchSovereignVenueId with useSovereignVenueId, when the hook is refactored to accept venueId as a param.
   const {
     value: sovereignVenueId,
     loading: isLoadingSovereignVenueId,

--- a/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
+++ b/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
@@ -14,13 +14,12 @@ import {
 
 import { resizeFile } from "utils/image";
 
-import { useQuery } from "hooks/useQuery";
-
 import "./ProfilePictureInput.scss";
 
 type Reference = ReturnType<FirebaseStorage["ref"]>;
 
 interface ProfilePictureInputProps {
+  venueId: string;
   setValue: (inputName: string, value: string, rerender: boolean) => void;
   user: UserInfo;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,6 +30,7 @@ interface ProfilePictureInputProps {
 }
 
 const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = ({
+  venueId,
   setValue,
   user,
   errors,
@@ -41,8 +41,6 @@ const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = (
   const [error, setError] = useState("");
   const firebase = useFirebase();
   const uploadRef = useRef<HTMLInputElement>(null);
-  const queryParams = useQuery();
-  const venueId = queryParams.get("venueId") ?? "";
 
   const {
     value: sovereignVenueId,

--- a/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
+++ b/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
@@ -102,7 +102,9 @@ const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = (
     [setValue]
   );
 
-  const isLoading = isLoadingCustomAvatars || isLoadingSovereignVenueId;
+  const isLoading =
+    (isLoadingSovereignVenueId || isLoadingCustomAvatars) &&
+    (customAvatars !== undefined || error !== undefined);
 
   const defaultAvatars = customAvatars?.length
     ? customAvatars

--- a/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
+++ b/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
@@ -110,21 +110,19 @@ const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = (
     : DEFAULT_AVATARS;
 
   const avatarImages = useMemo(() => {
-    return defaultAvatars.map((avatar, index) => {
-      return (
-        <div
-          key={`${avatar}-${index}`}
-          className="profile-picture-preview-container"
-          onClick={() => uploadDefaultAvatar(avatar)}
-        >
-          <img
-            src={`${avatar}`}
-            className="profile-icon profile-picture-preview"
-            alt="your profile"
-          />
-        </div>
-      );
-    });
+    return defaultAvatars.map((avatar, index) => (
+      <div
+        key={`${avatar}-${index}`}
+        className="profile-picture-preview-container"
+        onClick={() => uploadDefaultAvatar(avatar)}
+      >
+        <img
+          src={avatar}
+          className="profile-icon profile-picture-preview"
+          alt={`default avatar ${index}`}
+        />
+      </div>
+    ));
   }, [defaultAvatars, uploadDefaultAvatar]);
 
   return (
@@ -158,8 +156,7 @@ const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputProps> = (
       {error && <small>Error uploading: {error}</small>}
       <small>Or pick one from our Sparkle profile pics</small>
       <div className="default-avatars-container">
-        {isLoading && <div>Loading...</div>}
-        {!isLoading && avatarImages}
+        {isLoading ? <div>Loading...</div> : avatarImages}
       </div>
       <input
         name="pictureUrl"

--- a/src/components/organisms/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/organisms/EditProfileModal/EditProfileModal.tsx
@@ -1,16 +1,22 @@
 import React, { useEffect } from "react";
 import { Modal } from "react-bootstrap";
 import { useForm } from "react-hook-form";
-import "./EditProfileModal.scss";
+
+import { useUser } from "hooks/useUser";
+import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
+
+import { currentVenueSelectorData } from "utils/selectors";
+
+import { QuestionType } from "types/Question";
+
 import { ProfileFormData } from "pages/Account/Profile";
 import { QuestionsFormData } from "pages/Account/Questions";
 import { updateUserProfile } from "pages/Account/helpers";
-import { QuestionType } from "types/Question";
 import ProfilePictureInput from "components/molecules/ProfilePictureInput";
 import { DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
-import { currentVenueSelectorData } from "utils/selectors";
+
+import "./EditProfileModal.scss";
 
 interface PropsType {
   show: boolean;
@@ -21,6 +27,7 @@ const EditProfileModal: React.FunctionComponent<PropsType> = ({
   show,
   onHide,
 }) => {
+  const venueId = useVenueId();
   const { user, profile } = useUser();
   const profileQuestions = useSelector(
     (state) => currentVenueSelectorData(state)?.profile_questions
@@ -87,8 +94,9 @@ const EditProfileModal: React.FunctionComponent<PropsType> = ({
                 less
               </span>
             )}
-            {user && (
+            {user && venueId && (
               <ProfilePictureInput
+                venueId={venueId}
                 setValue={setValue}
                 user={user}
                 errors={errors}

--- a/src/components/organisms/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/organisms/EditProfileModal/EditProfileModal.tsx
@@ -2,19 +2,20 @@ import React, { useEffect } from "react";
 import { Modal } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
-import { useVenueId } from "hooks/useVenueId";
+import { DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
+
+import { QuestionType } from "types/Question";
 
 import { currentVenueSelectorData } from "utils/selectors";
 
-import { QuestionType } from "types/Question";
+import { useUser } from "hooks/useUser";
+import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
 
 import { ProfileFormData } from "pages/Account/Profile";
 import { QuestionsFormData } from "pages/Account/Questions";
 import { updateUserProfile } from "pages/Account/helpers";
 import ProfilePictureInput from "components/molecules/ProfilePictureInput";
-import { DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
 
 import "./EditProfileModal.scss";
 

--- a/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
+++ b/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
-import "./EditProfileForm.scss";
+
+import { DEFAULT_PROFILE_IMAGE, DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
+
+import { useUser } from "hooks/useUser";
+import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
+
+import { currentVenueSelectorData } from "utils/selectors";
+
+import { QuestionType } from "types/Question";
+
 import { ProfileFormData } from "pages/Account/Profile";
 import { QuestionsFormData } from "pages/Account/Questions";
 import { updateUserProfile } from "pages/Account/helpers";
-import { QuestionType } from "types/Question";
 import ProfilePictureInput from "components/molecules/ProfilePictureInput";
-import { useUser } from "hooks/useUser";
-import { DEFAULT_PROFILE_IMAGE, DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
-import { useSelector } from "hooks/useSelector";
-import { currentVenueSelectorData } from "utils/selectors";
+
+import "./EditProfileForm.scss";
 
 interface PropsType {
   setIsEditMode: (value: boolean) => void;
@@ -18,6 +25,7 @@ interface PropsType {
 const EditProfileForm: React.FunctionComponent<PropsType> = ({
   setIsEditMode,
 }) => {
+  const venueId = useVenueId();
   const { user, profile } = useUser();
   const profileQuestions = useSelector(
     (state) => currentVenueSelectorData(state)?.profile_questions
@@ -82,8 +90,9 @@ const EditProfileForm: React.FunctionComponent<PropsType> = ({
               less
             </span>
           )}
-          {user && (
+          {user && venueId && (
             <ProfilePictureInput
+              venueId={venueId}
               setValue={setValue}
               user={user}
               errors={errors}

--- a/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
+++ b/src/components/organisms/ProfileModal/EditProfileForm/EditProfileForm.tsx
@@ -3,13 +3,13 @@ import { useForm } from "react-hook-form";
 
 import { DEFAULT_PROFILE_IMAGE, DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
 
-import { useUser } from "hooks/useUser";
-import { useSelector } from "hooks/useSelector";
-import { useVenueId } from "hooks/useVenueId";
+import { QuestionType } from "types/Question";
 
 import { currentVenueSelectorData } from "utils/selectors";
 
-import { QuestionType } from "types/Question";
+import { useUser } from "hooks/useUser";
+import { useSelector } from "hooks/useSelector";
+import { useVenueId } from "hooks/useVenueId";
 
 import { ProfileFormData } from "pages/Account/Profile";
 import { QuestionsFormData } from "pages/Account/Questions";

--- a/src/pages/Account/Profile.tsx
+++ b/src/pages/Account/Profile.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
-import { updateUserProfile } from "./helpers";
 import "firebase/storage";
-import "./Account.scss";
-import ProfilePictureInput from "components/molecules/ProfilePictureInput";
-import { RouterLocation } from "types/RouterLocation";
-import { useUser } from "hooks/useUser";
+
 import { IS_BURN } from "secrets";
-import getQueryParameters from "utils/getQueryParameters";
+
 import { DEFAULT_VENUE, DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
+
 import { useVenueId } from "hooks/useVenueId";
+import { useUser } from "hooks/useUser";
+
+import getQueryParameters from "utils/getQueryParameters";
+
+import { RouterLocation } from "types/RouterLocation";
+
+import { updateUserProfile } from "./helpers";
+
+import ProfilePictureInput from "components/molecules/ProfilePictureInput";
+
+import "./Account.scss";
 
 export interface ProfileFormData {
   partyName: string;
@@ -90,6 +98,7 @@ const Profile: React.FunctionComponent<PropsType> = ({ location }) => {
             )}
             {user && (
               <ProfilePictureInput
+                venueId={venueId}
                 setValue={setValue}
                 user={user}
                 errors={errors}

--- a/src/pages/Account/Profile.tsx
+++ b/src/pages/Account/Profile.tsx
@@ -7,12 +7,12 @@ import { IS_BURN } from "secrets";
 
 import { DEFAULT_VENUE, DISPLAY_NAME_MAX_CHAR_COUNT } from "settings";
 
-import { useVenueId } from "hooks/useVenueId";
-import { useUser } from "hooks/useUser";
+import { RouterLocation } from "types/RouterLocation";
 
 import getQueryParameters from "utils/getQueryParameters";
 
-import { RouterLocation } from "types/RouterLocation";
+import { useVenueId } from "hooks/useVenueId";
+import { useUser } from "hooks/useUser";
 
 import { updateUserProfile } from "./helpers";
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -556,6 +556,13 @@ export const RANDOM_AVATARS = [
   "avatar-12.png",
 ];
 
+export const DEFAULT_AVATARS = [
+  "/avatars/default-profile-pic-1.png",
+  "/avatars/default-profile-pic-2.png",
+  "/avatars/default-profile-pic-3.png",
+  "/avatars/default-profile-pic-4.png",
+];
+
 export const REACTION_TIMEOUT = 5000; // time in ms
 export const SHOW_EMOJI_IN_REACTION_PAGE = true;
 


### PR DESCRIPTION
Custom avatars are now fetched and used if they exist in the database. Otherwise the component fallbacks to the default ones.
This is a partial implementation of the whole feature. As already discussed with Sofi, the admin part of this is (optional) for now, but will be required in the near future.

Partially fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/673