### PR TITLE
fix for venue chat name change when redirect back from room to venue map

### DIFF
--- a/src/components/organisms/ChatSidebar/ChatSidebar.tsx
+++ b/src/components/organisms/ChatSidebar/ChatSidebar.tsx
@@ -31,7 +31,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({ venue }) => {
     selectPrivateChat,
   } = useChatSidebarControls();
 
-  const { privateChatTabTitle, venueChatTabTitle } = useChatSidebarInfo();
+  const { privateChatTabTitle, venueChatTabTitle } = useChatSidebarInfo(venue);
 
   const containerStyles = classNames("chat-sidebar", {
     "chat-sidebar--expanded": isExpanded,

--- a/src/hooks/chatSidebar.ts
+++ b/src/hooks/chatSidebar.ts
@@ -14,8 +14,7 @@ import {
 import { useSelector } from "./useSelector";
 import { useDispatch } from "./useDispatch";
 import { useNumberOfUnreadChats } from "./privateChats";
-import { useVenueId } from "./useVenueId";
-import { useConnectCurrentVenueNG } from "./useConnectCurrentVenueNG";
+import { AnyVenue } from "types/venues";
 
 export const useChatSidebarControls = () => {
   const dispatch = useDispatch();
@@ -69,12 +68,9 @@ export const useChatSidebarControls = () => {
   };
 };
 
-export const useChatSidebarInfo = () => {
+export const useChatSidebarInfo = (venue: AnyVenue) => {
   const numberOfUnreadChats = useNumberOfUnreadChats();
-  const venueId = useVenueId();
-  const { currentVenue } = useConnectCurrentVenueNG(venueId);
-
-  const chatTitle = currentVenue?.chatTitle ?? "Venue";
+  const chatTitle = venue?.chatTitle ?? "Venue";
 
   return {
     privateChatTabTitle: `Direct Messages ${


### PR DESCRIPTION
Fix for venue chat as per https://github.com/sparkletown/internal-sparkle-issues/issues/824
* Fixed venue chat name change when going back from room to venue map

closes https://github.com/sparkletown/internal-sparkle-issues/issues/824

Patch described by @0xdevalias in https://github.com/sparkletown/internal-sparkle-issues/issues/824#issuecomment-863848152