### PR TITLE
improve PosterHall search by adjusting fuse.js options + related

### DIFF
--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -22,6 +22,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
   const {
     posterVenues,
     isPostersLoaded,
+    hasHiddenPosters,
 
     increaseDisplayedPosterCount,
 
@@ -55,7 +56,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
       </div>
 
       <div className="PosterHall__more-button">
-        {isPostersLoaded && (
+        {hasHiddenPosters && isPostersLoaded && (
           <Button onClick={increaseDisplayedPosterCount}>
             Show more posters
           </Button>

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -32,6 +32,8 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
     setLiveFilter,
   } = usePosters(venue.id);
 
+  const shouldShowMorePosters = isPostersLoaded && hasHiddenPosters;
+
   const renderedPosterPreviews = useMemo(() => {
     return posterVenues.map((posterVenue) => (
       <PosterPreview
@@ -56,7 +58,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
       </div>
 
       <div className="PosterHall__more-button">
-        {hasHiddenPosters && isPostersLoaded && (
+        {shouldShowMorePosters && (
           <Button onClick={increaseDisplayedPosterCount}>
             Show more posters
           </Button>

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -5,7 +5,7 @@ import Fuse from "fuse.js";
 import { DEFAULT_DISPLAYED_POSTER_PREVIEW_COUNT } from "settings";
 
 import { posterVenuesSelector } from "utils/selectors";
-import { breakStringWithQuotesBySpaces } from "utils/text";
+import { tokeniseStringWithQuotesBySpaces } from "utils/text";
 
 import { isLoaded, useFirestoreConnect } from "./useFirestoreConnect";
 import { useSelector } from "./useSelector";
@@ -90,19 +90,20 @@ export const usePosters = (posterHallId: string) => {
 
     if (!normalizedSearchQuery) return filteredPosterVenues;
 
-    const matchEntries: string[] =
-      breakStringWithQuotesBySpaces(normalizedSearchQuery) ?? [];
+    const tokenisedSearchQuery = tokeniseStringWithQuotesBySpaces(
+      normalizedSearchQuery
+    );
 
-    if (!matchEntries) return filteredPosterVenues;
+    if (tokenisedSearchQuery.length === 0) return filteredPosterVenues;
 
     return fuseVenues
       .search({
-        $and: matchEntries.map((x: string) => {
+        $and: tokenisedSearchQuery.map((searchToken: string) => {
           const orFields: Fuse.Expression[] = [
-            { name: x },
-            { "poster.title": x },
-            { "poster.authorName": x },
-            { "poster.categories": x },
+            { name: searchToken },
+            { "poster.title": searchToken },
+            { "poster.authorName": searchToken },
+            { "poster.categories": searchToken },
           ];
 
           return {
@@ -110,7 +111,7 @@ export const usePosters = (posterHallId: string) => {
           };
         }),
       })
-      .map((fuseSearchItem) => fuseSearchItem.item);
+      .map((fuseResult) => fuseResult.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues]);
 
   const displayedPosterVenues = useMemo(

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -102,7 +102,7 @@ export const usePosters = (posterHallId: string) => {
         //@ts-ignore
         $and: searchQuery
           .trim()
-          .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472
+          .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
               { "poster.title": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,13 +71,25 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: ["poster.title", "poster.authorName", "poster.categories"],
-        threshold: 0.4, // default 0.6: brings too distant if anyhow related hits
+        keys: [
+          {
+            name: "poster.title",
+            weight: 2,
+          },
+          {
+            name: "poster.authorName",
+            weight: 3,
+          },
+          {
+            name: "poster.categories",
+            weight: 1,
+          },
+        ],
+        threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
-        // Otherwise can't find a word in a sentence
-        // includeScore: true   // so it could be displayed!?
-        // distance: 40        //  default 100 - ignored if ignoreLocation: true
-        // useExtendedSearch: true // might be neat!
+        findAllMatches: true,
+        minMatchCharLength: 3,
+        // useExtendedSearch: true,  // might be neat but confusing. might be worthwhile a UI switch
       }),
     [filteredPosterVenues]
   );

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -97,7 +97,7 @@ export const usePosters = (posterHallId: string) => {
           .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
-              { "name": x },
+              { name: x },
               { "poster.title": x },
               { "poster.authorName": x },
               { "poster.categories": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -99,7 +99,19 @@ export const usePosters = (posterHallId: string) => {
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues
-      .search(searchQuery.trim()) // trim so adding space does not kill all results at once
+      .search({
+        //@ts-ignore
+        $and: searchQuery
+          .trim()
+          .split(" ")
+          .map((x) => ({
+            $or: [
+              { "poster.title": x },
+              { "poster.authorName": x },
+              { "poster.categories": x },
+            ],
+          })),
+      })
       .slice(0, displayedPostersCount)
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues, displayedPostersCount]);

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -88,7 +88,6 @@ export const usePosters = (posterHallId: string) => {
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,
-        minMatchCharLength: 3,
         // useExtendedSearch: true,  // might be neat but confusing. might be worthwhile a UI switch
       }),
     [filteredPosterVenues]

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -99,7 +99,7 @@ export const usePosters = (posterHallId: string) => {
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues
-      .search(searchQuery)
+      .search(searchQuery.trim()) // trim so adding space does not kill all results at once
       .slice(0, displayedPostersCount)
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues, displayedPostersCount]);

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -103,7 +103,7 @@ export const usePosters = (posterHallId: string) => {
         //@ts-ignore
         $and: searchQuery
           .trim()
-          .split(" ")
+          .match(/(".*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472
           .map((x) => ({
             $or: [
               { "poster.title": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -69,6 +69,7 @@ export const usePosters = (posterHallId: string) => {
     [posterVenues, liveFilter]
   );
 
+  // See https://fusejs.io/api/options.html
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -106,9 +106,9 @@ export const usePosters = (posterHallId: string) => {
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues]);
 
-  const displayedPosterVenues = searchedPosterVenues.slice(
-    0,
-    displayedPostersCount
+  const displayedPosterVenues = useMemo(
+    () => searchedPosterVenues.slice(0, displayedPostersCount),
+    [searchedPosterVenues, displayedPostersCount]
   );
 
   const hasHiddenPosters =

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -72,6 +72,12 @@ export const usePosters = (posterHallId: string) => {
     () =>
       new Fuse(filteredPosterVenues, {
         keys: ["poster.title", "poster.authorName", "poster.categories"],
+        threshold: 0.4, // default 0.6: brings too distant if anyhow related hits
+        ignoreLocation: true, // default False: True - to search ignoring location of the words.
+        // Otherwise can't find a word in a sentence
+        // includeScore: true   // so it could be displayed!?
+        // distance: 40        //  default 100 - ignored if ignoreLocation: true
+        // useExtendedSearch: true // might be neat!
       }),
     [filteredPosterVenues]
   );

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -86,7 +86,7 @@ export const usePosters = (posterHallId: string) => {
   );
 
   const searchedPosterVenues = useMemo(() => {
-    if (!searchQuery)
+    if (!searchQuery.trim())
       return filteredPosterVenues.slice(0, displayedPostersCount);
 
     return fuseVenues

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,7 +71,12 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: ["poster.title", "poster.authorName", "poster.categories"],
+        keys: [
+          "name",
+          "poster.title",
+          "poster.authorName",
+          "poster.categories",
+        ],
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,
@@ -92,6 +97,7 @@ export const usePosters = (posterHallId: string) => {
           .match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) // source: https://stackoverflow.com/a/16261693/1265472 + fix
           .map((x) => ({
             $or: [
+              { "name": x },
               { "poster.title": x },
               { "poster.authorName": x },
               { "poster.categories": x },

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -90,21 +90,25 @@ export const usePosters = (posterHallId: string) => {
 
     if (!normalizedSearchQuery) return filteredPosterVenues;
 
-    const matchEntries = breakStringWithQuotesBySpaces(normalizedSearchQuery);
+    const matchEntries: string[] =
+      breakStringWithQuotesBySpaces(normalizedSearchQuery) ?? [];
 
     if (!matchEntries) return filteredPosterVenues;
 
     return fuseVenues
       .search({
-        $and: matchEntries.map((x) => ({
-          $or: [
+        $and: matchEntries.map((x: string) => {
+          const orFields: Fuse.Expression[] = [
             { name: x },
             { "poster.title": x },
             { "poster.authorName": x },
             { "poster.categories": x },
-            // @debt Rewrite the search query to match the $and type
-          ] as Record<string, string>[],
-        })),
+          ];
+
+          return {
+            $or: orFields,
+          };
+        }),
       })
       .map((fuseSearchItem) => fuseSearchItem.item);
   }, [searchQuery, fuseVenues, filteredPosterVenues]);

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -71,20 +71,7 @@ export const usePosters = (posterHallId: string) => {
   const fuseVenues = useMemo(
     () =>
       new Fuse(filteredPosterVenues, {
-        keys: [
-          {
-            name: "poster.title",
-            weight: 2,
-          },
-          {
-            name: "poster.authorName",
-            weight: 3,
-          },
-          {
-            name: "poster.categories",
-            weight: 1,
-          },
-        ],
+        keys: ["poster.title", "poster.authorName", "poster.categories"],
         threshold: 0.2, // 0.1 seems to be exact, default 0.6: brings too distant if anyhow related hits
         ignoreLocation: true, // default False: True - to search ignoring location of the words.
         findAllMatches: true,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,2 @@
+export const breakStringWithQuotesBySpaces = (string: string) =>
+  string.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g); // source: https://stackoverflow.com/a/16261693/1265472

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,2 +1,9 @@
-export const breakStringWithQuotesBySpaces = (string: string) =>
-  string.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g); // source: https://stackoverflow.com/a/16261693/1265472
+/**
+ * Split the provided string by spaces (ignoring spaces within "quoted text") into an array of tokens.
+ *
+ * @param string
+ *
+ * @see https://stackoverflow.com/a/16261693/1265472
+ */
+export const tokeniseStringWithQuotesBySpaces = (string: string): string[] =>
+  string.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) ?? [];

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -4,6 +4,9 @@
  * @param string
  *
  * @see https://stackoverflow.com/a/16261693/1265472
+ *
+ * @debt Depending on the outcome of https://github.com/github/codeql/issues/5964 we may end up needing to change
+ *   this regex for performance reasons.
  */
 export const tokeniseStringWithQuotesBySpaces = (string: string): string[] =>
   string.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) ?? [];


### PR DESCRIPTION
**Note:** This is a re-created PR (to fix CI issues/etc) for the work tested & developed by @yarikoptic in #1443 

**Edit:** While the original PR accidentally overwrote the commit history, that has since been fixed and restored. Details in https://github.com/sparkletown/sparkle/pull/1460#issuecomment-850127899

---

This is basically a copy of #1443 + some additions/tweaks.

The reason for copying it was to test it & slightly clean up the code

closes #1391
closes #1453 

## Original PR Description

> At large closes #1391 (**Edit by @0xdevalias:** also closes https://github.com/sparkletown/internal-sparkle-issues/issues/745) although remains notably suboptimal.  With settings @margulies came up with seems to go a few steps further than my exploration (initial commit) 
> - additional explicit trimming of the search query (we aren't into [Whitespace](https://en.wikipedia.org/wiki/Whitespace_(programming_language)) here aren't we? but adding a space trailing space has an immediate detrimental effect)
> - split by space into words and search for each within `$and` across all keys.  See below for more info on how plain fuse.js seems not capable of that
> - allow for `" "` to enclose phrase to not be split
> 
> With the above changes search becomes **pragmatically useful**! That splitting **resolved** following gotchas: 
> - `LastName FirstName` would return no result whenever `FirstName LastName` is ok.
> - results often make no real sense from UX PoV: e.g. there is a poster by Tsai with "connectivity" in the title.  Entering Tsai - shows the poster. Entering "Tsai connectivity" shows bunch of posters none of which is of Tsai
> 
> edits:
> -  I think this is the most related issue https://github.com/krisk/Fuse/issues/235 (closed without resolution pointing to built-in deficiency of fuse.js for our use case)
>   - to workaround people breed monsters like https://github.com/krisk/Fuse/issues/235#issuecomment-821220246
> - the approach of the bot closing issues without resolution there is really annoying, keep running into them (tokenize was removed but no changelog https://github.com/krisk/Fuse/issues/511, so not clear why/how to workaround... started to be removed in https://github.com/krisk/Fuse/commit/4343f71e4159e5ee046a821b2be700eee0708148 in favor of "extended" mode I guess; but in extended mode you seems need to specify fields for logical operation)
> - with that in mind it might need some JS foo to first split query string, and prep it to be fed to "advanced" mode
>   - may be dirty sufficient workaround would be to meld all 3 fields into one to give to fuse
>   - or just perform separate queries per each split term and take intersection