### PR TITLE
increase post.title weight in search within PosterHall's usePosters hook

### DIFF
--- a/src/hooks/posters.ts
+++ b/src/hooks/posters.ts
@@ -105,7 +105,10 @@ export const usePosters = (posterHallId: string) => {
       new Fuse(filteredPosterVenues, {
         keys: [
           "name",
-          "poster.title",
+          {
+            name: "poster.title",
+            weight: 20,
+          },
           {
             name: "poster.authorName",
             weight: 16,


### PR DESCRIPTION
This is an attempt to weight titles more heavily in the search so that obvious matches appear towards the top of the list. 

fixes https://github.com/sparkletown/sparkle/issues/1604

---

Follow on from https://github.com/sparkletown/sparkle/pull/1578 which added more weight to `authorName` and `authors`