### PR TITLE
add my engineering QoL helper scripts

### DIFF
--- a/scripts/deploy-master-to-prod-envs
+++ b/scripts/deploy-master-to-prod-envs
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Push the origin master branch to all of our 'main' production environments
+#
+# List of environments: https://github.com/sparkletown/internal-sparkle-issues/issues/295
+
+# Ref: https://wiki.bash-hackers.org/scripting/debuggingtips#use_shell_debug_output
+#set -o xtrace
+
+# Ref: https://stackoverflow.com/questions/3216360/merge-update-and-pull-git-branches-without-using-checkouts/17722977#17722977
+echo "About to fetch and sync origin/master branch with local master branch:"
+read -p "  Press enter to continue"
+
+(set -x; git fetch origin master:master)
+
+# Legacy branch names
+
+echo
+echo "About to deploy to sparkle1 - sparkle5:"
+read -p "  Press enter to continue"
+
+(set -x; git push origin master:sparkle1)
+(set -x; git push origin master:sparkle2)
+(set -x; git push origin master:sparkle3)
+(set -x; git push origin master:sparkle4)
+(set -x; git push origin master:sparkle5)
+
+echo
+echo "About to deploy to sparkle6 - sparkle10, bigtop, deloitte:"
+read -p "  Press enter to continue"
+
+(set -x; git push origin master:sparkle6)
+(set -x; git push origin master:sparkle7)
+(set -x; git push origin master:sparkle8)
+(set -x; git push origin master:sparkle9)
+(set -x; git push origin master:sparkle10)
+
+(set -x; git push origin master:bigtop)
+(set -x; git push origin master:deloitte)
+
+# Modern branch names
+
+echo
+echo "About to deploy to memrise, unesco, ohbm, pa:"
+read -p "  Press enter to continue"
+
+#(set -x; git push origin master:env/kotr) # Note: This runs custom code/is no longer used/required. Don't deploy to it.
+(set -x; git push origin master:env/memrise)
+(set -x; git push origin master:env/unesco)
+(set -x; git push origin master:env/ohbm)
+(set -x; git push origin master:env/pa)
+
+echo
+echo "All done!"

--- a/scripts/pr-show-commits
+++ b/scripts/pr-show-commits
@@ -1,0 +1,21 @@
+# https://cli.github.com/
+# https://github.com/octokit/core.js
+#   TODO: rewrite this so that it uses octokit core, and then maybe do it as a GitHub action/similar?
+#   https://github.com/octokit/graphql.js
+#   https://github.com/octokit/action.js
+#   https://github.com/octokit/request-action
+#   https://github.com/actions/toolkit
+
+
+# Useful for generating the description for a 'deploy' PR that follows our standards.
+#
+# Usage:
+#   Retrieve a markdown formatted list of the first line of commit message for each commit in the specified PR
+#     ./pr-show-commits 1138
+#
+#   Count of commits in PR
+#     ./pr-show-commits 1138 | wc -l
+
+PR=$1
+
+gh api "/repos/:owner/:repo/pulls/$PR/commits" --jq 'map(.commit.message |= "- " + split("(?:\r\n|\n)"; "")[0]) | .[] | .commit.message'

--- a/scripts/pr-show-commits
+++ b/scripts/pr-show-commits
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # https://cli.github.com/
 # https://github.com/octokit/core.js
 #   TODO: rewrite this so that it uses octokit core, and then maybe do it as a GitHub action/similar?

--- a/scripts/pr-unresolved-review-comments
+++ b/scripts/pr-unresolved-review-comments
@@ -1,0 +1,54 @@
+# https://cli.github.com/
+# https://docs.github.com/en/graphql/overview/explorer
+# https://stackoverflow.com/questions/26701538/how-to-filter-an-array-of-objects-based-on-values-in-an-inner-array-with-jq/26701851#26701851
+# https://github.com/octokit/core.js#graphql-example
+#   TODO: rewrite this so that it uses octokit core, and then maybe do it as a GitHub action/similar?
+#   https://github.com/octokit/graphql.js
+#   https://github.com/octokit/action.js
+#   https://github.com/octokit/request-action
+#   https://github.com/actions/toolkit
+
+# Posted solution to:
+#   https://stackoverflow.com/questions/55713929/list-all-unresolved-pull-request-comments/66072198#66072198
+#   https://github.community/t/state-of-conversation-marked-resolved/14355/3?u=0xdevalias
+
+# Usage:
+#   Retrieve unresolved review comments
+#     ./pr-unresolved-review-comments sparkletown sparkle 1016
+#
+#   Count of unresolved review comment threads
+#     ./pr-unresolved-review-comments sparkletown sparkle 1016 | jq length
+
+OWNER=$1
+REPO=$2
+PR=$3
+
+gh api graphql -f query="
+  query FetchReviewComments {
+    repository(owner: \"$OWNER\", name: \"$REPO\") {
+      pullRequest(number: $PR) {
+        url
+        reviewDecision
+        reviewThreads(first: 100) {
+          edges {
+            node {
+              isResolved
+              isOutdated
+              isCollapsed
+              comments(first: 100) {
+                totalCount
+                nodes {
+                  author {
+                    login
+                  }
+                  body
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+" | jq '.data.repository.pullRequest.reviewThreads.edges | map(select(.node.isResolved == false))'

--- a/scripts/pr-unresolved-review-comments
+++ b/scripts/pr-unresolved-review-comments
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # https://cli.github.com/
 # https://docs.github.com/en/graphql/overview/explorer
 # https://stackoverflow.com/questions/26701538/how-to-filter-an-array-of-objects-based-on-values-in-an-inner-array-with-jq/26701851#26701851


### PR DESCRIPTION
- `scripts/deploy-master-to-prod-envs`: Basic hacky bash script to deploy `master` to all(?) of our environments
- `scripts/pr-show-commits`: Uses the GitHub CLI to call the GitHub API to retrieve all of the commits for a given PR (useful for quickly making the list of included commits for the description in deployment PRs)
- `scripts/pr-unresolved-review-comments`: Uses the GitHub CLI to call the GitHub GraphQL API to list the unresolved review comments for the specified PR