### PR TITLE
[env/ohbm] fix PostersProvider causing posters to re-randomize on render

### DIFF
--- a/src/hooks/posters.tsx
+++ b/src/hooks/posters.tsx
@@ -120,7 +120,7 @@ export const PostersProvider: React.FC<PostersProviderProps> = ({
   useEffect(() => {
     // only save the shuffled poster venues state if the previous ones were empty
     // additional logic can be added to (re-/in-)validate based on time, userId or other parameters
-    if (isEmptyQuery && isPostersLoaded && previousPosterVenues.length !== 0) {
+    if (isEmptyQuery && isPostersLoaded && previousPosterVenues.length === 0) {
       setPreviousPosterVenues(shuffledPosterVenues);
     }
   }, [


### PR DESCRIPTION
Originally the intent was to store first randomization of posters and reused it on re-renders of `PostersProvider` but instead the check
```javascript
if (isEmptyQuery && isPostersLoaded && previousPosterVenues.length === 0) {
  setPreviousPosterVenues(shuffledPosterVenues);
}
```
wasn't properly done because of a typo.