### PR TITLE
increase number of poster previews shown from 12 to 48

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -581,7 +581,7 @@ export const POSTERPAGE_MAX_VIDEO_PARTICIPANTS = 10;
 
 export const SEARCH_DEBOUNCE_TIME = 200; // ms
 
-export const DEFAULT_DISPLAYED_POSTER_PREVIEW_COUNT = 12;
+export const DEFAULT_DISPLAYED_POSTER_PREVIEW_COUNT = 48;
 
 export const USER_STATUSES = [UserStatus.available, UserStatus.busy];
 


### PR DESCRIPTION
I have tried with 1200 and it still works ok.  The next UX fiasco which is not
fixed in this PR anyhow is "Show more posters" for a search query which has no
more to show.