### PR TITLE
[env/github] change login text

### DIFF
--- a/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
+++ b/src/components/organisms/AuthenticationModal/LoginForm/LoginForm.tsx
@@ -96,8 +96,11 @@ const LoginForm: React.FunctionComponent<LoginFormProps> = ({
       <h2>Log in for non-Hubbers</h2>
 
       <em>
-        Are you a Hubber with an Okta account? If so, you should use &apos;Quick
-        log in with Okta&apos; above instead of this form! ☝
+        Are you a Hubber with an Okta account? <br /> <strong>If so</strong>,
+        you should use &apos;Quick log in with Okta&apos; above! ☝ <br />{" "}
+        <br />
+        <strong>If not</strong>, use the whitelisted email and temporary
+        password <br /> that Github has sent you. 👇
       </em>
 
       <form


### PR DESCRIPTION
these changes were requested by @mobilevinay 
no github issue to link

looks like this now:
<img width="502" alt="Screen Shot 2021-06-29 at 6 48 50 PM" src="https://user-images.githubusercontent.com/51083763/123844211-a705af00-d90a-11eb-9286-1efd2cc5f807.png">
