### PR TITLE
[scripts] improve scripts/configure-venue-access script (email whitelisting, access codes, etc)

### DIFF
--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -117,10 +117,6 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
       );
       break;
   }
-
-  console.log("Finished.");
-
-  process.exit(0);
 })()
   .catch((error) => {
     console.error(error);

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -12,10 +12,18 @@ import { initFirebaseAdminApp, makeScriptUsage } from "./lib/helpers";
 
 const usage = makeScriptUsage({
   description: "Configures the venue access with the selected method and value",
-  usageParams:
-    "PROJECT_ID VENUE_ID [password|emaillist|codelist] [password | emails file path | codes file path] [CREDENTIAL_PATH]",
-  exampleParams:
-    "co-reality-map password abc123 [theMatchingAccountServiceKey.json] / co-reality-map emails emails-one-per-line.txt [theMatchingAccountServiceKey.json] / co-reality-map codes ticket-codes-one-per-line.txt [theMatchingAccountServiceKey.json]",
+  usageParams: [
+    "PROJECT_ID VENUE_ID METHOD ACCESS_DETAIL [CREDENTIAL_PATH]",
+    "",
+    `PROJECT_ID VENUE_ID ${VenueAccessMode.Password} THE_PASSWORD_TO_SET [CREDENTIAL_PATH]`,
+    `PROJECT_ID VENUE_ID ${VenueAccessMode.Emails} LIST_OF_EMAILS_PATH [CREDENTIAL_PATH]`,
+    `PROJECT_ID VENUE_ID ${VenueAccessMode.Codes} LIST_OF_ONE_TIME_USE_CODES_PATH [CREDENTIAL_PATH]`,
+  ],
+  exampleParams: [
+    `co-reality-map venue123Id ${VenueAccessMode.Password} secretPassword123 [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venue123Id ${VenueAccessMode.Emails} emails-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venue123Id ${VenueAccessMode.Codes} one-time-use-ticket-codes-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+  ],
 });
 
 const [

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -30,6 +30,8 @@ const usage = makeScriptUsage({
   ],
 });
 
+// TODO: refactor this to work with multiple venueIds at once, in a similar way to how scripts/count-users-entered-venue.ts works
+
 const [
   projectId,
   venueId,

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -137,5 +137,6 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
     process.exit(1);
   })
   .finally(() => {
+    console.log("Done");
     process.exit(0);
   });

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -72,9 +72,6 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
     `Configuring venue '${venueId}' access data for '${method}' using '${accessDetail}'...`
   );
 
-  const accessDoc = await accessDocRef.get();
-  const access = accessDoc.exists ? accessDoc.data() : {};
-
   switch (method) {
     case VenueAccessMode.Password:
       const password = accessDetail.trim();
@@ -103,16 +100,18 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
       break;
 
     case VenueAccessMode.Codes:
-      const codes = fs
+      const codes: string[] = fs
         .readFileSync(accessDetail, "utf-8")
         .split(/\r?\n/)
-        .forEach((line) => {
-          access?.codes?.push(line.trim());
-        });
-      console.log(`Setting venues/${venueId}/access/${method}...`);
+        .map((line) => line.trim());
+
+      console.log(
+        `  Adding ${codes.length} access codes to the '${venueId}' venue's '${method}' list..`
+      );
+
       await accessDocRef.set(
         {
-          codes: codes,
+          codes: FieldValue.arrayUnion(...codes),
         },
         { merge: true }
       );

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -87,7 +87,19 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
       const emails: string[] = fs
         .readFileSync(accessDetail, "utf-8")
         .split(/\r?\n/)
-        .map((line) => line.trim().toLowerCase());
+        .map((line) => line.trim().toLowerCase())
+        .filter((line) => {
+          const isEmail = line.includes("@");
+
+          // We don't want to spam the logs about empty lines
+          if (!isEmail && line.length > 0) {
+            console.log(
+              `  Line doesn't appear to be an email, skipping: ${line}`
+            );
+          }
+
+          return isEmail;
+        });
 
       console.log(
         `  Adding ${emails.length} email addresses to the '${venueId}' venue's '${method}' whitelist..`

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node -r esm -r ts-node/register
 
+import fs from "fs";
 import { resolve } from "path";
 
-import fs from "fs";
-import admin from "firebase-admin";
 import "firebase/firestore";
+import { intersection, uniq } from "lodash";
 
 import { VenueAccessMode } from "../src/types/VenueAcccess";
 
@@ -17,16 +17,21 @@ import {
 const usage = makeScriptUsage({
   description: "Configures the venue access with the selected method and value",
   usageParams: [
-    "PROJECT_ID VENUE_ID METHOD ACCESS_DETAIL [CREDENTIAL_PATH]",
+    "PROJECT_ID VENUE_IDS METHOD ACCESS_DETAIL [CREDENTIAL_PATH]",
     "",
-    `PROJECT_ID VENUE_ID ${VenueAccessMode.Password} THE_PASSWORD_TO_SET [CREDENTIAL_PATH]`,
-    `PROJECT_ID VENUE_ID ${VenueAccessMode.Emails} LIST_OF_EMAILS_PATH [CREDENTIAL_PATH]`,
-    `PROJECT_ID VENUE_ID ${VenueAccessMode.Codes} LIST_OF_ONE_TIME_USE_CODES_PATH [CREDENTIAL_PATH]`,
+    `PROJECT_ID VENUE_IDS ${VenueAccessMode.Password} THE_PASSWORD_TO_SET [CREDENTIAL_PATH]`,
+    `PROJECT_ID VENUE_IDS ${VenueAccessMode.Emails} LIST_OF_EMAILS_PATH [CREDENTIAL_PATH]`,
+    `PROJECT_ID VENUE_IDS ${VenueAccessMode.Codes} LIST_OF_ONE_TIME_USE_CODES_PATH [CREDENTIAL_PATH]`,
   ],
   exampleParams: [
-    `co-reality-map venue123Id ${VenueAccessMode.Password} secretPassword123 [theMatchingAccountServiceKey.json]`,
-    `co-reality-map venue123Id ${VenueAccessMode.Emails} emails-one-per-line.txt [theMatchingAccountServiceKey.json]`,
-    `co-reality-map venue123Id ${VenueAccessMode.Codes} one-time-use-ticket-codes-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venueId                    ${VenueAccessMode.Password} secretPassword123 [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venueId1,venueId2,venueIdN ${VenueAccessMode.Password} secretPassword123 [theMatchingAccountServiceKey.json]`,
+    "",
+    `co-reality-map venueId                    ${VenueAccessMode.Emails} emails-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venueId1,venueId2,venueIdN ${VenueAccessMode.Emails} emails-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+    "",
+    `co-reality-map venueId                    ${VenueAccessMode.Codes} one-time-use-ticket-codes-one-per-line.txt [theMatchingAccountServiceKey.json]`,
+    `co-reality-map venueId1,venueId2,venueIdN ${VenueAccessMode.Codes} one-time-use-ticket-codes-one-per-line.txt [theMatchingAccountServiceKey.json]`,
   ],
 });
 
@@ -34,56 +39,122 @@ const usage = makeScriptUsage({
 
 const [
   projectId,
-  venueId,
+  venueIds,
   method,
   accessDetail,
   credentialPath,
 ] = process.argv.slice(2);
-if (!projectId || !venueId || !method || !accessDetail) {
+if (!projectId || !venueIds || !method || !accessDetail) {
   usage();
 }
+console.log();
 
 if (!VenueAccessMode[method as keyof typeof VenueAccessMode]) {
   console.error(`Invalid access method ${method}`);
   process.exit(1);
 }
 
-initFirebaseAdminApp(projectId, {
+const venueIdsArray = venueIds.split(",");
+
+if (venueIdsArray.length === 0) {
+  console.error("Error: You must specify at least 1 venueId to process.");
+  console.error("  venueIdsArray.length :", venueIdsArray.length);
+  process.exit(1);
+}
+
+const uniqueVenueIdsArray = uniq(venueIdsArray);
+if (venueIdsArray.length !== uniqueVenueIdsArray.length) {
+  console.error("Error: You cannot specify duplicate venueIds to process.");
+  console.error("  venueIdsArray.length       :", venueIdsArray.length);
+  console.error("  uniqueVenueIdsArray.length :", uniqueVenueIdsArray.length);
+  console.error(
+    "  duplicate venueIds         :",
+    intersection(venueIdsArray, uniqueVenueIdsArray)
+  );
+  process.exit(1);
+}
+
+// Firestore's batch write limit is 500 entries. Since we make 2 writes per venue, we can process up to 250 venues at once.
+//   Note: it's super unlikely we will ever need to handle this, but if we do, we can split our firestore query into 'chunks'
+const MAX_VENUE_IDS = 250;
+if (venueIdsArray.length > MAX_VENUE_IDS) {
+  console.error(
+    `Error: This script can only process up to ${MAX_VENUE_IDS} venueIds at once at the moment.`
+  );
+  console.error("  venueIdsArray.length :", venueIdsArray.length);
+  process.exit(1);
+}
+
+const app = initFirebaseAdminApp(projectId, {
   credentialPath: credentialPath
     ? resolve(__dirname, credentialPath)
     : undefined,
 });
 
-const venueDocRef = admin.firestore().collection("venues").doc(venueId);
-const accessDocRef = venueDocRef.collection("access").doc(method);
+const allVenueDocRefs = venueIdsArray.map((venueId) =>
+  app.firestore().collection("venues").doc(venueId)
+);
+
+const allVenueAccessDocRefs = allVenueDocRefs.map((venueDocRef) =>
+  venueDocRef.collection("access").doc(method)
+);
 
 (async () => {
-  const venueDoc = await venueDocRef.get();
+  // Check that all the requested venues exist
+  const allVenueDocs = await Promise.all(
+    allVenueDocRefs.map((venueDocRef) => venueDocRef.get())
+  );
 
-  if (!venueDoc.exists) {
-    console.error(`venue '${venueId}' doesn't exist`);
-    process.exit(1);
+  const missingVenueIds = allVenueDocs
+    .filter((venueDoc) => !venueDoc.exists)
+    .map((venueDoc) => venueDoc.id);
+
+  if (missingVenueIds.length > 0) {
+    missingVenueIds.forEach((venueId) => {
+      console.error(`Error: venue '${venueId}' doesn't exist`);
+    });
+
+    throw new Error(
+      `${missingVenueIds.length} out of the ${allVenueDocRefs.length} requested venues don't exist`
+    );
   }
 
-  await admin.firestore().doc(`venues/${venueId}`).update({ access: method });
+  // Batch all of our writes together in a single atomic commit
+  const batchWrite = app.firestore().batch();
 
+  // Configure the venue's access mode
   console.log(
-    `Configuring venue '${venueId}' access mode to use '${method}'...`
+    `[batch] Preparing to configure ${allVenueDocRefs.length} venue's access modes to use '${method}'..`
   );
-  console.log(
-    `Configuring venue '${venueId}' access data for '${method}' using '${accessDetail}'...`
-  );
+  allVenueDocRefs.forEach((venueDocRef) => {
+    console.log(`[batch]   ${venueDocRef.id}`);
+    batchWrite.update(venueDocRef, { access: method });
+  });
+  console.log();
 
+  // Configure the venue's access data
+  console.log(
+    `[batch] Preparing to configure ${allVenueAccessDocRefs.length} venue's access data for '${method}' using '${accessDetail}'..`
+  );
   switch (method) {
-    case VenueAccessMode.Password:
+    case VenueAccessMode.Password: {
       const password = accessDetail.trim();
-      console.log(
-        `Setting venues/${venueId}/access/${method} to {password: ${password}}...`
-      );
-      await accessDocRef.set({ password });
-      break;
 
-    case VenueAccessMode.Emails:
+      console.log(
+        `[batch]   Preparing to configure password for ${allVenueAccessDocRefs.length} venue(s)..`
+      );
+      allVenueAccessDocRefs.forEach((venueAccessDocRef) => {
+        const venueId = venueAccessDocRef.parent.parent?.id;
+        console.log(`[batch]     Prepared ${venueId}`);
+        batchWrite.set(venueAccessDocRef, { password });
+      });
+      break;
+    }
+
+    case VenueAccessMode.Emails: {
+      console.log(
+        `[batch]   Reading email addresses from file: ${accessDetail}`
+      );
       const emails: string[] = fs
         .readFileSync(accessDetail, "utf-8")
         .split(/\r?\n/)
@@ -93,44 +164,64 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
 
           // We don't want to spam the logs about empty lines
           if (!isEmail && line.length > 0) {
-            console.log(
-              `  Line doesn't appear to be an email, skipping: ${line}`
+            console.warn(
+              `[batch]     Warning: Line doesn't appear to be an email, skipping: ${line}`
             );
           }
 
           return isEmail;
         });
+      console.log();
 
       console.log(
-        `  Adding ${emails.length} email addresses to the '${venueId}' venue's '${method}' whitelist..`
+        `[batch]   Preparing to append ${emails.length} email address(es) to whitelist for ${allVenueAccessDocRefs.length} venue(s)..`
       );
-
-      await accessDocRef.set(
-        {
-          emails: FieldValue.arrayUnion(...emails),
-        },
-        { merge: true }
-      );
+      allVenueAccessDocRefs.forEach((venueAccessDocRef) => {
+        const venueId = venueAccessDocRef.parent.parent?.id;
+        console.log(`[batch]     Prepared ${venueId}`);
+        batchWrite.set(
+          venueAccessDocRef,
+          {
+            emails: FieldValue.arrayUnion(...emails),
+          },
+          { merge: true }
+        );
+      });
       break;
+    }
 
-    case VenueAccessMode.Codes:
+    case VenueAccessMode.Codes: {
+      console.log(`[batch]   Reading access codes from file: ${accessDetail}`);
       const codes: string[] = fs
         .readFileSync(accessDetail, "utf-8")
         .split(/\r?\n/)
-        .map((line) => line.trim());
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      console.log();
 
       console.log(
-        `  Adding ${codes.length} access codes to the '${venueId}' venue's '${method}' list..`
+        `[batch]   Preparing to append ${codes.length} access codes to list for ${allVenueAccessDocRefs.length} venue(s)..`
       );
-
-      await accessDocRef.set(
-        {
-          codes: FieldValue.arrayUnion(...codes),
-        },
-        { merge: true }
-      );
+      allVenueAccessDocRefs.forEach((venueAccessDocRef) => {
+        const venueId = venueAccessDocRef.parent.parent?.id;
+        console.log(`[batch]     Prepared ${venueId}`);
+        batchWrite.set(
+          venueAccessDocRef,
+          {
+            codes: FieldValue.arrayUnion(...codes),
+          },
+          { merge: true }
+        );
+      });
       break;
+    }
   }
+  console.log();
+
+  // Commit our batch of prepared writes
+  console.log("[batch] Committing all prepared writes to the database..");
+  await batchWrite.commit();
+  console.log();
 })()
   .catch((error) => {
     console.error(error);

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -48,9 +48,13 @@ initFirebaseAdminApp(projectId, {
     : undefined,
 });
 
+const venueDocRef = admin.firestore().collection("venues").doc(venueId);
+const accessDocRef = venueDocRef.collection("access").doc(method);
+
 (async () => {
   console.log(`Ensuring ${venueId} access via ${method} - ${accessDetail}`);
-  const venueDoc = await admin.firestore().doc(`venues/${venueId}`).get();
+  const venueDoc = await venueDocRef.get();
+
   if (!venueDoc.exists) {
     console.error(`venue ${venueId} does not exist`);
     process.exit(1);
@@ -61,9 +65,6 @@ initFirebaseAdminApp(projectId, {
 
   console.log(`Configuring access details for ${method}...`);
 
-  const accessDocRef = admin
-    .firestore()
-    .doc(`venues/${venueId}/access/${method}`);
   const accessDoc = await accessDocRef.get();
   const access = accessDoc.exists ? accessDoc.data() : {};
 

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -52,18 +52,21 @@ const venueDocRef = admin.firestore().collection("venues").doc(venueId);
 const accessDocRef = venueDocRef.collection("access").doc(method);
 
 (async () => {
-  console.log(`Ensuring ${venueId} access via ${method} - ${accessDetail}`);
   const venueDoc = await venueDocRef.get();
 
   if (!venueDoc.exists) {
-    console.error(`venue ${venueId} does not exist`);
+    console.error(`venue '${venueId}' doesn't exist`);
     process.exit(1);
   }
 
   await admin.firestore().doc(`venues/${venueId}`).update({ access: method });
-  console.log("Done");
 
-  console.log(`Configuring access details for ${method}...`);
+  console.log(
+    `Configuring venue '${venueId}' access mode to use '${method}'...`
+  );
+  console.log(
+    `Configuring venue '${venueId}' access data for '${method}' using '${accessDetail}'...`
+  );
 
   const accessDoc = await accessDocRef.get();
   const access = accessDoc.exists ? accessDoc.data() : {};
@@ -83,7 +86,7 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
         .split(/\r?\n/)
         .map((line) => line.trim().toLowerCase());
       console.log(
-        `Setting venues/${venueId}/access/${method} to {emails: ${emails}}...`
+        `  Adding ${emails.length} email addresses to the '${venueId}' venue's '${method}' whitelist..`
       );
       await accessDocRef.set(
         {
@@ -109,7 +112,8 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
       );
       break;
   }
-  console.log("Done.");
+
+  console.log("Finished.");
 
   process.exit(0);
 })()

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -8,7 +8,11 @@ import "firebase/firestore";
 
 import { VenueAccessMode } from "../src/types/VenueAcccess";
 
-import { initFirebaseAdminApp, makeScriptUsage } from "./lib/helpers";
+import {
+  initFirebaseAdminApp,
+  makeScriptUsage,
+  FieldValue,
+} from "./lib/helpers";
 
 const usage = makeScriptUsage({
   description: "Configures the venue access with the selected method and value",
@@ -81,16 +85,18 @@ const accessDocRef = venueDocRef.collection("access").doc(method);
       break;
 
     case VenueAccessMode.Emails:
-      const emails = fs
+      const emails: string[] = fs
         .readFileSync(accessDetail, "utf-8")
         .split(/\r?\n/)
         .map((line) => line.trim().toLowerCase());
+
       console.log(
         `  Adding ${emails.length} email addresses to the '${venueId}' venue's '${method}' whitelist..`
       );
+
       await accessDocRef.set(
         {
-          emails: emails,
+          emails: FieldValue.arrayUnion(...emails),
         },
         { merge: true }
       );

--- a/scripts/lib/helpers.ts
+++ b/scripts/lib/helpers.ts
@@ -4,6 +4,8 @@ import { relative, resolve } from "path";
 import admin from "firebase-admin";
 import formatDate from "date-fns/format/index.js";
 
+import { asArray } from "../../src/utils/types";
+
 export interface CredentialFile {
   type?: string;
   project_id?: string;
@@ -124,11 +126,23 @@ export const ensureProjectIdMatchesCredentialProjectId = (
  * @param usageParams shows the positioning of each script parameter and what it's general name is
  * @param exampleParams shows an example of supplying values for each script parameter
  *
- * @example
+ * @example One line for usage/example
  *   const usage = makeScriptUsage({
  *     description:   "Describe my script in a really useful way.",
  *     usageParams:   "PROJECT_ID VENUE_IDS [CREDENTIAL_PATH]", // Note: CREDENTIAL_PATH is optional here
  *     exampleParams: "my-project-id venueId,venueId2,venueIdN [theMatchingAccountServiceKey.json]",
+ *   });
+ *
+ * @example Multiple lines for usage/example
+ *   const usage = makeScriptUsage({
+ *     description: "Describe my script in a really useful way.",
+ *     usageParams: [
+ *       "PROJECT_ID VENUE_IDS [CREDENTIAL_PATH]"
+ *       "PROJECT_ID VENUE_IDS SOMETHINGELSE [CREDENTIAL_PATH]"
+ *     ], // Note: CREDENTIAL_PATH is optional here
+ *     exampleParams: [
+ *       "my-project-id venueId,venueId2,venueIdN [theMatchingAccountServiceKey.json]",
+ *     ]
  *   });
  */
 export const makeScriptUsage = ({
@@ -137,17 +151,32 @@ export const makeScriptUsage = ({
   exampleParams,
 }: {
   description: string;
-  usageParams: string;
-  exampleParams: string;
+  usageParams: string | string[];
+  exampleParams: string | string[];
 }) => () => {
   const scriptName = relative(process.cwd(), process.argv[1]);
+
+  const usageLines = asArray(usageParams).map((params) =>
+    params ? `${scriptName} ${params}` : ""
+  );
+
+  const exampleLines = asArray(exampleParams).map((params) =>
+    params ? `${scriptName} ${params}` : ""
+  );
+
+  const renderLines = (lines: string[]) => {
+    const prefix = lines.length > 1 ? "\n  " : "";
+
+    return `${prefix}${lines.join(prefix)}`;
+  };
+
   const helpText = `
 ---------------------------------------------------------
 ${description}
 
-Usage: ${scriptName} ${usageParams}
+Usage: ${renderLines(usageLines)}
 
-Example: ${scriptName} ${exampleParams}
+Example: ${renderLines(exampleLines)}
 ---------------------------------------------------------
 `;
 

--- a/src/types/VenueAcccess.ts
+++ b/src/types/VenueAcccess.ts
@@ -1,3 +1,5 @@
+// @debt Should we add some kind of 'none'/'disabled' entry to VenueAccessMode?
+// @debt Refactor VenueAccessMode to use lowercase, non-plural keys (but also figure how to backfill the database to account for this change first)
 export enum VenueAccessMode {
   Emails = "Emails",
   Codes = "Codes",


### PR DESCRIPTION
**Note:** This PR was originally created based on needs in https://github.com/sparkletown/internal-sparkle-issues/issues/750. You can read more of the specifics of that story in https://github.com/sparkletown/internal-sparkle-issues/issues/750#issuecomment-848470989 and the following comments.

---

- refactors `makeScriptUsage` (`scripts/lib/helpers.ts`) to support multiple usage/example lines
- improves `configure-venue-access` script
  - help with multiline usage/examples
  - refactors `VenueAccessMode.Emails` functionality to use `FieldValue.arrayUnion`
  - refactors `VenueAccessMode.Codes` functionality to use `FieldValue.arrayUnion` + fix bugs
  - general cleanup

## TODO

- [x] refactor this to work with multiple `venueIds` at once, in a similar way to how `scripts/count-users-entered-venue.ts` works

### Potentially OOS?

- [ ] refactor this to make local backups of DB data before writing to it (using `makeSaveToBackupFile` from `scripts/lib/helpers.ts`
- [ ] refactor this to have 'add', 'update', 'clear' modes so we're not just always appending to existing configured email/code array?