### PR TITLE
Enh: disable leave seat

### DIFF
--- a/src/components/templates/Audience/Audience.scss
+++ b/src/components/templates/Audience/Audience.scss
@@ -87,27 +87,6 @@ $spacing: calc(1 * min(var(--seat-size), var(--seat-size-min)));
             font-size: 20px;
             cursor: pointer;
           }
-
-          .leave-seat-button {
-            display: inline-block;
-            font-weight: 700;
-            text-decoration: none;
-            border-radius: 8px;
-            text-align: center;
-            font-size: 0.7em;
-            transition: all 400ms $transition-function;
-            line-height: 1.5;
-            border: 1px solid transparent;
-            transform: translateY(0);
-            cursor: pointer;
-            padding: 4px 10px;
-            background: rgb(0, 0, 0);
-            color: $white;
-
-            &:hover {
-              background-color: rgba(255, 255, 255, 0.5);
-            }
-          }
         }
 
         .shout-container {

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -304,10 +304,6 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
     [venueId, userId]
   );
 
-  const leaveSeat = useCallback(() => {
-    takeSeat(null, null);
-  }, [takeSeat]);
-
   // @debt this return useMemo antipattern should be rewritten
   return useMemo(() => {
     const onSubmit = async (data: ChatOutDataType) => {
@@ -365,9 +361,6 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
               icon={isAudioEffectDisabled ? faVolumeMute : faVolumeUp}
             />
           </div>
-          <button className="leave-seat-button" onClick={leaveSeat}>
-            Leave Seat
-          </button>
         </div>
         <div className="shout-container">
           <form onSubmit={handleSubmit(onSubmit)} className="shout-form">
@@ -497,7 +490,6 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
     reset,
     columnsForSizedAuditorium,
     isAudioEffectDisabled,
-    leaveSeat,
     handleSubmit,
     register,
     isShoutSent,

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -354,6 +354,7 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
           ))}
           <div
             className="mute-button"
+            title="(Un)Mute audience reactions"
             onClick={() => setIsAudioEffectDisabled((state) => !state)}
           >
             <FontAwesomeIcon


### PR DESCRIPTION
Thank you for all your amazing and hard work! Sparkle is awesome, and OHBM will be fantastic!  ✨  I love the final design! 😍 

This PR is just a little enhancement. It removes the ability to "Leave my seat" while attending an event in the main auditorium and symposia halls. This functionality is not needed, (unnatural and even confusing as it does not make the attendee leave the room, but just turns them into a floating ghost). 

I also added a tooltip for the speaker icon in the emoji container for main auditorium and symposia halls to prevent confusion (feedback included that this could be to unmute oneself to talk to audience).

(I did not add the tooltip to the Jazz Lounge but if you'd prefer to have it there for consistency, happy to add it.)
