### PR TITLE
Fix/add category filter to posterhall

### DIFF
--- a/src/components/templates/PosterHall/PosterHall.scss
+++ b/src/components/templates/PosterHall/PosterHall.scss
@@ -25,4 +25,17 @@
     cursor: pointer;
     text-transform: capitalize;
   }
+
+  &__subcategories {
+    display: flex;
+    justify-content: center;
+    margin: $spacing--xs;
+    flex-wrap: wrap;
+  }
+
+  &__subcategory {
+    font-size: $font-size--xxs;
+    cursor: pointer;
+    text-transform: capitalize;
+  }
 }

--- a/src/components/templates/PosterHall/PosterHall.scss
+++ b/src/components/templates/PosterHall/PosterHall.scss
@@ -1,3 +1,5 @@
+@import "scss/constants";
+
 .PosterHall {
   &__posters {
     display: flex;
@@ -9,5 +11,18 @@
   &__more-button {
     display: flex;
     justify-content: center;
+  }
+
+  &__categories {
+    display: flex;
+    justify-content: center;
+    margin: $spacing--md;
+    flex-wrap: wrap;
+  }
+
+  &__category {
+    font-size: $font-size--sm;
+    cursor: pointer;
+    text-transform: capitalize;
   }
 }

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -72,6 +72,11 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
     [categoryList, categoryFilter, setCategoryFilter, unsetCategoryFilter]
   );
 
