### PR TITLE
fix event room finding logic used to determine event room url

### DIFF
--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -37,7 +37,15 @@ export const EventModal: React.FC<EventModalProps> = ({
   });
 
   const eventRoom = useMemo<Room | undefined>(
-    () => eventVenue?.rooms?.find((room) => room.title === event.room),
+    () =>
+      eventVenue?.rooms?.find((room) => {
+        const noSlashUrl = room.url.endsWith("/")
+          ? room.url.slice(0, -1)
+          : room.url;
+        const [roomName] = noSlashUrl.split("/").slice(-1);
+
+        return event?.room?.endsWith(`${roomName}`);
+      }),
     [eventVenue, event]
   );
 

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -8,7 +8,12 @@ import { VenueEvent } from "types/venues";
 
 import { getEventStatus, isEventLive } from "utils/event";
 import { WithVenueId } from "utils/id";
-import { enterVenue } from "utils/url";
+import {
+  enterVenue,
+  openUrl,
+  getUrlWithoutTrailingSlash,
+  getLastUrlParam,
+} from "utils/url";
 
 import { useInterval } from "hooks/useInterval";
 
@@ -39,12 +44,13 @@ export const EventModal: React.FC<EventModalProps> = ({
   const eventRoom = useMemo<Room | undefined>(
     () =>
       eventVenue?.rooms?.find((room) => {
-        const noSlashUrl = room.url.endsWith("/")
-          ? room.url.slice(0, -1)
-          : room.url;
-        const [roomName] = noSlashUrl.split("/").slice(-1);
+        const { room: eventRoom = "" } = event;
 
-        return event?.room?.endsWith(`${roomName}`);
+        const noTrailSlashUrl = getUrlWithoutTrailingSlash(room.url);
+
+        const [roomName] = getLastUrlParam(noTrailSlashUrl);
+
+        return eventRoom.endsWith(`${roomName}`);
       }),
     [eventVenue, event]
   );
@@ -59,6 +65,14 @@ export const EventModal: React.FC<EventModalProps> = ({
 
   const goToEventLocation = () => {
     onHide();
+
+    const { room = "" } = event;
+
+    if (!eventRoom) {
+      openUrl(room);
+
+      return;
+    }
 
     if (event.room) {
       enterRoom();

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -13,6 +13,7 @@ import {
   openUrl,
   getUrlWithoutTrailingSlash,
   getLastUrlParam,
+  getUrlParamFromString,
 } from "utils/url";
 
 import { useInterval } from "hooks/useInterval";
@@ -49,8 +50,9 @@ export const EventModal: React.FC<EventModalProps> = ({
         const noTrailSlashUrl = getUrlWithoutTrailingSlash(room.url);
 
         const [roomName] = getLastUrlParam(noTrailSlashUrl);
+        const roomUrlParam = getUrlParamFromString(eventRoom);
 
-        return eventRoom.endsWith(`${roomName}`);
+        return roomUrlParam.endsWith(`${roomName}`);
       }),
     [eventVenue, event]
   );
@@ -67,9 +69,10 @@ export const EventModal: React.FC<EventModalProps> = ({
     onHide();
 
     const { room = "" } = event;
+    const roomUrlParam = getUrlParamFromString(room);
 
     if (!eventRoom) {
-      openUrl(room);
+      openUrl(roomUrlParam);
 
       return;
     }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -109,3 +109,11 @@ export const getExtraLinkProps = (isExternal: boolean) =>
 
 export const getFullVenueInsideUrl = (venueId: string) =>
   new URL(venueInsideUrl(venueId), window.location.origin).href;
+
+export const getUrlWithoutTrailingSlash = (url: string) => {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+};
+
+export const getLastUrlParam = (url: string) => {
+  return url.split("/").slice(-1);
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -117,3 +117,7 @@ export const getUrlWithoutTrailingSlash = (url: string) => {
 export const getLastUrlParam = (url: string) => {
   return url.split("/").slice(-1);
 };
+
+export const getUrlParamFromString = (data: string) => {
+  return data.replace(" ", "").toLowerCase();
+};


### PR DESCRIPTION
Fixed event modal link url
* changed event room find logic

Since event room name could easily not be equal to the actual room title there were cases when we couldn't find a room with the event in question. Now whether user assigns `http://domain/{v || in}/roomName` or simply `roomName` as the event room we'll be able to determine the room to redirect him into

Fixes #1622
fixes #1585 

![image](https://user-images.githubusercontent.com/56254806/123809124-03140780-d8fa-11eb-856c-956b73303283.png)
![image](https://user-images.githubusercontent.com/56254806/123809502-55552880-d8fa-11eb-9da5-926a6aadf57c.png)

