### PR TITLE
pulse rooms on partymap when event is live

### DIFF
--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -85,4 +85,30 @@ $label-visible: flex;
   &__title--count {
     display: $label-hidden;
   }
+
+  .islive {
+    filter: drop-shadow(0px 0px 9px rgba(255, 0, 255, 0.5)) contrast(110%)
+      saturate(110%);
+    animation: pulse 1.5s infinite;
+
+    &:hover {
+      animation: none;
+      filter: drop-shadow(0px 0px 9px rgba(255, 0, 255, 1)) contrast(110%)
+        saturate(110%);
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      filter: drop-shadow(0px 0px 9px rgba(255, 0, 255, 0.5));
+    }
+
+    50% {
+      filter: drop-shadow(0px 0px 9px rgba(255, 0, 255, 1));
+    }
+
+    100% {
+      filter: drop-shadow(0px 0px 9px rgba(255, 0, 255, 0.5));
+    }
+  }
 }

--- a/src/components/templates/PartyMap/components/Map/MapRoom.tsx
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.tsx
@@ -19,12 +19,14 @@ const noop = () => {};
 export interface MapRoomProps {
   venue: PartyMapVenue;
   room: Room;
+  isLive?: Boolean;
   selectRoom: () => void;
 }
 
 export const MapRoom: React.FC<MapRoomProps> = ({
   venue,
   room,
+  isLive,
   selectRoom,
 }) => {
   const { recentRoomUsers } = useRoom({ room, venueName: venue.name });
@@ -53,6 +55,10 @@ export const MapRoom: React.FC<MapRoomProps> = ({
   const titleClasses = classNames("maproom__title", {
     "maproom__title--count":
       !isUnclickable && venue.roomVisibility === RoomVisibility.count,
+  });
+
+  const imageClasses = classNames("maproom__image", {
+    "maproom__title islive": isLive,
   });
 
   const roomInlineStyles = useMemo(
@@ -86,7 +92,7 @@ export const MapRoom: React.FC<MapRoomProps> = ({
       onMouseEnter={isUnclickable ? noop : handleRoomHovered}
       onMouseLeave={isUnclickable ? noop : handleRoomUnhovered}
     >
-      <img className="maproom__image" src={room.image_url} alt={room.title} />
+      <img className={imageClasses} src={room.image_url} alt={room.title} />
 
       {!isUnclickable && (
         <div className="maproom__label">


### PR DESCRIPTION
This PR aims to help attendees orient themselves on the partymap by providing a visual cue to the venues that currently have live events. Happy for any comments. 