### PR TITLE
initial fix for overlapping events

### DIFF
--- a/src/components/molecules/ScheduleEvent/ScheduleEvent.scss
+++ b/src/components/molecules/ScheduleEvent/ScheduleEvent.scss
@@ -4,7 +4,7 @@ $ScheduleEvent--margin-top: 0.25rem;
 $ScheduleEvent--height: 3.75rem;
 $ScheduleEvent--padding: 0 0.25rem 0 0.75rem;
 $ScheduleEvent--border-radius: 18px;
-$ScheduleEvent--box-shadow: 0 5px 10px rgba(0, 0, 0, 0.65);
+$ScheduleEvent--box-shadow: 0 5px 10px 3px rgba(0, 0, 0, 0.65);
 
 $bookmark--padding: 0.5rem;
 $bookmark-hover--padding-top: 0.375rem;
@@ -17,12 +17,12 @@ $description--margin-top: 2px;
   border-radius: $ScheduleEvent--border-radius;
   padding: $ScheduleEvent--padding;
   cursor: pointer;
-  height: $ScheduleEvent--height;
+  height: var(--event--height); // $ScheduleEvent--height;
   justify-content: space-between;
   align-items: center;
   background-color: $secondary--schedule-event;
   box-shadow: $ScheduleEvent--box-shadow;
-  margin-top: $ScheduleEvent--margin-top;
+  margin-top: var(--event--margin-top); // $ScheduleEvent--margin-top;
   margin-left: var(--event--margin-left);
   width: var(--event--width);
 

--- a/src/components/molecules/ScheduleEvent/ScheduleEvent.tsx
+++ b/src/components/molecules/ScheduleEvent/ScheduleEvent.tsx
@@ -30,12 +30,16 @@ export interface ScheduleEventProps {
   event: PersonalizedVenueEvent;
   scheduleStartHour: number;
   personalizedEvent?: boolean;
+  overlapEvents?: number;
+  totalOverlaps?: number;
 }
 
 export const ScheduleEvent: React.FC<ScheduleEventProps> = ({
   event,
   scheduleStartHour,
   personalizedEvent: isPersonalizedEvent = false,
+  overlapEvents,
+  totalOverlaps,
 }) => {
   const { userId } = useUser();
 
@@ -49,9 +53,16 @@ export const ScheduleEvent: React.FC<ScheduleEventProps> = ({
     scheduleStartHour
   );
 
+  const eventMarginTopPx: number = overlapEvents ? overlapEvents * 24 + 4 : 0;
+  const eventHeightPx: number =
+    totalOverlaps !== 1 ? (60 / (totalOverlaps || 24)) * 2.5 : 60;
+  console.log(totalOverlaps, overlapEvents);
+
   const containerCssVars = useCss({
     "--event--margin-left": `${eventMarginLeftPx}px`,
     "--event--width": `${eventWidthPx}px`,
+    "--event--margin-top": `${eventMarginTopPx}px`,
+    "--event--height": `${eventHeightPx}px`,
   });
 
   const containerClasses = classNames(

--- a/src/components/molecules/ScheduleRoomEvents/ScheduleRoomEvents.tsx
+++ b/src/components/molecules/ScheduleRoomEvents/ScheduleRoomEvents.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { PersonalizedVenueEvent } from "types/venues";
+import { checkOverlap } from "utils/event";
 
 import { ScheduleEvent } from "components/molecules/ScheduleEvent";
 
@@ -17,14 +18,21 @@ export const _ScheduleRoomEvents: React.FC<ScheduleRoomEventsProps> = ({
   scheduleStartHour,
   personalizedRoom,
 }) => {
+  const { overlapEvents, totalOverlaps, sortedEvents } = useMemo(
+    () => checkOverlap(events),
+    [events]
+  );
+
   return (
     <div className="ScheduleRoomEvents">
-      {events.map((event) => (
+      {sortedEvents.map((event, index) => (
         <ScheduleEvent
           key={`event-${event.id}`}
           personalizedEvent={personalizedRoom}
           event={event}
           scheduleStartHour={scheduleStartHour}
+          overlapEvents={overlapEvents[index]}
+          totalOverlaps={totalOverlaps[index]}
         />
       ))}
     </div>


### PR DESCRIPTION
This is a bit hacky, but seems to roughly achieve the goal of spreading events vertically if they're overlapping within the room/venue-row of the dropdown schedule navbar.