### PR TITLE
ENH: poster search - give authors more weightand authorName even twice more

### DIFF
--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -76,9 +76,15 @@ export const usePosters = (posterHallId: string) => {
         keys: [
           "name",
           "poster.title",
-          "poster.authorName",
+          {
+            name: "poster.authorName",
+            weight: 16,
+          },
           "poster.categories",
-          "poster.authors",
+          {
+            name: "poster.authors",
+            weight: 8,
+          },
           "poster.keywords",
           "poster.introduction",
         ],


### PR DESCRIPTION
Without such a change, search for a well cited (in introduction) scientist
leads to have those hits ahead of the hits where that person is the author
or among authors.  Since names are typically "unique" in sense of not overlapping
with keywords or words used in the title, I think a side-effect on search by
titles etc is (tested on some) non-existing or very minor.

Sample searches to do on env/ohbm would be Fornito or Poldrack to see the effect