### PR TITLE
Add bottom text to login form and replace 'Hubbers' with 'Okta users'

### DIFF
--- a/src/components/organisms/AuthenticationModal/InitialForm/InitialForm.tsx
+++ b/src/components/organisms/AuthenticationModal/InitialForm/InitialForm.tsx
@@ -25,7 +25,7 @@ export const InitialForm: FC<InitialFormProps> = ({
         className="btn btn-block btn-centered login-button"
         onClick={displayLoginForm}
       >
-        Log in for non-Hubbers
+        Log in for non-Okta users
       </div>
     </div>
   );

--- a/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
+++ b/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
@@ -93,7 +93,7 @@ const LoginForm: React.FunctionComponent<LoginFormProps> = ({
       {/*  </span>*/}
       {/*</div>*/}
 
-      <h2>Log in for non-Hubbers</h2>
+      <h2>Log in for non-Okta users</h2>
 
       <em>
         Are you a Hubber with an Okta account? If so, you should use &apos;Quick

--- a/src/pages/Account/Login.scss
+++ b/src/pages/Account/Login.scss
@@ -21,4 +21,10 @@
       opacity: 0.8;
     }
   }
+
+  &__issues-text {
+    margin-top: $spacing--xxl;
+    color: $secondary--light;
+    font-style: italic;
+  }
 }

--- a/src/pages/Account/Login.tsx
+++ b/src/pages/Account/Login.tsx
@@ -149,7 +149,7 @@ export const Login: React.FC<LoginProps> = ({
         )}
       </div>
       <p className="Login__issues-text">
-        Issues with OKTA? Send a Slack message to:{" "}
+        Issues with Okta? Send a Slack message to:{" "}
         <strong>#summit-21-registration</strong>
       </p>
     </div>

--- a/src/pages/Account/Login.tsx
+++ b/src/pages/Account/Login.tsx
@@ -148,6 +148,10 @@ export const Login: React.FC<LoginProps> = ({
           />
         )}
       </div>
+      <p className="Login__issues-text">
+        Issues with OKTA? Send a Slack message to:{" "}
+        <strong>#summit-21-registration</strong>
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/821

Looks like this now:
<img width="775" alt="Screen Shot 2021-06-28 at 6 23 34 PM" src="https://user-images.githubusercontent.com/51083763/123678399-2b3e3080-d83e-11eb-9cc9-c332acdd4d97.png">
