### PR TITLE
chat - place only author specific elements under onClick={openAuthorProfile}

### DIFF
--- a/src/components/atoms/ChatMessageInfo/ChatMessageInfo.tsx
+++ b/src/components/atoms/ChatMessageInfo/ChatMessageInfo.tsx
@@ -38,9 +38,11 @@ export const ChatMessageInfo: React.FC<ChatMessageInfoProps> = ({
   });
 
   return (
-    <div className={containerClasses} onClick={openAuthorProfile}>
-      <UserAvatar user={author} showStatus />
-      <span className="ChatMessageInfo__author">{author.partyName}</span>
+    <div className={containerClasses}>
+      <div className={containerClasses} onClick={openAuthorProfile}>
+        <UserAvatar user={author} showStatus />
+        <span className="ChatMessageInfo__author">{author.partyName}</span>
+      </div>
       <span className="ChatMessageInfo__time">
         {formatTimeLocalised(timestamp)}
       </span>


### PR DESCRIPTION
So that delete below could have a chance to be clickable

Closes #1618 

applicable to staging as well most likely, didn't check

PS edit didn't check too hard, but clicking on trashcan seems to do have desired effect but message seems to not be removed from visible chat in the browser... but that would be a separate issue for someone to file if confirmed