### PR TITLE
fix IFRAME_ALLOW by adding semicolons after both statements

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -156,8 +156,8 @@ export const ACCEPTED_IMAGE_TYPES =
 export const VALID_URL_PROTOCOLS = ["http:", "https:"];
 
 export const IFRAME_ALLOW =
-  "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen";
-export const IFRAME_ALLOW_ADVANCED = `${IFRAME_ALLOW} camera; microphone`;
+  "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen;";
+export const IFRAME_ALLOW_ADVANCED = `${IFRAME_ALLOW} camera; microphone;`;
 
 export const ENABLE_SUSPECTED_LOCATION = false;
 export const ENABLE_PLAYA_ADDRESS = false;


### PR DESCRIPTION
Following up on https://github.com/sparkletown/sparkle/pull/1643

Closes https://github.com/sparkletown/internal-sparkle-issues/issues/662

Unsure why a backtick is used instead of quotation marks -- (for the variable thing you added, Glenn?) Just checking

![image](https://user-images.githubusercontent.com/17037335/123878045-33a47300-d8f3-11eb-84e9-fe7e99da06ea.png)