### PR TITLE
fix NavSearchBar to filter out rooms that aren't enabled (and events in those rooms) from search results

### DIFF
--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -70,7 +70,13 @@ export const NavSearchBar: React.FC<NavSearchBarProps> = ({ venueId }) => {
     () =>
       relatedVenues
         .flatMap((venue) => venue.rooms ?? [])
-        .filter((room) => room),
+        .filter((room) => {
+          if (isDefined(room.type) && COVERT_ROOM_TYPES.includes(room.type)) {
+            return false;
+          }
+
+          return room.isEnabled;
+        }),
     [relatedVenues]
   );
 
@@ -96,12 +102,7 @@ export const NavSearchBar: React.FC<NavSearchBarProps> = ({ venueId }) => {
     /* @debt we really shouldn't be using the index as part of the key here, it's unstable.. but rooms don't have a unique identifier */
     return (
       relatedRooms
-        ?.filter(
-          (room) =>
-            (!room.type || !COVERT_ROOM_TYPES.includes(room.type)) &&
-            room.isEnabled &&
-            room.title.toLowerCase().includes(searchQuery)
-        )
+        .filter((room) => room.title.toLowerCase().includes(searchQuery))
         .map((room, index) => (
           <NavSearchResult
             key={`room-${room.title}-${index}`}

--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -87,6 +87,7 @@ export const NavSearchBar: React.FC<NavSearchBarProps> = ({ venueId }) => {
         ?.filter(
           (room) =>
             (!room.type || !COVERT_ROOM_TYPES.includes(room.type)) &&
+            room.isEnabled &&
             room.title.toLowerCase().includes(searchQuery)
         )
         .map((room, index) => (

--- a/src/components/molecules/NavSearchBar/NavSearchBar.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchBar.tsx
@@ -152,11 +152,15 @@ export const NavSearchBar: React.FC<NavSearchBarProps> = ({ venueId }) => {
 
     return relatedEvents
       .filter((event) => {
-        const isRoomEnabled = isDefined(event.room)
-          ? relatedRoomsByTitle[event.room]?.isEnabled ?? true
-          : true;
+        const isEventRoomEnabledAndExists =
+          isDefined(event.room) && event.room !== ""
+            ? isDefined(relatedRoomsByTitle[event.room])
+            : true;
 
-        return isRoomEnabled && event.name.toLowerCase().includes(searchQuery);
+        return (
+          isEventRoomEnabledAndExists &&
+          event.name.toLowerCase().includes(searchQuery)
+        );
       })
       .map((event) => {
         const imageUrl =


### PR DESCRIPTION
Fixed `NavSearchBar` to filter out rooms that aren't enabled (and events in those rooms) from search results.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/147

**Note:** I haven't tested these changes in a clickthrough, so that should definitely be done before merging this PR.