### PR TITLE
refactor openUrl/openRoomUrl/enterVenue to allow custom openers + use React Router for navigation in PosterPreview / NavBar's back button

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -19,7 +19,7 @@ import {
 } from "utils/selectors";
 
 import { hasElements } from "utils/types";
-import { venueInsideUrl } from "utils/url";
+import { enterVenue, venueInsideUrl } from "utils/url";
 
 import { useRadio } from "hooks/useRadio";
 import { useSelector } from "hooks/useSelector";
@@ -101,6 +101,7 @@ const NavBar: React.FC<NavBarPropsType> = ({
 
   const {
     location: { pathname },
+    push: openUrlUsingRouter,
   } = useHistory();
   const isOnPlaya = pathname.toLowerCase() === venueInsideUrl(PLAYA_VENUE_ID);
 
@@ -153,8 +154,8 @@ const NavBar: React.FC<NavBarPropsType> = ({
 
   const parentVenueId = venue?.parentId ?? "";
   const backToParentVenue = useCallback(() => {
-    window.location.href = venueInsideUrl(parentVenueId);
-  }, [parentVenueId]);
+    enterVenue(parentVenueId, { customOpenRelativeUrl: openUrlUsingRouter });
+  }, [parentVenueId, openUrlUsingRouter]);
 
   const navigateToHomepage = useCallback(() => {
     const venueLink =

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from "react";
 import { GenericVenue } from "types/venues";
 
 import { WithId } from "utils/id";
-import { enterVenue } from "utils/url";
 
 import { usePosters } from "hooks/posters";
 
@@ -33,11 +32,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
 
   const renderedPosterPreviews = useMemo(() => {
     return posterVenues.map((posterVenue) => (
-      <PosterPreview
-        key={posterVenue.id}
-        posterVenue={posterVenue}
-        enterVenue={enterVenue}
-      />
+      <PosterPreview key={posterVenue.id} posterVenue={posterVenue} />
     ));
   }, [posterVenues]);
 

--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import classNames from "classnames";
+import { useHistory } from "react-router-dom";
 
 import { PosterPageVenue } from "types/venues";
 
@@ -25,7 +26,11 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
     "PosterPreview--live": posterVenue.isLive,
   });
 
-  const handleEnterVenue = useCallback(() => enterVenue(venueId), [venueId]);
+  const { push: openUrlUsingRouter } = useHistory();
+  const handleEnterVenue = useCallback(
+    () => enterVenue(venueId, { customOpenRelativeUrl: openUrlUsingRouter }),
+    [venueId, openUrlUsingRouter]
+  );
 
   const renderedCategories = useMemo(
     () =>

--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import { PosterPageVenue } from "types/venues";
 
 import { WithId } from "utils/id";
+import { enterVenue } from "utils/url";
 
 import { PosterCategory } from "components/atoms/PosterCategory";
 
@@ -11,12 +12,10 @@ import "./PosterPreview.scss";
 
 export interface PosterPreviewProps {
   posterVenue: WithId<PosterPageVenue>;
-  enterVenue: (venueId: string) => void;
 }
 
 export const PosterPreview: React.FC<PosterPreviewProps> = ({
   posterVenue,
-  enterVenue,
 }) => {
   const { title, authorName, categories } = posterVenue.poster ?? {};
 
@@ -26,10 +25,7 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
     "PosterPreview--live": posterVenue.isLive,
   });
 
-  const handleEnterVenue = useCallback(() => enterVenue(venueId), [
-    enterVenue,
-    venueId,
-  ]);
+  const handleEnterVenue = useCallback(() => enterVenue(venueId), [venueId]);
 
   const renderedCategories = useMemo(
     () =>

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -38,8 +38,14 @@ export const openRoomUrl = (url: string) => {
 };
 
 export const enterVenue = (venueId: string) => openUrl(venueInsideUrl(venueId));
+export interface OpenUrlOptions {
+  customOpenRelativeUrl?: (url: string) => void;
+  customOpenExternalUrl?: (url: string) => void;
+}
 
-export const openUrl = (url: string) => {
+export const openUrl = (url: string, options?: OpenUrlOptions) => {
+  const { customOpenExternalUrl, customOpenRelativeUrl } = options ?? {};
+
   if (!isValidUrl(url)) {
     Bugsnag.notify(
       // new Error(`Invalid URL ${url} on page ${window.location.href}; ignoring`),
@@ -55,10 +61,14 @@ export const openUrl = (url: string) => {
   }
 
   if (isExternalUrl(url)) {
-    window.open(url, "_blank", "noopener,noreferrer");
+    customOpenExternalUrl
+      ? customOpenExternalUrl(url)
+      : window.open(url, "_blank", "noopener,noreferrer");
   } else {
-    // @debt Possibly use react router here with window.location.pathname.
-    window.location.href = url;
+    // @debt Is this a decent enough way to use react router here? Should we just use it always and get rid of window.location.href?
+    customOpenRelativeUrl
+      ? customOpenRelativeUrl(url)
+      : (window.location.href = url);
   }
 };
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -33,8 +33,8 @@ export const isExternalUrl = (url: string) => {
 export const getRoomUrl = (roomUrl: string) =>
   roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
 
-export const openRoomUrl = (url: string) => {
-  openUrl(getRoomUrl(url));
+export const openRoomUrl = (url: string, options?: OpenUrlOptions) => {
+  openUrl(getRoomUrl(url), options);
 };
 
 export const enterVenue = (venueId: string) => openUrl(venueInsideUrl(venueId));

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -37,7 +37,9 @@ export const openRoomUrl = (url: string, options?: OpenUrlOptions) => {
   openUrl(getRoomUrl(url), options);
 };
 
-export const enterVenue = (venueId: string) => openUrl(venueInsideUrl(venueId));
+export const enterVenue = (venueId: string, options?: OpenUrlOptions) =>
+  openUrl(venueInsideUrl(venueId), options);
+
 export interface OpenUrlOptions {
   customOpenRelativeUrl?: (url: string) => void;
   customOpenExternalUrl?: (url: string) => void;


### PR DESCRIPTION
The changes in this PR basically pave the way to us being able to use React Router for relative link navigation, rather than having to entirely load the application every time someone changes spaces (or as @yarikoptic describes it: the "blue screen of sparkle")

- https://reactrouter.com/web/api/history
  - > `push(path, [state])` - (`function`) Pushes a new entry onto the history stack

It adds this support in `openUrl`, `openRoomUrl`, and `enterVenue` within `utils/url`.

It uses this in only 2 places currently (we can add more in future followup PRs):

- the `backToParentVenue` button in the `NavBar` component
- within the `PosterPreview` component when accessing a `PosterPage`

I want to keep the scope of this PR fairly small for now, as while it does increase the perceived performance of the app quite a bit when navigating between spaces; there are cases where we actually benefit from the "forced to fully reload the page" navigation, as it can force aspects of our code with potential memory leaks/etc to get reset/cleaned up. I'm not certain if/where/how much of an impact that will be, so I want to avoid updating this across the entire app until we have a better idea around that.

---

partially fixes https://github.com/sparkletown/sparkle/issues/1461

Will likely be useful for https://github.com/sparkletown/internal-sparkle-issues/issues/752#issuecomment-850333759