### PR TITLE
fix CircleCI config to allow firebase deploy to remove deleted functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,12 @@ jobs:
             fi
 
             ./node_modules/.bin/firebase use $ENV --token "$FIREBASE_TOKEN"
-            ./node_modules/.bin/firebase deploy --only functions --token "$FIREBASE_TOKEN"
+
+            # -f, --force: delete Cloud Functions missing from the current working directory without confirmation
+            ./node_modules/.bin/firebase deploy --only functions --token "$FIREBASE_TOKEN --force"
+
             ./node_modules/.bin/firebase deploy --only firestore:rules --token "$FIREBASE_TOKEN"
+
             ./node_modules/.bin/firebase deploy --only storage --token "$FIREBASE_TOKEN"
             ./node_modules/.bin/firebase deploy --only storage:rules --token "$FIREBASE_TOKEN"
       - *notify-on-fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
             ./node_modules/.bin/firebase use $ENV --token "$FIREBASE_TOKEN"
 
             # -f, --force: delete Cloud Functions missing from the current working directory without confirmation
-            ./node_modules/.bin/firebase deploy --only functions --token "$FIREBASE_TOKEN --force"
+            ./node_modules/.bin/firebase deploy --only functions --token "$FIREBASE_TOKEN" --force
 
             ./node_modules/.bin/firebase deploy --only firestore:rules --token "$FIREBASE_TOKEN"
 


### PR DESCRIPTION
The CirlceCI build was timing out when trying to delete functions that had been previously deployed, but since removed, as it was waiting for user confirmation to do so.

Looking at the help for `firebase deploy`, the solution is straightforward:

```
⇒  npx firebase deploy --help
Usage: firebase deploy [options]

..snip..

  -f, --force              delete Cloud Functions missing from the current working directory without confirmation
```

---

> The CI build for this is failing when trying to deploy the functions. Looks like our current CI script doesn’t pass correct flags to say ‘yes it’s ok to delete functions that are no longer present in our config’, which causes it to hang waiting for user input until it times out.
> 
> - https://app.circleci.com/pipelines/github/sparkletown/sparkle/6062/workflows/25660752-e536-433c-9677-2cd72c454c79/jobs/9821/parallel-runs/0/steps/0-106
> 
>
> ```
> The following functions are found in your project but do not exist in your local source code:
> 	venue-getVenueEvents(us-central1)
> 
> If you are renaming a function or changing its region, it is recommended that you create the new function first before deleting the old one to prevent event loss. For more info, visit https://firebase.google.com/docs/functions/manage-functions#modify
> 
> ? Would you like to proceed with deletion? Selecting no will continue the rest o
> f the deployments. (y/N) ? Would you like to proceed with deletion? Selecting no will continue the rest o
> f the deployments. (y/N) ? Would you like to proceed with deletion? Selecting no will continue the rest o
> f the deployments. (y/N) 
> 
> Too long with no output (exceeded 10m0s): context deadline exceeded
> ```
>
> I expect the fix for this is likely going to be a line or two change in our Circle CI config.
> 
> _Originally posted by @0xdevalias in https://github.com/sparkletown/sparkle/issues/1366#issuecomment-835657584_