### PR TITLE
fix logic in Auditorium (v1) where row/column 0 is treated as false instead of being a valid seat

### DIFF
--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -23,6 +23,7 @@ import { GenericVenue } from "types/venues";
 import { ConvertToEmbeddableUrl } from "utils/ConvertToEmbeddableUrl";
 import { WithId } from "utils/id";
 import { createEmojiReaction, createTextReaction } from "utils/reactions";
+import { isDefined } from "utils/types";
 
 import { useDispatch } from "hooks/useDispatch";
 import { useRecentVenueUsers } from "hooks/users";

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -229,7 +229,7 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
 
     return recentVenueUsers.filter((user) => {
       const { row, column } = user.data?.[venueId] ?? {};
-      return row != null && column != null;
+      return isDefined(row) && isDefined(column);
     });
   }, [recentVenueUsers, venueId]);
 

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -229,8 +229,7 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
 
     return recentVenueUsers.filter((user) => {
       const { row, column } = user.data?.[venueId] ?? {};
-
-      return row && column;
+      return row != null && column != null;
     });
   }, [recentVenueUsers, venueId]);
 

--- a/src/components/templates/PartyMap/components/Map/hooks/usePartygoersBySeat.ts
+++ b/src/components/templates/PartyMap/components/Map/hooks/usePartygoersBySeat.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { User } from "types/User";
 import { WithId } from "utils/id";
+import { isDefined } from "utils/types";
 import { ReactHook } from "types/utility";
 
 import { makeMatrixReducer } from "utils/reducers";
@@ -37,7 +38,7 @@ export const usePartygoersbySeat: ReactHook<
 
   const isSeatTaken = useCallback(
     (row: number, column: number): boolean =>
-      !!partygoersBySeat?.[row]?.[column],
+      isDefined(partygoersBySeat?.[row]?.[column]),
     [partygoersBySeat]
   );
 


### PR DESCRIPTION
There is a separate check for FireLane (column) so should be ok in that regard
now that it would return True for 0, 0

Closes #1422 