### PR TITLE
load venue events from pre-cached content stored in gs://

### DIFF
--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -13,7 +13,7 @@ import { groupBy } from "lodash";
 import {
   PLATFORM_BRAND_NAME,
   SCHEDULE_SHOW_DAYS_AHEAD,
-  SCHEDULE_LOADFROM_GS,
+  SCHEDULE_LOAD_FROM_GS,
   REMOVE_EVENTS_FROM_VENUE,
 } from "settings";
 
@@ -99,7 +99,7 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
   });
 
   const isLoadingSchedule =
-    (!SCHEDULE_LOADFROM_GS && isLoading) || isEventsLoading;
+    (!SCHEDULE_LOAD_FROM_GS && isLoading) || isEventsLoading;
 
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
 

--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -13,6 +13,7 @@ import { groupBy } from "lodash";
 import {
   PLATFORM_BRAND_NAME,
   SCHEDULE_SHOW_DAYS_AHEAD,
+  SCHEDULE_LOADFROM_GS,
   REMOVE_EVENTS_FROM_VENUE,
 } from "settings";
 
@@ -97,7 +98,8 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
     venueIds: relatedVenueIds,
   });
 
-  const isLoadingSchedule = isLoading || isEventsLoading;
+  const isLoadingSchedule =
+    (!SCHEDULE_LOADFROM_GS && isLoading) || isEventsLoading;
 
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
 

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -10,7 +10,7 @@ import { WithId, WithVenueId } from "utils/id";
 //import { tracePromise } from "utils/performance";
 import { useFirebase } from "react-redux-firebase";
 
-import { SCHEDULE_LOADFROM_GS } from "settings";
+import { SCHEDULE_LOAD_FROM_GS } from "settings";
 
 const emptyArray: never[] = [];
 
@@ -40,7 +40,7 @@ export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
     const storage = firebase.storage();
     const url = await storage
       .ref()
-      .child(SCHEDULE_LOADFROM_GS)
+      .child(SCHEDULE_LOAD_FROM_GS)
       .getDownloadURL();
     return fetch(url).then((res) => res.json());
 

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -1,12 +1,16 @@
 import { useAsync } from "react-use";
 
-import { fetchAllVenueEvents } from "api/events";
+//import { fetchAllVenueEvents } from "api/events";
 
 import { ReactHook } from "types/utility";
 import { VenueEvent } from "types/venues";
 
 import { WithId, WithVenueId } from "utils/id";
-import { tracePromise } from "utils/performance";
+
+//import { tracePromise } from "utils/performance";
+import { useFirebase } from "react-redux-firebase";
+
+import { SCHEDULE_LOADFROM_GS } from "settings";
 
 const emptyArray: never[] = [];
 
