### PR TITLE
Styling fix: add option to remove venue icon / title / description in navbar dropdown schedule

### DIFF
--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -41,6 +41,8 @@ import {
   prepareForSchedule,
 } from "./utils";
 
+import { SCHEDULE_SHOW_VENUE_DESCRIPTION_IN_NAVBAR } from "settings";
+
 import "./NavBarSchedule.scss";
 
 const emptyRelatedEvents: WithVenueId<VenueEvent>[] = [];
@@ -205,7 +207,9 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
 
   return (
     <div className={containerClasses}>
-      {venueId && <ScheduleVenueDescription venueId={venueId} />}
+      {venueId && SCHEDULE_SHOW_VENUE_DESCRIPTION_IN_NAVBAR && (
+        <ScheduleVenueDescription venueId={venueId} />
+      )}
       {!isLoadingSchedule && (
         <div className="NavBarSchedule__download-buttons">
           {hasSavedEvents && (

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -606,6 +606,7 @@ export const USER_STATUSES = [UserStatus.available, UserStatus.busy];
 
 // SCHEDULE
 // @debt probably would be better to adjust max hour based on user's display size
+export const SCHEDULE_SHOW_VENUE_DESCRIPTION_IN_NAVBAR = true;
 export const SCHEDULE_MAX_START_HOUR = 16;
 export const SCHEDULE_HOUR_COLUMN_WIDTH_PX = 200;
 export const SCHEDULE_SHOW_DAYS_AHEAD = 7;


### PR DESCRIPTION
[original bug this was trying to address wasn't fixed. so modified this PR to the one working issue it now addresses]

The venue icon takes up approximately 1/3 of the vertical space in the navbar schedule. In the case of complex, multi-venue/room schedule, this space might be better used displaying the schedule content and reducing the need to scroll. I've set this as an option that can be changed in `settings.ts`: bacf9e79783ff95fce289e0c4194808f957e856c