### PR TITLE
remove description from ongoing event in room modal

### DIFF
--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.scss
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.scss
@@ -22,11 +22,6 @@
     margin-bottom: 10px;
   }
 
-  .event-description {
-    margin-bottom: 10px;
-    white-space: pre-wrap;
-  }
-
   .room-entry-button {
     width: 100%;
   }

--- a/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
+++ b/src/components/templates/PartyMap/components/RoomModalOngoingEvent/RoomModalOngoingEvent.tsx
@@ -10,8 +10,6 @@ import { getCurrentEvent } from "utils/event";
 
 import { useDispatch } from "hooks/useDispatch";
 
-import { RenderMarkdown } from "components/organisms/RenderMarkdown";
-
 import "./RoomModalOngoingEvent.scss";
 
 interface RoomModalOngoingEventProps {
@@ -57,9 +55,6 @@ export const RoomModalOngoingEvent: React.FC<RoomModalOngoingEventProps> = ({
             <div>
               by <span className="artist-name">{eventToDisplay.host}</span>
             </div>
-          </div>
-          <div className="event-description">
-            <RenderMarkdown text={eventToDisplay.description} />
           </div>
         </>
       )}


### PR DESCRIPTION
This PR addresses the issue that a long description for the current (or upcoming) event in the room modal can make the rest of the modal unwieldy -- it becomes difficult to view the future events below. As the current event is actually duplicated in the list of events below, the description seems redundent at the top and coule be removed:
Before: 
<img width="1578" alt="Screen Shot 2021-06-20 at 10 01 28 PM" src="https://user-images.githubusercontent.com/1884442/122690991-1acdfa80-d22d-11eb-8761-4765d4effac1.png">
After: 
<img width="1599" alt="Screen Shot 2021-06-20 at 10 01 11 PM" src="https://user-images.githubusercontent.com/1884442/122690993-20c3db80-d22d-11eb-9ec4-e3951fc1bb2f.png">
