### PR TITLE
posterhall: Add a way to quickly preview abstract or download in a separate tab/window (reused)

### DIFF
--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -5,7 +5,7 @@ import { useHistory } from "react-router-dom";
 import { PosterPageVenue } from "types/venues";
 
 import { WithId } from "utils/id";
-import { enterVenue } from "utils/url";
+import { enterVenue, externalUrlAdditionalProps } from "utils/url";
 
 import { PosterCategory } from "components/atoms/PosterCategory";
 
@@ -51,6 +51,14 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
       <a href={posterAbsUrl} target="_ohbm-poster-preview">
         📄
       </a>
+      {posterVenue.iframeUrl?.trim() !== "" ? (
+        <a href={posterVenue.iframeUrl} {...externalUrlAdditionalProps}>
+          {" "}
+          ⬇{" "}
+        </a>
+      ) : (
+        <div />
+      )}
       <div onClick={handleEnterVenue}>
         <p className="PosterPreview__title">
           {posterVenue.name}: {title}

--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -21,6 +21,12 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
   const { title, authorName, categories } = posterVenue.poster ?? {};
 
   const venueId = posterVenue.id;
+  const posterId = venueId.replace("poster", "");
+  // TODO: the posterId doesn't correspond to abs ID. We will need proper URL in DB.
+  // This version is just to demonstrate possibility
+  const posterAbsUrl =
+    "https://ww4.aievolution.com/hbm2101/index.cfm?do=abs.viewAbs&src=ext&abs=" +
+    posterId;
 
   const posterClassnames = classNames("PosterPreview", {
     "PosterPreview--live": posterVenue.isLive,
@@ -41,14 +47,19 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
   );
 
   return (
-    <div className={posterClassnames} onClick={handleEnterVenue}>
-      <p className="PosterPreview__title">
-        {posterVenue.name}: {title}
-      </p>
+    <div className={posterClassnames}>
+      <a href={posterAbsUrl} target="_ohbm-poster-preview">
+        📄
+      </a>
+      <div onClick={handleEnterVenue}>
+        <p className="PosterPreview__title">
+          {posterVenue.name}: {title}
+        </p>
 
-      <div className="PosterPreview__categories">{renderedCategories}</div>
+        <div className="PosterPreview__categories">{renderedCategories}</div>
 
-      <div className="PosterPreview__author">{authorName}</div>
+        <div className="PosterPreview__author">{authorName}</div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Ideally should sit on top of    https://github.com/sparkletown/sparkle/pull/1375
which would also add a bookmarking capability.  Both bookmark and this page icon should stay side by side.

With this tiny PR visitors could arrange it like
![image](https://user-images.githubusercontent.com/39889/121418460-f9216900-c938-11eb-965b-c5e94200f072.png)

and quickly navigate through the posters until you decide to enter one.  We can trust external urls in this case IMHO so I do not think there are security implications.

edit: added also a "download" icon (following @0xdevalias instructions on how to make it harmoneously into a separate new window for this one).  Now just need to figure out how to not do overall `display: flex;` of the entire `PosterPreview` class, since they stack up vertically:
![image](https://user-images.githubusercontent.com/39889/121456618-571f7200-c974-11eb-9996-8a77ea9136d2.png)

If this would be an acceptable solution, we would need 
- [ ] get proper IDs or full URLs in DB 
- [ ] harmonize with #1375 in positioning of bookmark and this 📄 icon (partially addresses #1462)
