### PR TITLE
FIX check if event.host is empty when creating calendar

### DIFF
--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -19,7 +19,7 @@ export const createCalendar = ({
     calendar.createEvent({
       start: eventStartTime(event),
       end: eventEndTime(event),
-      organizer: parseCalenderOrganizer(event), // `${eventHostName} <undefined>`, // string format: "name <email>". email cannot be blank
+      organizer: parseCalenderOrganizer(event), // string format: "name <email>". email cannot be blank
       description: event.description,
       summary: event.name,
       url: getFullVenueInsideUrl(event.venueId),

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -19,7 +19,7 @@ export const createCalendar = ({
     calendar.createEvent({
       start: eventStartTime(event),
       end: eventEndTime(event),
-      organizer: `${event.host} <undefined>`, // string format: "name <email>". email cannot be blank
+      organizer: parseCalenderOrganizer(event), // `${eventHostName} <undefined>`, // string format: "name <email>". email cannot be blank
       description: event.description,
       summary: event.name,
       url: getFullVenueInsideUrl(event.venueId),
@@ -27,6 +27,14 @@ export const createCalendar = ({
   );
 
   return calendar;
+};
+
+const parseCalenderOrganizer = (event: VenueEvent): string => {
+  if (event.host) {
+    return `${event.host} <undefined>`;
+  } else {
+    return `undefined <undefined>`;
+  }
 };
 
 export interface DownloadCalendarProps {


### PR DESCRIPTION
The calendar ics download was not working properly and pointed to an error related to `event.host`.
I suspect empty string broke the check on host name and email in the upstream package. Now I add a dirty check to ensure the calendar generator either use the value from event.host or has a string saying `undefined`
cc @margulies 