### PR TITLE
show poster number alongside the title in PosterPreview / PosterPage

### DIFF
--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -19,7 +19,6 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
   posterVenue,
 }) => {
   const { title, authorName, categories } = posterVenue.poster ?? {};
-  const number = posterVenue.name.replace("poster", "");
 
   const venueId = posterVenue.id;
 
@@ -44,7 +43,7 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
   return (
     <div className={posterClassnames} onClick={handleEnterVenue}>
       <p className="PosterPreview__title">
-        {number}: {title}
+        {posterVenue.name}: {title}
       </p>
 
       <div className="PosterPreview__categories">{renderedCategories}</div>

--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -19,6 +19,7 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
   posterVenue,
 }) => {
   const { title, authorName, categories } = posterVenue.poster ?? {};
+  const number = posterVenue.name.replace("poster", "");
 
   const venueId = posterVenue.id;
 
@@ -42,7 +43,9 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
 
   return (
     <div className={posterClassnames} onClick={handleEnterVenue}>
-      <p className="PosterPreview__title">{title}</p>
+      <p className="PosterPreview__title">
+        {number}: {title}
+      </p>
 
       <div className="PosterPreview__categories">{renderedCategories}</div>
 

--- a/src/components/templates/PosterPage/PosterPage.tsx
+++ b/src/components/templates/PosterPage/PosterPage.tsx
@@ -30,6 +30,7 @@ export const PosterPage: React.FC<PosterPageProps> = ({ venue }) => {
   const { id: venueId, isLive: isPosterLive, poster, iframeUrl } = venue;
 
   const { title, introVideoUrl, categories } = poster ?? {};
+  const number = venue.name.replace("poster", "");
 
   const {
     isShown: isIntroVideoShown,
@@ -84,7 +85,9 @@ export const PosterPage: React.FC<PosterPageProps> = ({ venue }) => {
         <div />
 
         <div className="PosterPage__header--middle-cell">
-          <p className="PosterPage__title">{title}</p>
+          <p className="PosterPage__title">
+            {number}: {title}
+          </p>
           <div className="PosterPage__categories">{renderedCategories}</div>
         </div>
 

--- a/src/components/templates/PosterPage/PosterPage.tsx
+++ b/src/components/templates/PosterPage/PosterPage.tsx
@@ -30,7 +30,6 @@ export const PosterPage: React.FC<PosterPageProps> = ({ venue }) => {
   const { id: venueId, isLive: isPosterLive, poster, iframeUrl } = venue;
 
   const { title, introVideoUrl, categories } = poster ?? {};
-  const number = venue.name.replace("poster", "");
 
   const {
     isShown: isIntroVideoShown,
@@ -86,7 +85,7 @@ export const PosterPage: React.FC<PosterPageProps> = ({ venue }) => {
 
         <div className="PosterPage__header--middle-cell">
           <p className="PosterPage__title">
-            {number}: {title}
+            {venue.name}: {title}
           </p>
           <div className="PosterPage__categories">{renderedCategories}</div>
         </div>


### PR DESCRIPTION
Poster number is important information since people refer to their posters by
numbers for easy finding/association/check if in the right place.  But it was
nowhere shown.

I guess ideally it should not be melded into the same `<element>` as title, but
this is the fastest and easiest way since title is in `<p>` and we do not want to
break it all across multiple lines etc.  Specific recommendations or better
tune up commits pushed directly would be most welcome to expedite this
PR.

Search for number yet to be supported (will see if could do in #1443) and is
orthogonal IMHO to having them displayed.