### PR TITLE
Added pdf uploader for posterpage template

### DIFF
--- a/src/components/organisms/PosterPageAdmin/PosterPageAdmin.scss
+++ b/src/components/organisms/PosterPageAdmin/PosterPageAdmin.scss
@@ -1,0 +1,25 @@
+.ppa {
+  padding: 10px 20px;
+  background-color: #333;
+  border-radius: 10px;
+  margin-top: 20px;
+
+  .ppa-header {
+    font-weight: bold;
+    line-height: 200%;
+  }
+  .ppa-submit {
+    margin: 10px 0;
+    float: right;
+  }
+  iframe {
+    margin-top: 10px;
+    width: 100%;
+    height: 350px;
+    border: 0;
+  }
+
+  br.clear {
+    clear: both;
+  }
+}

--- a/src/components/organisms/PosterPageAdmin/PosterPageAdmin.tsx
+++ b/src/components/organisms/PosterPageAdmin/PosterPageAdmin.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+
+import firebase from "firebase/app";
+
+import { AnyVenue } from "types/venues";
+import { UserInfo } from "firebase/app";
+
+import "./PosterPageAdmin.scss";
+
+interface PosterPageAdminProps {
+  user: UserInfo;
+  venueId?: string;
+  venue: AnyVenue;
+}
+
+// @debt This component is almost exactly the same as IframeAdmin, we should refactor them both to use the same generic base component
+//   BannerAdmin is the 'canonical example' to follow when we do this
+export const PosterPageAdmin: React.FC<PosterPageAdminProps> = ({
+  user,
+  venueId,
+  venue,
+}) => {
+  //const pdfPath = 'posters/'+user.uid+'/'+venueId+".pdf";
+  const pdfPath = "posters/" + venueId + ".pdf";
+
+  const [url, setUrl] = useState<string>();
+  function findURL() {
+    const storageRef = firebase.storage().ref();
+    const pdfRef = storageRef.child(pdfPath);
+    pdfRef.getDownloadURL().then(setUrl).catch(console.error);
+  }
+
+  findURL();
+
+  //const url = firebase.storage().refFromURL('gs://posters/poster1042.pdf');
+  //console.log("path", url);
+
+  //const [error, setError] = useState<string | null>();
+  const [pdfFile, setPdfFile] = useState<File>();
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    setPdfFile(e.target.files[0]);
+  };
+
+  const [uploading, setUploading] = useState<boolean>();
+  const savePDF = () => {
+    if (!pdfFile) return;
+
+    const storageRef = firebase.storage().ref();
+    const metadata = {
+      customMetadata: {
+        owners: venue.owners.join(), //can't store array
+      },
+    };
+
+    setUploading(true);
+    storageRef
+      .child(pdfPath)
+      .put(pdfFile, metadata)
+      .then((snapshot) => {
+        setUploading(false);
+        findURL();
+      })
+      .catch((err) => {
+        setUploading(false);
+        console.error(err);
+      });
+  };
+
+  return (
+    <div className="container">
+      <div className="ppa">
+        <span className="ppa-header">PDF</span>
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={handleFileChange}
+        />
+        {url && <iframe title="pdf-preview" src={url} />}
+        {uploading ? (
+          <span className="ppa-submit">Uploading..</span>
+        ) : (
+          <button
+            className="btn btn-primary ppa-submit"
+            type="button"
+            onClick={savePDF}
+          >
+            Upload PDF
+          </button>
+        )}
+        <br className="clear" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/organisms/PosterPageAdmin/index.ts
+++ b/src/components/organisms/PosterPageAdmin/index.ts
@@ -1,0 +1,1 @@
+export { PosterPageAdmin } from "./PosterPageAdmin";

--- a/src/pages/Admin/Venue/VenueAdminPage.tsx
+++ b/src/pages/Admin/Venue/VenueAdminPage.tsx
@@ -16,6 +16,7 @@ import { useConnectCurrentVenueNG } from "hooks/useConnectCurrentVenueNG";
 import { LoadingPage } from "components/molecules/LoadingPage";
 import { IframeAdmin } from "components/molecules/IframeAdmin";
 import { BannerAdmin } from "components/organisms/BannerAdmin";
+import { PosterPageAdmin } from "components/organisms/PosterPageAdmin";
 
 import "./VenueAdminPage.scss";
 
@@ -55,6 +56,9 @@ export const VenueAdminPage: React.FC = () => {
       <h4 className="admin-page-title">You are editing venue: {venue.name}</h4>
       <BannerAdmin venueId={venueId} venue={venue} />
       {isIframeVenue && <IframeAdmin venueId={venueId} venue={venue} />}
+      {venue.template === "posterpage" && user && (
+        <PosterPageAdmin user={user} venueId={venueId} venue={venue} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
This change adds the capability to upload a pdf file by the poster admin.

![image](https://user-images.githubusercontent.com/923896/118423507-214bde00-b693-11eb-88b6-bbf7ac993f11.png)

On firebase / storage, I've added the following rule

```
    match /posters/{allPaths=**} {
        allow read
        allow write: if request.auth != null;
        allow update: if resource.metadata.owners.matches(".*"+request.auth.uid+".*");
    }
``` 

If poster is already uploaded, it does the auth check using the `customMetadata.owners` as set by the UI code, but if the file doesn't exist, I couldn't figure out a good way to check if the user is *supposed to be* able to upload the poster or not. I think this can be mitigated by pre-uploading all posters before hand (I have a backend script for that). And update can be done if the user is listed in the owners list.