### PR TITLE
[env/ohbm] disable generic email/password registration method

### DIFF
--- a/src/components/organisms/AuthenticationModal/InitialForm/InitialForm.tsx
+++ b/src/components/organisms/AuthenticationModal/InitialForm/InitialForm.tsx
@@ -13,12 +13,13 @@ export const InitialForm: FC<InitialFormProps> = ({
 }) => {
   return (
     <div className="initial-form">
-      <div
-        className="btn btn-primary btn-block btn-centered create-account-button"
-        onClick={displayRegisterForm}
-      >
-        Create your account
-      </div>
+      {/* @debt Removed for OHBM SSO */}
+      {/*<div*/}
+      {/*  className="btn btn-primary btn-block btn-centered create-account-button"*/}
+      {/*  onClick={displayRegisterForm}*/}
+      {/*>*/}
+      {/*  Create your account*/}
+      {/*</div>*/}
       <div className="buttons-separator">or</div>
       <div
         className="btn btn-block btn-centered login-button"

--- a/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
+++ b/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
@@ -84,13 +84,14 @@ const LoginForm: React.FunctionComponent<LoginFormProps> = ({
 
   return (
     <div className="form-container">
-      <div className="secondary-action">
-        {`Don't have an account yet?`}
-        <br />
-        <span className="link" onClick={displayRegisterForm}>
-          Register instead!
-        </span>
-      </div>
+      {/* @debt Removed for OHBM SSO */}
+      {/*<div className="secondary-action">*/}
+      {/*  {`Don't have an account yet?`}*/}
+      {/*  <br />*/}
+      {/*  <span className="link" onClick={displayRegisterForm}>*/}
+      {/*    Register instead!*/}
+      {/*  </span>*/}
+      {/*</div>*/}
 
       <h2>Log in</h2>
 

--- a/src/pages/Account/Login.tsx
+++ b/src/pages/Account/Login.tsx
@@ -15,7 +15,7 @@ import { useSAMLSignIn } from "hooks/useSAMLSignIn";
 import { InitialForm } from "components/organisms/AuthenticationModal/InitialForm";
 import LoginForm from "components/organisms/AuthenticationModal/LoginForm";
 import PasswordResetForm from "components/organisms/AuthenticationModal/PasswordResetForm";
-import RegisterForm from "components/organisms/AuthenticationModal/RegisterForm";
+// import RegisterForm from "components/organisms/AuthenticationModal/RegisterForm";
 
 import { LoadingPage } from "components/molecules/LoadingPage";
 
@@ -117,20 +117,22 @@ export const Login: React.FC<LoginProps> = ({
             </div>
           </div>
         )}
-        {formToDisplay === "initial" && (
+        {/* @debt Changed for OHBM SSO */}
+        {["initial", "register"].includes(formToDisplay) && (
           <InitialForm
             displayLoginForm={displayLoginForm}
             displayRegisterForm={displayRegisterForm}
           />
         )}
-        {formToDisplay === "register" && (
-          <RegisterForm
-            displayLoginForm={displayLoginForm}
-            displayPasswordResetForm={displayPasswordResetForm}
-            afterUserIsLoggedIn={redirectAfterLogin}
-            closeAuthenticationModal={() => null}
-          />
-        )}
+        {/* @debt Removed for OHBM SSO */}
+        {/*{formToDisplay === "register" && (*/}
+        {/*  <RegisterForm*/}
+        {/*    displayLoginForm={displayLoginForm}*/}
+        {/*    displayPasswordResetForm={displayPasswordResetForm}*/}
+        {/*    afterUserIsLoggedIn={redirectAfterLogin}*/}
+        {/*    closeAuthenticationModal={() => null}*/}
+        {/*  />*/}
+        {/*)}*/}
         {formToDisplay === "login" && (
           <LoginForm
             displayRegisterForm={displayRegisterForm}


### PR DESCRIPTION
partially closes https://github.com/sparkletown/sparkle/pull/1523

Removes the standard registration method (while still allowing existing accounts to login) in preference of the SSO flow.

Initial View:
![image](https://user-images.githubusercontent.com/753891/122588329-4bcdf400-d0a2-11eb-9f7e-c2e11e9e02fc.png)

Login View:
![image](https://user-images.githubusercontent.com/753891/122588387-61431e00-d0a2-11eb-9ec4-68817c6c1d25.png)

Reset Password View:
![image](https://user-images.githubusercontent.com/753891/122588421-6c964980-d0a2-11eb-9d67-85c945dd00cd.png)