### PR TITLE
add optional scheduleStartDate to DB + force NavBarSchedule to start from that date when present

### DIFF
--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -82,6 +82,8 @@ export const NavBarSchedule: FC<NavBarScheduleProps> = ({ isVisible }) => {
       : startOfToday();
   }, [scheduledStartDate]);
 
+  const isScheduleTimeshifted = !isToday(firstDayOfSchedule);
+
   const {
     isEventsLoading,
     events: relatedVenueEvents = emptyRelatedEvents,
@@ -94,10 +96,12 @@ export const NavBarSchedule: FC<NavBarScheduleProps> = ({ isVisible }) => {
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
 
   const weekdays = useMemo(() => {
-    const formatDayLabel = (day: Date) => {
-      if (isToday(day)) return "Today";
-      if (isToday(firstDayOfSchedule)) return format(day, "E");
-      return format(day, "E, LLL d");
+    const formatDayLabel = (day: Date | number) => {
+      if (isScheduleTimeshifted) {
+        return format(day, "E, LLL d");
+      } else {
+        return isToday(day) ? "Today" : format(day, "E");
+      }
     };
 
     return range(0, SCHEDULE_SHOW_DAYS_AHEAD).map((dayIndex) => {
@@ -120,7 +124,7 @@ export const NavBarSchedule: FC<NavBarScheduleProps> = ({ isVisible }) => {
         </li>
       );
     });
-  }, [selectedDayIndex, firstDayOfSchedule]);
+  }, [selectedDayIndex, firstDayOfSchedule, isScheduleTimeshifted]);
 
   const getEventLocation = useCallback(
     (locString: string): VenueLocation => {

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -171,7 +171,6 @@ export interface BaseVenue {
   showRadio?: boolean;
   showBadges?: boolean;
   showZendesk?: boolean;
-  scheduleStartDate?: firebase.firestore.Timestamp;
 }
 
 export interface GenericVenue extends BaseVenue {

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -171,7 +171,7 @@ export interface BaseVenue {
   showRadio?: boolean;
   showBadges?: boolean;
   showZendesk?: boolean;
-  scheduleStartDate?: number;
+  scheduleStartDate?: firebase.firestore.Timestamp;
 }
 
 export interface GenericVenue extends BaseVenue {

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -171,6 +171,7 @@ export interface BaseVenue {
   showRadio?: boolean;
   showBadges?: boolean;
   showZendesk?: boolean;
+  scheduleStartDate?: number;
 }
 
 export interface GenericVenue extends BaseVenue {


### PR DESCRIPTION
Added an initial fix to enable setting the start date for the schedule using `start_utc_seconds` in `venue`. Planning to develop this further, but having this feature available for testing purposes would be helpful at this stage.