### PR TITLE
add optional end_utc_seconds to Venue + use it to limit days shown in NavBarSchedule

### DIFF
--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -11,7 +11,7 @@ import {
 import classNames from "classnames";
 import { groupBy } from "lodash";
 
-import { PLATFORM_BRAND_NAME, SCHEDULE_SHOW_DAYS_AHEAD } from "settings";
+import { PLATFORM_BRAND_NAME, SCHEDULE_MAX_DAYS_AHEAD } from "settings";
 
 import {
   LocationEvents,
@@ -138,8 +138,8 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
       : undefined;
 
     const scheduleDaysToShowCount = isDefined(daysTillScheduleEnded)
-      ? Math.min(daysTillScheduleEnded, SCHEDULE_SHOW_DAYS_AHEAD)
-      : SCHEDULE_SHOW_DAYS_AHEAD;
+      ? Math.min(daysTillScheduleEnded, SCHEDULE_MAX_DAYS_AHEAD)
+      : SCHEDULE_MAX_DAYS_AHEAD;
 
     return range(scheduleDaysToShowCount).map((dayIndex) => {
       const day = addDays(firstDayOfSchedule, dayIndex);

--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -113,6 +113,8 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
 
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
 
+  // TODO: extract a new useMemo'd  const startOfSelectedDay = addDays(firstDayOfSchedule, selectedDayIndex);
+  //  Then reuse that in all the places that are currently duplicating this logic
   const renderedScheduleDayTabs = useMemo(() => {
     const formatDayLabel = (day: Date | number) => {
       if (isScheduleTimeshifted) {
@@ -179,7 +181,8 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
     const daysEvents = relatedVenueEvents
       .filter(
         isScheduleTimeshifted
-          ? isEventWithinDate(startOfSelectedDay)
+          ? // @debt do we need this ternary here? Can we just always use one of isEventWithinDate / isEventWithinDateAndNotFinished ?
+            isEventWithinDate(startOfSelectedDay)
           : isEventWithinDateAndNotFinished(startOfSelectedDay)
       )
       .map(
@@ -215,6 +218,7 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
 
   const downloadPersonalEventsCalendar = useCallback(() => {
     const startOfSelectedDay = addDays(firstDayOfSchedule, selectedDayIndex);
+    // @debt this seems to only download events for the currently selected day, yet the UI implies as though it will download all of my events
     const allPersonalEvents: PersonalizedVenueEvent[] = relatedVenueEvents
       .map(
         prepareForSchedule({
@@ -250,6 +254,8 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
           {hasSavedEvents && (
             <Button
               onClick={downloadPersonalEventsCalendar}
+              // @debt downloadPersonalEventsCalendar seems to only download events for the currently selected day,
+              //  yet the UI here implies as though it will download all of my events
               customClass="NavBarSchedule__download-schedule-btn"
             >
               Download your schedule

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -615,7 +615,7 @@ export const DEFAULT_SHOW_SCHEDULE = true;
 // @debt probably would be better to adjust max hour based on user's display size
 export const SCHEDULE_MAX_START_HOUR = 16;
 export const SCHEDULE_HOUR_COLUMN_WIDTH_PX = 200;
-export const SCHEDULE_SHOW_DAYS_AHEAD = 7;
+export const SCHEDULE_MAX_DAYS_AHEAD = 7;
 
 /**
  * @see https://firebase.google.com/docs/firestore/query-data/queries#in_not-in_and_array-contains-any

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -161,6 +161,7 @@ export interface BaseVenue {
   };
   showLearnMoreLink?: boolean;
   start_utc_seconds?: number;
+  end_utc_seconds?: number; // Note: this is intended to only be set/used on the sovereign venue, to define the end timestamp of the entire party/event
   attendeesTitle?: string;
   requiresDateOfBirth?: boolean;
   ticketUrl?: string;


### PR DESCRIPTION
supercedes https://github.com/sparkletown/sparkle/pull/1665

partially fixes https://github.com/sparkletown/internal-sparkle-issues/issues/849

When `end_utc_seconds` is present, it will be used to limit the days shown on `NavBarSchedule` to the greater of `SCHEDULE_SHOW_DAYS_AHEAD` or the remaining days until `end_utc_seconds`.

When there are no 'day tabs' to show (eg. `end_utc_seconds` has already passed), then a different UI is rendered, explaining that the scheduled events have ended.

Also fixes a number of bugs related to how 'time shifted' dates are handled in `NavBarSchedule`, so that the schedule properly advances each day when `start_utc_seconds` is configured. Previously it looks like it would have always stayed static with the first 'day tab' of the schedule always being `start_utc_seconds`, rather than being 'today'. This would have meant that a party/event that had `start_utc_seconds` configured, and lasted longer than `SCHEDULE_SHOW_DAYS_AHEAD`, would have it's schedule cut off before the end of the event.

Note that I explicitly chose to use `end_utc_seconds` to match the existing `start_utc_seconds`, even though neither fit our naming patterns. I consider that to be future tech-debt to clean up together, and OOS of this PR. The 'risk'/'impact' of not having them aligned is 'worse' than the cost of them not matching our naming patterns.

## Notes on testing

- You can use https://www.epochconverter.com/ to easily get the required UTC seconds value
- There is no UI for configuring the Venue's `end_utc_seconds` in this PR, so you'll need to set it directly within the firestore DB
- I don't believe the `NavBarSchedule` live-updates when it's venue config changes, so you may need to do a full page reload between updating the venue config before being able to see the output change