### PR TITLE
[env/github] Replace back to label with back

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -358,9 +358,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
       {hasBackButton && venue?.parentId && parentVenue?.name && (
         <div className="back-map-btn" onClick={backToParentVenue}>
           <div className="back-icon" />
-          <span className="back-link">
-            Back{parentVenue ? ` to ${parentVenue.name}` : ""}
-          </span>
+          <span className="back-link">Back</span>
         </div>
       )}
     </>

--- a/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
+++ b/src/components/templates/Jazzbar/JazzTab/JazzTab.tsx
@@ -152,7 +152,7 @@ const Jazz: React.FC<JazzProps> = ({ setUserList, venue }) => {
       {!seatedAtTable && parentVenueId && parentVenue && (
         <div className="back-map-btn" onClick={backToParentVenue}>
           <div className="back-icon" />
-          <span className="back-link">Back to {parentVenue.name}</span>
+          <span className="back-link">Back</span>
         </div>
       )}
 

--- a/src/pages/VenuePage/TemplateWrapper.tsx
+++ b/src/pages/VenuePage/TemplateWrapper.tsx
@@ -87,7 +87,7 @@ const TemplateWrapper: React.FC<TemplateWrapperProps> = ({ venue }) => {
             className="btn btn-primary"
             onClick={() => history.goBack()}
           >
-            Go Back
+            Back
           </button>
         </p>
       );


### PR DESCRIPTION
As per https://github.com/sparkletown/internal-sparkle-issues/issues/855
* Replaced `back to {href}` with `back` label for github only