### PR TITLE
ENH: provide fuse.js options to improve search for some adequacy

### DIFF
--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -102,7 +102,7 @@ export const usePosters = (posterHallId: string) => {
         //@ts-ignore
         $and: searchQuery
           .trim()
-          .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472
+          .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
               { "poster.title": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,13 +71,25 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: ["poster.title", "poster.authorName", "poster.categories"],
-        threshold: 0.4, // default 0.6: brings too distant if anyhow related hits
+        keys: [
+          {
+            name: "poster.title",
+            weight: 2,
+          },
+          {
+            name: "poster.authorName",
+            weight: 3,
+          },
+          {
+            name: "poster.categories",
+            weight: 1,
+          },
+        ],
+        threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
-        // Otherwise can't find a word in a sentence
-        // includeScore: true   // so it could be displayed!?
-        // distance: 40        //  default 100 - ignored if ignoreLocation: true
-        // useExtendedSearch: true // might be neat!
+        findAllMatches: true,
+        minMatchCharLength: 3,
+        // useExtendedSearch: true,  // might be neat but confusing. might be worthwhile a UI switch
       }),
     [filteredPosterVenues]
   );

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -97,7 +97,7 @@ export const usePosters = (posterHallId: string) => {
           .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
-              { "name": x },
+              { name: x },
               { "poster.title": x },
               { "poster.authorName": x },
               { "poster.categories": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -99,7 +99,19 @@ export const usePosters = (posterHallId: string) => {
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues
-      .search(searchQuery.trim()) // trim so adding space does not kill all results at once
+      .search({
+        //@ts-ignore
+        $and: searchQuery
+          .trim()
+          .split(" ")
+          .map((x) => ({
+            $or: [
+              { "poster.title": x },
+              { "poster.authorName": x },
+              { "poster.categories": x },
+            ],
+          })),
+      })
       .slice(0, displayedPostersCount)
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues, displayedPostersCount]);

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -88,7 +88,6 @@ export const usePosters = (posterHallId: string) => {
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,
-        minMatchCharLength: 3,
         // useExtendedSearch: true,  // might be neat but confusing. might be worthwhile a UI switch
       }),
     [filteredPosterVenues]

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -99,7 +99,7 @@ export const usePosters = (posterHallId: string) => {
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues
-      .search(searchQuery)
+      .search(searchQuery.trim()) // trim so adding space does not kill all results at once
       .slice(0, displayedPostersCount)
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues, displayedPostersCount]);

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -103,7 +103,7 @@ export const usePosters = (posterHallId: string) => {
         //@ts-ignore
         $and: searchQuery
           .trim()
-          .split(" ")
+          .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472
           .map((x) => ({
             $or: [
               { "poster.title": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -72,6 +72,12 @@ export const usePosters = (posterHallId: string) => {
     () =>
       new Fuse(filteredPosterVenues, {
         keys: ["poster.title", "poster.authorName", "poster.categories"],
+        threshold: 0.4, // default 0.6: brings too distant if anyhow related hits
+        ignoreLocation: true, // default False: True - to search ignoring location of the words.
+        // Otherwise can't find a word in a sentence
+        // includeScore: true   // so it could be displayed!?
+        // distance: 40        //  default 100 - ignored if ignoreLocation: true
+        // useExtendedSearch: true // might be neat!
       }),
     [filteredPosterVenues]
   );

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -86,7 +86,7 @@ export const usePosters = (posterHallId: string) => {
   );
 
   const searchedPosterVenues = useMemo(() => {
-    if (!searchQuery)
+    if (!searchQuery.trim())
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,7 +71,12 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: ["poster.title", "poster.authorName", "poster.categories"],
+        keys: [
+          "name",
+          "poster.title",
+          "poster.authorName",
+          "poster.categories",
+        ],
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,
@@ -92,6 +97,7 @@ export const usePosters = (posterHallId: string) => {
           .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
+              { "name": x },
               { "poster.title": x },
               { "poster.authorName": x },
               { "poster.categories": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,20 +71,7 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: [
-          {
-            name: "poster.title",
-            weight: 2,
-          },
-          {
-            name: "poster.authorName",
-            weight: 3,
-          },
-          {
-            name: "poster.categories",
-            weight: 1,
-          },
-        ],
+        keys: ["poster.title", "poster.authorName", "poster.categories"],
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,


### PR DESCRIPTION
At large closes #1391 (**Edit by @0xdevalias:** also closes https://github.com/sparkletown/internal-sparkle-issues/issues/745) although remains notably suboptimal.  With settings @margulies came up with seems to go a few steps further than my exploration (initial commit) 
- additional explicit trimming of the search query (we aren't into [Whitespace](https://en.wikipedia.org/wiki/Whitespace_(programming_language)) here aren't we? but adding a space trailing space has an immediate detrimental effect)
- split by space into words and search for each within `$and` across all keys.  See below for more info on how plain fuse.js seems not capable of that
- allow for `" "` to enclose phrase to not be split

With the above changes search becomes **pragmatically useful**! That splitting **resolved** following gotchas: 
- `LastName FirstName` would return no result whenever `FirstName LastName` is ok.
- results often make no real sense from UX PoV: e.g. there is a poster by Tsai with "connectivity" in the title.  Entering Tsai - shows the poster. Entering "Tsai connectivity" shows bunch of posters none of which is of Tsai

edits:
-  I think this is the most related issue https://github.com/krisk/Fuse/issues/235 (closed without resolution pointing to built-in deficiency of fuse.js for our use case)
  - to workaround people breed monsters like https://github.com/krisk/Fuse/issues/235#issuecomment-821220246
- the approach of the bot closing issues without resolution there is really annoying, keep running into them (tokenize was removed but no changelog https://github.com/krisk/Fuse/issues/511, so not clear why/how to workaround... started to be removed in https://github.com/krisk/Fuse/commit/4343f71e4159e5ee046a821b2be700eee0708148 in favor of "extended" mode I guess; but in extended mode you seems need to specify fields for logical operation)
- with that in mind it might need some JS foo to first split query string, and prep it to be fed to "advanced" mode
  - may be dirty sufficient workaround would be to meld all 3 fields into one to give to fuse
  - or just perform separate queries per each split term and take intersection