### PR TITLE
Peformance fix: reduce the number of user profile updates

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -21,7 +21,8 @@ export const useUser = (): UseUserResult => {
   return {
     user: !auth.isEmpty ? auth : undefined,
     profile: !profile.isEmpty ? profile : undefined,
-    userWithId: auth && profile ? { ...profile, id: auth.uid } : undefined,
+    userWithId:
+      auth && profile ? Object.assign(profile, { id: auth.uid }) : undefined,
     userId: auth && profile ? auth.uid : undefined,
   };
 };

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -14,6 +14,8 @@ type UseUserResult = {
   userId?: string;
 };
 
+const emptyUserProfile = {};
+
 export const useUser = (): UseUserResult => {
   const auth = useSelector(authSelector);
   const profile = useSelector(profileSelector);
@@ -22,7 +24,9 @@ export const useUser = (): UseUserResult => {
     user: !auth.isEmpty ? auth : undefined,
     profile: !profile.isEmpty ? profile : undefined,
     userWithId:
-      auth && profile ? Object.assign(profile, { id: auth.uid }) : undefined,
+      auth && profile
+        ? Object.assign(emptyUserProfile, profile, { id: auth.uid })
+        : undefined,
     userId: auth && profile ? auth.uid : undefined,
   };
 };


### PR DESCRIPTION
using `{ }` notation we force all the related components to re-render creating a new object every time. 
`Object.assign()` uses the same target object. 
Hopefully, that can reduce the number of component re-renders on the users' side.

I've chosen `env/ohbm` as a base branch to reduce the fire, maybe we could find a better approach for our main codebase `staging`.