### PR TITLE
Pay the @debt - it was a false positive

### DIFF
--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -4,9 +4,6 @@
  * @param string
  *
  * @see https://stackoverflow.com/a/16261693/1265472
- *
- * @debt Depending on the outcome of https://github.com/github/codeql/issues/5964 we may end up needing to change
- *   this regex for performance reasons.
  */
 export const tokeniseStringWithQuotesBySpaces = (string: string): string[] =>
   string.match(/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/g) ?? [];


### PR DESCRIPTION
false positive statement: https://github.com/github/codeql/issues/5964#issuecomment-850344692

Verified by timing given in the https://github.com/github/codeql/issues/5964
example

	$> cat ./test.js
	/("[^"]*?"|[^"\s]+)+X/.test("!!!!!!!!!!!!!!!!!!!!!!!!!!!")

	$> time nodejs ./test.js
	nodejs ./test.js  8.92s user 0.01s system 99% cpu 8.931 total

against our lookahead (added a few more ! for a good measure to no effect):

	$> cat ./test.js
	/("[^"]*?"|[^"\s]+)+(?=\s*|\s*$)/.test("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")

	$> time nodejs ./test.js
	nodejs ./test.js  0.10s user 0.01s system 100% cpu 0.113 total

and note that it is not per se about ! but any non "\s (a few less chars here
-- time is scarse):

	$> cat ./test.js
	/("[^"]*?"|[^"\s]+)+X/.test("########################")

	$> time nodejs ./test.js
	nodejs ./test.js  1.15s user 0.01s system 100% cpu 1.154 total

attn @0xdevalias @mike-lvov 

ref origin: https://github.com/sparkletown/sparkle/pull/1443