### PR TITLE
Stylize scrollbar in RoomModals and show it only when needed

### DIFF
--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
@@ -54,6 +54,7 @@ $spacing: 20px;
   }
 
   &__description {
+    @include scrollbar;
     margin-top: $spacing;
     padding: 10px $spacing;
 
@@ -61,7 +62,7 @@ $spacing: 20px;
     border-radius: $border-radius;
 
     max-height: 25vh;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   &__events {


### PR DESCRIPTION
discovered a small UI "bug" in the RoomModal while reviewing #1538

the scrollbar of the description area was always visible ( even if there is nothing to scroll )
\+ applied styling to it

BEFORE
* short description (scrollbar is not needed)
![image](https://user-images.githubusercontent.com/63313732/122109205-1a77ce80-cdeb-11eb-9527-e3eed2e15717.png)
* long description (scrollbar is needed)
![image](https://user-images.githubusercontent.com/63313732/122109385-50b54e00-cdeb-11eb-8186-70db752d919c.png)


AFTER
* short description (scrollbar is not needed)
![image](https://user-images.githubusercontent.com/63313732/122109257-26639080-cdeb-11eb-8520-8220bf404aee.png)
* long description (scrollbar is needed)
![image](https://user-images.githubusercontent.com/63313732/122109407-57dc5c00-cdeb-11eb-953a-8d73bc50e406.png)