@@ -25,13 +29,24 @@ export interface VenueEventsData {
 export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
   venueIds,
 }) => {
+  const firebase = useFirebase();
+
   const {
     loading: isEventsLoading,
     error: eventsError,
     value: events = emptyArray,
   } = useAsync(async () => {
-    if (!venueIds) return emptyArray;
+    //load from gS
+    const storage = firebase.storage();
+    const url = await storage
+      .ref()
+      .child(SCHEDULE_LOADFROM_GS)
+      .getDownloadURL();
+    return fetch(url).then((res) => res.json());
 
+    //load from firebase - depends on venueIds
+    /*
+    if (!venueIds) return emptyArray;
     return tracePromise(
       "useVenueEvents::fetchAllVenueEvents",
       () => fetchAllVenueEvents(venueIds),
@@ -41,8 +56,8 @@ export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
         },
       }
     );
-  }, [venueIds]); // TODO: figure out this deps in an efficient way so it doesn't keep re-rendering
-
+    */
+  }, [firebase /*venueIds*/]);
   return {
     isEventsLoading,
     isError: eventsError !== undefined,

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -36,7 +36,7 @@ export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
     error: eventsError,
     value: events = emptyArray,
   } = useAsync(async () => {
-    //load from gS
+    //load from gs
     const storage = firebase.storage();
     const url = await storage
       .ref()
@@ -57,7 +57,7 @@ export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
       }
     );
     */
-  }, [firebase /*venueIds*/]);
+  });
   return {
     isEventsLoading,
     isError: eventsError !== undefined,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -624,7 +624,7 @@ export const SCHEDULE_SHOW_DAYS_AHEAD = 7;
 export const FIRESTORE_QUERY_IN_ARRAY_MAX_ITEMS = 10;
 
 export const REMOVE_EVENTS_FROM_VENUE = /^poster[0-9]{4}$/;
-export const SCHEDULE_LOADFROM_GS = "cache/events.json";
+export const SCHEDULE_LOAD_FROM_GS = "assets/cache/events.json";
 
 export const FACEBOOK_SHARE_URL = "https://www.facebook.com/sharer/sharer.php?";
 export const TWITTER_SHARE_URL = "https://twitter.com/intent/tweet?";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -624,7 +624,9 @@ export const SCHEDULE_SHOW_DAYS_AHEAD = 7;
 export const FIRESTORE_QUERY_IN_ARRAY_MAX_ITEMS = 10;
 
 export const REMOVE_EVENTS_FROM_VENUE = /^poster[0-9]{4}$/;
-export const SCHEDULE_LOAD_FROM_GS = "assets/cache/events.json";
+//export const SCHEDULE_LOAD_FROM_GS = "assets/cache/events.json";
+export const SCHEDULE_LOAD_FROM_GS =
+  "https://firebasestorage.googleapis.com/v0/b/sparkle-ohbm.appspot.com/o/assets%2Fcache%2Fevents.json?alt=media&token=89abdf1a-4f0c-4f13-9a5f-e50088e090bc";
 
 export const FACEBOOK_SHARE_URL = "https://www.facebook.com/sharer/sharer.php?";
 export const TWITTER_SHARE_URL = "https://twitter.com/intent/tweet?";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -624,6 +624,7 @@ export const SCHEDULE_SHOW_DAYS_AHEAD = 7;
 export const FIRESTORE_QUERY_IN_ARRAY_MAX_ITEMS = 10;
 
 export const REMOVE_EVENTS_FROM_VENUE = /^poster[0-9]{4}$/;
+export const SCHEDULE_LOADFROM_GS = "cache/events.json";
 
 export const FACEBOOK_SHARE_URL = "https://www.facebook.com/sharer/sharer.php?";
 export const TWITTER_SHARE_URL = "https://twitter.com/intent/tweet?";

--- a/src/store/reducers/Cache.ts
+++ b/src/store/reducers/Cache.ts
@@ -1,0 +1,18 @@
+//import { CacheActions } from "../actions/Cache";
+import { VenueEvent } from "types/venues";
+import { WithId, WithVenueId } from "utils/id";
+
+interface cacheState {
+  events: Promise<WithVenueId<WithId<VenueEvent>>[]>;
+}
+
+const initialState: cacheState = {
+  events: fetch(
+    "https://firebasestorage.googleapis.com/v0/b/sparkle-ohbm.appspot.com/o/assets%2Fcache%2Fevents.json?alt=media&token=d190d1c3-249d-4f05-ad33-ae349c8771c2"
+  ).then((res) => res.json()),
+};
+
+export const cacheReducer = (
+  state = initialState
+  //action: cacheActions
+): cacheState => state;

--- a/src/store/reducers/Cache.ts
+++ b/src/store/reducers/Cache.ts
@@ -2,14 +2,23 @@
 import { VenueEvent } from "types/venues";
 import { WithId, WithVenueId } from "utils/id";
 
+//import firebase from "firebase/app";
+//import "firebase/storage";
+
+import { SCHEDULE_LOAD_FROM_GS } from "settings";
+
 interface cacheState {
   events: Promise<WithVenueId<WithId<VenueEvent>>[]>;
 }
 
 const initialState: cacheState = {
-  events: fetch(
-    "https://firebasestorage.googleapis.com/v0/b/sparkle-ohbm.appspot.com/o/assets%2Fcache%2Fevents.json?alt=media&token=d190d1c3-249d-4f05-ad33-ae349c8771c2"
-  ).then((res) => res.json()),
+  events: new Promise(async (resolve) => {
+    //const storage = firebase.storage();
+    //const url = await storage.ref().child(SCHEDULE_LOAD_FROM_GS).getDownloadURL();
+    fetch(SCHEDULE_LOAD_FROM_GS)
+      .then((res) => res.json())
+      .then(resolve);
+  }),
 };
 
 export const cacheReducer = (

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -6,6 +6,7 @@ import { attendanceReducer } from "./Attendance";
 import { chatReducer } from "./Chat";
 import { sovereignVenueReducer } from "./SovereignVenue";
 import { userProfileReducer } from "./UserProfile";
+import { cacheReducer } from "./Cache";
 
 // Reducers per VenueTemplate (eg. reducer for playa template)
 export const VenueTemplateReducers: { [key: string]: Reducer } = {};
@@ -18,4 +19,5 @@ export const MiscReducers = {
   room: roomReducer,
   sovereignVenue: sovereignVenueReducer,
   userProfile: userProfileReducer,
+  cache: cacheReducer,
 };


### PR DESCRIPTION
To load the venue calendar, sparkle currently must download all venues (which takes about 30-45 seconds for OHBM), followed by downloading all events from all venues (takes another 10-15 seconds). In total, user must sit and wait for about 40-60 seconds before they can see the schedule. Most user won't wait that long.

This PR replaces the call to firebase to download venues and venues/events, and instead, it loads from the cached json file stored in gs://cache/events.json (or wherever we set it to). By loading from the gs://, the calendar can be opened almost as soon as the main venue opens. 

The cache is uploaded from a server that queries all venues/events and we can run this as frequently as we need - during our conference. Any server with firebase admin sdk configured can do the caching (I've already set it up on my jetstream VM). 

I tried to make this feature optional by setting `SCHEDULE_LOADFROM_GS`, but I couldn't quite get the useVenueEvent function to use `useAsync` conditionally. When we are loading from `events.json` it does not require venueIds. So we have to make this somewhat dynamic.  