### PR TITLE
Adjust .ScheduleItem itself and reset padding/margin left/right

### DIFF
--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
@@ -68,12 +68,18 @@ $spacing: 20px;
   &__events {
     max-height: 35vh;
     overflow-y: auto;
+
     // @debt these overrides are here because ScheduleItem sets incompatible margins/etc.
     //   We should just clean it up there instead.
-    .schedule-item-container {
-      margin: -10px;
-      padding: 10px $spacing;
+    .ScheduleItem {
+      margin-left: 0px;
+      margin-right: 0px;
 
+      padding-left: 0px;
+      padding-right: 0px;
+    }
+
+    .schedule-item-container {
       border-radius: $border-radius;
     }
   }


### PR DESCRIPTION
instead toying with .schedule-item-container margin/padding

Closes #1582

With this looks like


before | after 
----|----
![image](https://user-images.githubusercontent.com/39889/122621891-eb6c9180-d064-11eb-884f-2d38fad95a26.png) | ![image](https://user-images.githubusercontent.com/39889/122621850-cd9f2c80-d064-11eb-93de-1e0a41d8ef0c.png)

