### PR TITLE
More markdown: event modal description

### DIFF
--- a/src/components/organisms/EventModal/EventModal.scss
+++ b/src/components/organisms/EventModal/EventModal.scss
@@ -24,13 +24,6 @@ $EventModal--padding-top: 40px;
     opacity: 0.8;
   }
 
-  &__description {
-    font-size: $font-size--md;
-    opacity: 0.8;
-    padding-top: $spacing--xl;
-    padding-bottom: $spacing--xl;
-  }
-
   // @debt we need to transform the rule to `&__button { ... }` once `<Button />` styles stop appearing later than the styles from this file
   & .EventModal__button {
     background-color: $primary--live;

--- a/src/components/organisms/EventModal/EventModal.scss
+++ b/src/components/organisms/EventModal/EventModal.scss
@@ -24,6 +24,13 @@ $EventModal--padding-top: 40px;
     opacity: 0.8;
   }
 
+  &__description {
+    font-size: $font-size--md;
+    opacity: 0.8;
+    padding-top: $spacing--xl;
+    padding-bottom: $spacing--xl;
+  }
+
   // @debt we need to transform the rule to `&__button { ... }` once `<Button />` styles stop appearing later than the styles from this file
   & .EventModal__button {
     background-color: $primary--live;

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -78,7 +78,9 @@ export const EventModal: React.FC<EventModalProps> = ({
           </button>
         </span>
 
-        <RenderMarkdown text={event.description} />
+        <div className="EventModal__description">
+          <RenderMarkdown text={event.description} />
+        </div>
 
         <Button
           customClass="EventModal__button"

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -17,6 +17,8 @@ import { useRoom } from "hooks/useRoom";
 
 import { Button } from "components/atoms/Button";
 
+import { RenderMarkdown } from "components/organisms/RenderMarkdown";
+
 import "./EventModal.scss";
 
 export interface EventModalProps {
@@ -68,7 +70,9 @@ export const EventModal: React.FC<EventModalProps> = ({
   return (
     <Modal show={show} onHide={onHide} className="EventModal">
       <div className="EventModal__content">
-        <h4 className="EventModal__title">{event.name}</h4>
+        <h4 className="EventModal__title">
+          <RenderMarkdown text={event.name} />
+        </h4>
         <span className="EventModal__subtitle">
           by {event.host} in{" "}
           <button className="button--a" onClick={goToEventLocation}>
@@ -76,7 +80,7 @@ export const EventModal: React.FC<EventModalProps> = ({
           </button>
         </span>
 
-        <p className="EventModal__description">{event.description}</p>
+        <RenderMarkdown text={event.description} />
 
         <Button
           customClass="EventModal__button"

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -70,9 +70,7 @@ export const EventModal: React.FC<EventModalProps> = ({
   return (
     <Modal show={show} onHide={onHide} className="EventModal">
       <div className="EventModal__content">
-        <h4 className="EventModal__title">
-          <RenderMarkdown text={event.name} />
-        </h4>
+        <h4 className="EventModal__title">{event.name}</h4>
         <span className="EventModal__subtitle">
           by {event.host} in{" "}
           <button className="button--a" onClick={goToEventLocation}>


### PR DESCRIPTION
This is how it would look like with this PR (edit: title is no longer rendered so must not be markdown)

![image](https://user-images.githubusercontent.com/39889/121106236-9ebac800-c7d3-11eb-89f8-db6cef7878d2.png)

in comparison to 

![image](https://user-images.githubusercontent.com/39889/121106302-c1e57780-c7d3-11eb-9923-7ba61ebad7f7.png)

Closes #1505 