+  const showCategoriesFilter = useMemo(
+    () => venue?.showCategoriesFilter ?? false,
+    [venue]
+  );
+
   return (
     <div className="PosterHall">
       <PosterHallSearch
@@ -81,7 +86,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
         setLiveValue={setLiveFilter}
       />
 
-      {renderedCategoryOptions}
+      {showCategoriesFilter ? renderedCategoryOptions : null}
 
       <div className="PosterHall__posters">
         {isPostersLoaded ? renderedPosterPreviews : "Loading posters"}

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -55,7 +55,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
           containerClassname="PosterHall__category"
           active={categoryFilter === undefined}
         />
-        {categoryList.map((category, index) => {
+        {categoryList.map((category) => {
           if (!category) return [];
           return (
             <PosterCategory

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -26,14 +26,18 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
 
     increaseDisplayedPosterCount,
 
-    searchInputValue,
-    setSearchInputValue,
-    liveFilter,
-    setLiveFilter,
-
     categoryList,
+    subCategoryList,
+
+    searchInputValue,
+    liveFilter,
     categoryFilter,
+    subCategoryFilter,
+
+    setSearchInputValue,
+    setLiveFilter,
     setCategoryFilter,
+    setSubCategoryFilter,
     unsetCategoryFilter,
   } = usePosters(venue.id);
 
@@ -72,6 +76,23 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
     [categoryList, categoryFilter, setCategoryFilter, unsetCategoryFilter]
   );
 
+  const renderedSubCategoryOptions = useMemo(
+    () => (
+      <div className="PosterHall__subcategories">
+        {subCategoryList.map((subCategory) => (
+          <PosterCategory
+            key={subCategory}
+            category={subCategory}
+            onClick={() => setSubCategoryFilter(subCategory)}
+            containerClassname="PosterHall__subcategory"
+            active={subCategory === subCategoryFilter}
+          />
+        ))}
+      </div>
+    ),
+    [subCategoryList, subCategoryFilter, setSubCategoryFilter]
+  );
+
   const showCategoriesFilter = useMemo(
     () => venue?.showCategoriesFilter ?? false,
     [venue]
@@ -87,6 +108,7 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
       />
 
       {showCategoriesFilter ? renderedCategoryOptions : null}
+      {showCategoriesFilter ? renderedSubCategoryOptions : null}
 
       <div className="PosterHall__posters">
         {isPostersLoaded ? renderedPosterPreviews : "Loading posters"}

--- a/src/components/templates/PosterHall/PosterHall.tsx
+++ b/src/components/templates/PosterHall/PosterHall.tsx
@@ -7,6 +7,7 @@ import { WithId } from "utils/id";
 import { usePosters } from "hooks/posters";
 
 import { Button } from "components/atoms/Button";
+import { PosterCategory } from "components/atoms/PosterCategory";
 
 import { PosterPreview } from "./components/PosterPreview";
 import { PosterHallSearch } from "./components/PosterHallSearch";
@@ -29,6 +30,11 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
     setSearchInputValue,
     liveFilter,
     setLiveFilter,
+
+    categoryList,
+    categoryFilter,
+    setCategoryFilter,
+    unsetCategoryFilter,
   } = usePosters(venue.id);
 
   const shouldShowMorePosters = isPostersLoaded && hasHiddenPosters;
@@ -39,6 +45,33 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
     ));
   }, [posterVenues]);
 
+  const renderedCategoryOptions = useMemo(
+    () => (
+      <div className="PosterHall__categories">
+        <PosterCategory
+          key="All posters"
+          category="All posters"
+          onClick={unsetCategoryFilter}
+          containerClassname="PosterHall__category"
+          active={categoryFilter === undefined}
+        />
+        {categoryList.map((category, index) => {
+          if (!category) return [];
+          return (
+            <PosterCategory
+              key={category}
+              category={category}
+              onClick={() => setCategoryFilter(category)}
+              containerClassname="PosterHall__category"
+              active={category === categoryFilter}
+            />
+          );
+        })}
+      </div>
+    ),
+    [categoryList, categoryFilter, setCategoryFilter, unsetCategoryFilter]
+  );
+
   return (
     <div className="PosterHall">
       <PosterHallSearch
@@ -47,6 +80,8 @@ export const PosterHall: React.FC<PosterHallProps> = ({ venue }) => {
         liveFilterValue={liveFilter}
         setLiveValue={setLiveFilter}
       />
+
+      {renderedCategoryOptions}
 
       <div className="PosterHall__posters">
         {isPostersLoaded ? renderedPosterPreviews : "Loading posters"}

--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -49,10 +49,19 @@ export const usePosters = (posterHallId: string) => {
     setSearchInputValue,
   } = useDebounceSearch();
 
+  const [categoryFilter, _setCategoryFilter] = useState<string>();
   const [liveFilter, setLiveFilter] = useState<boolean>(false);
   const [displayedPostersCount, setDisplayedPostersAmount] = useState(
     DEFAULT_DISPLAYED_POSTER_PREVIEW_COUNT
   );
+
+  const setCategoryFilter = useCallback((category: string) => {
+    _setCategoryFilter(category);
+  }, []);
+
+  const unsetCategoryFilter = useCallback(() => {
+    _setCategoryFilter(undefined);
+  }, []);
 
   const increaseDisplayedPosterCount = useCallback(() => {
     setDisplayedPostersAmount(
@@ -61,12 +70,36 @@ export const usePosters = (posterHallId: string) => {
     );
   }, []);
 
+  const categoryList = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          posterVenues
+            .map((posterVenue) => posterVenue.poster?.categories)
+            .flat()
+        )
+      ),
+    [posterVenues]
+  );
+
+  const filteredPostersByCategory = useMemo(
+    () =>
+      categoryFilter
+        ? posterVenues.filter((posterVenue) =>
+            posterVenue.poster?.categories.includes(categoryFilter)
+          )
+        : posterVenues,
+    [posterVenues, categoryFilter]
+  );
+
   const filteredPosterVenues = useMemo(
     () =>
       liveFilter
-        ? posterVenues.filter((posterVenue) => posterVenue.isLive)
-        : posterVenues,
-    [posterVenues, liveFilter]
+        ? filteredPostersByCategory.filter(
+            (filteredPostersByCategory) => filteredPostersByCategory.isLive
+          )
+        : filteredPostersByCategory,
+    [filteredPostersByCategory, liveFilter]
   );
 
   // See https://fusejs.io/api/options.html
@@ -134,11 +167,16 @@ export const usePosters = (posterHallId: string) => {
     isPostersLoaded,
     hasHiddenPosters,
 
+    categoryList,
+
     searchInputValue,
+    categoryFilter,
     liveFilter,
 
     increaseDisplayedPosterCount,
     setSearchInputValue,
     setLiveFilter,
+    setCategoryFilter,
+    unsetCategoryFilter,
   };
 };

--- a/src/types/posters.ts
+++ b/src/types/posters.ts
@@ -1,6 +1,7 @@
 export type Poster = {
   authorName: string;
   categories: string[];
+  subcategories?: string[];
   title: string;
   authors?: string[];
   contactEmail?: string;

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -176,6 +176,7 @@ export interface BaseVenue {
   showBadges?: boolean;
   showNametags?: UsernameVisibility;
   showZendesk?: boolean;
+  showCategoriesFilter?: boolean;
 }
 
 export interface GenericVenue extends BaseVenue {


### PR DESCRIPTION
This PR brings the functionality for filtering posters based on categories to the posterhall template. It is implemented based on the category-level filtering approach currently available in the screeningroom template. 

Given some of the challenges we're having with search specificity, this brings a valuable tool for exploring the contents of the posterhall.

I thought this might be sufficiently general for staging, but can rebase on env/ohbm if more appropriate there. 