### PR TITLE
Fix the order of the styles

### DIFF
--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -76,38 +76,6 @@ $page-max-width: 1240px;
   padding-top: $spacing--xxl;
 }
 
-.Profile {
-  max-height: 100%;
-  overflow: hidden;
-  position: absolute;
-  top: 20%;
-  left: 20%;
-  right: 20%;
-
-  .login-welcome-title {
-    font-style: italic;
-    font-weight: 900;
-    text-align: center;
-  }
-
-  .login-welcome-subtitle {
-    text-align: center;
-    padding-bottom: 30px;
-    margin-top: $spacing--xl;
-  }
-
-  &__summit-snap {
-    margin: auto;
-    text-decoration: none;
-    text-align: center;
-    display: block;
-
-    &:hover {
-      color: white;
-    }
-  }
-}
-
 .code-of-conduct-container {
   padding-top: 30px;
 
@@ -239,6 +207,39 @@ $page-max-width: 1240px;
       rgba(0, 0, 0, 0.6) 100%
     );
     background-color: darken($primary, 20%);
+  }
+}
+
+.Profile {
+  max-height: 100%;
+  overflow: hidden;
+  position: absolute;
+  top: 20%;
+  left: 20%;
+  right: 20%;
+
+  .login-welcome-title {
+    font-style: italic;
+    font-weight: 900;
+    text-align: center;
+  }
+
+  .login-welcome-subtitle {
+    text-align: center;
+    padding-bottom: 30px;
+    margin-top: $spacing--xl;
+  }
+
+  &__summit-snap {
+    margin: auto;
+    text-decoration: none;
+    text-align: center;
+    display: block;
+
+    &:hover {
+      color: white;
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
a follow-up PR of https://github.com/sparkletown/sparkle/pull/1654

`display: block` property of `Profile__summit-snap` was overwritten by `display: flex; ` of `.profile-picture-button`.
So I just changed the order of the rules as a quick fix.