### PR TITLE
[env/ohbm] add download icon (⬇) alongside with the bookmark

### DIFF
--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.scss
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.scss
@@ -49,6 +49,12 @@ $active-poster-shadows: 0 10px 20px 0 rgba($primary, 0.56);
     font-size: $font-size--sm;
   }
 
+  &__posterDownload {
+    display: inline;
+    font-size: $font-size--md;
+    margin-right: $spacing--sm;
+  }
+
   &__visiting {
     display: inline;
     font-size: $font-size--sm;

--- a/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
+++ b/src/components/templates/PosterHall/components/PosterPreview/PosterPreview.tsx
@@ -41,6 +41,9 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
 
   const venueId = posterVenue.id;
 
+  const iframeUrl = posterVenue.iframeUrl;
+  const hasPdf = iframeUrl?.endsWith(".pdf");
+
   const posterClassnames = classNames("PosterPreview", {
     "PosterPreview--live": posterVenue.isLive,
   });
@@ -117,6 +120,12 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
     ));
   }, [moreInfoUrls, renderInfoLink, moreUrlInfoText]);
 
+  const renderIframeUrl = useMemo(() => {
+    if (!iframeUrl) return;
+
+    return renderInfoLink(iframeUrl, "⬇");
+  }, [iframeUrl, renderInfoLink]);
+
   const hasMoreInfo = renderMoreInfoUrl || renderMoreInfoUrls;
 
   return (
@@ -126,6 +135,11 @@ export const PosterPreview: React.FC<PosterPreviewProps> = ({
           {canBeBookmarked && (
             <div className={posterBookmarkClassname}>
               <PosterBookmark posterVenue={posterVenue} />
+            </div>
+          )}
+          {posterId && hasPdf && (
+            <div className="PosterPreview__posterDownload">
+              {renderIframeUrl}
             </div>
           )}
           {posterId && (


### PR DESCRIPTION
Replacement for #1527.
Sits on top of #1547 for a fix.

But the effect of it fixes the incorrect (off the div) rendering of the number of current visitors. compare
![image](https://user-images.githubusercontent.com/39889/121990164-52d7c800-cd6b-11eb-9ec5-aa7c8eafc9a1.png)
as of staging to
![image](https://user-images.githubusercontent.com/39889/121990116-405d8e80-cd6b-11eb-9bfd-1a128516f22c.png)
as of this PR

edit 1: if someone could help to style it better (icons should be larger but somehow my tune ups to font-size had no effect, didn't inverstigate) correctly would be appreciated