### PR TITLE
use venue.chatTitle to set search field message

### DIFF
--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -46,6 +46,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
         searchInputValue={searchInputValue}
         liveFilterValue={liveFilter}
         setLiveValue={setLiveFilter}
+        searchTitleBase={venue?.chatTitle}
       />
 
       <div className="PosterHall__posters">

--- a/src/components/templates/PosterHall/components/PosterHallSearch/PosterHallSearch.tsx
+++ b/src/components/templates/PosterHall/components/PosterHallSearch/PosterHallSearch.tsx
@@ -14,6 +14,8 @@ export interface PosterHallSearchProps {
 
   liveFilterValue: boolean;
   setLiveValue: (isLive: boolean) => void;
+
+  searchTitleBase?: string;
 }
 
 export const PosterHallSearch: React.FC<PosterHallSearchProps> = ({
@@ -22,6 +24,8 @@ export const PosterHallSearch: React.FC<PosterHallSearchProps> = ({
 
   liveFilterValue,
   setLiveValue,
+
+  searchTitleBase,
 }) => {
   const onInputFieldChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,13 +39,15 @@ export const PosterHallSearch: React.FC<PosterHallSearchProps> = ({
     [setLiveValue]
   );
 
+  const searchTitle = `Search ${searchTitleBase}` ?? "Search Posters/Demos";
+
   return (
     <div className="PosterHallSearch">
       <InputField
         containerClassName="PosterHallSearch__input-container"
         inputClassName="PosterHallSearch__input"
         iconStart={faSearch}
-        placeholder="Search Posters/Demos"
+        placeholder={searchTitle}
         value={searchInputValue}
         onChange={onInputFieldChange}
       />


### PR DESCRIPTION
This fix addresses the default "Search Posters/Demos" message that appears in the posterhall template. This may not be appropriate for all contexts where posterhall is used. This PR addresses this issue by reusing `chatTitle` to provide a customized search field message. 

Thanks to @yarikoptic for catching this issue!