### PR TITLE
removed flex-shrink from the room img

### DIFF
--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -60,6 +60,7 @@ $label-visible: flex;
 
   &__image {
     position: relative;
+    flex-shrink: 0;
 
     width: 100%;
     height: 100%;

--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -60,7 +60,7 @@ $label-visible: flex;
 
   &__image {
     position: relative;
-    flex-shrink: 0;
+    flex-shrink: 0;FOO
 
     width: 100%;
     height: 100%;

--- a/src/components/templates/PartyMap/components/Map/MapRoom.scss
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.scss
@@ -60,7 +60,7 @@ $label-visible: flex;
 
   &__image {
     position: relative;
-    flex-shrink: 0;FOO
+    flex-shrink: 0;
 
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Fixes sparkletown/internal-sparkle-issues#721, when mousing over certain rooms, their aspect ratio changes. This only seems to happen with some images - but not others