### PR TITLE
[env/github] change default url to /v/register instead of sparkespaces.com

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,7 +18,7 @@ import sparkleNavLogo from "assets/icons/sparkle-nav-logo.png";
 import defaultMapIcon from "assets/icons/default-map-icon.png";
 import sparkleverseLogo from "assets/images/sparkleverse-logo.png";
 
-export const SPARKLE_HOMEPAGE_URL = "https://sparklespaces.com/";
+export const SPARKLE_HOMEPAGE_URL = "/v/register/";
 export const SPARKLE_TERMS_AND_CONDITIONS_URL =
   "https://sparklespaces.com/terms-of-use/";
 export const SPARKLE_PRIVACY_POLICY =


### PR DESCRIPTION
partly fixes https://github.com/sparkletown/internal-sparkle-issues/issues/868