### PR TITLE
fix covert room type classes in MapRoom to not scale on hover

### DIFF
--- a/src/components/templates/PartyMap/components/Map/MapRoom.tsx
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.tsx
@@ -47,8 +47,9 @@ export const MapRoom: React.FC<MapRoomProps> = ({
   }, [dispatch]);
 
   const containerClasses = classNames("maproom", {
-    "maproom--covert maproom--unclickable": isUnclickable,
-    "maproom--covert maproom--iframe": isMapFrame,
+    "maproom--covert": isCovertRoom,
+    "maproom--unclickable": isUnclickable,
+    "maproom--iframe": isMapFrame,
     "maproom--always-show-label":
       !isCovertRoom &&
       (venue.roomVisibility === RoomVisibility.nameCount ||

--- a/src/components/templates/PartyMap/components/Map/MapRoom.tsx
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.tsx
@@ -47,8 +47,8 @@ export const MapRoom: React.FC<MapRoomProps> = ({
   }, [dispatch]);
 
   const containerClasses = classNames("maproom", {
-    "maproom--covert--unclickable": isUnclickable,
-    "maproom--covert--iframe": isMapFrame,
+    "maproom--covert maproom--unclickable": isUnclickable,
+    "maproom--covert maproom--iframe": isMapFrame,
     "maproom--always-show-label":
       !isCovertRoom &&
       (venue.roomVisibility === RoomVisibility.nameCount ||


### PR DESCRIPTION
Minor bug fix to return prior functionality to covert room type. The recent update to this code in https://github.com/sparkletown/sparkle/pull/1427 seems to have allowed unclickable and mapframe room types to scale on hover. This PR reverts that change.