### PR TITLE
refactor RenderMarkdown to extract RenderMarkdownInner component + lazy load it

### DIFF
--- a/src/components/organisms/RenderMarkdown/RenderMarkdown.tsx
+++ b/src/components/organisms/RenderMarkdown/RenderMarkdown.tsx
@@ -1,24 +1,14 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 
-import ReactMarkdown from "react-markdown";
-import glm from "remark-gfm";
-import emoji from "remark-emoji";
-import externalLinks from "remark-external-links";
-import sanitize from "rehype-sanitize";
+import { tracePromise } from "utils/performance";
 
-import {
-  MARKDOWN_BASIC_FORMATTING_TAGS,
-  MARKDOWN_HEADING_TAGS,
-  MARKDOWN_IMAGE_TAGS,
-  MARKDOWN_LINK_TAGS,
-  MARKDOWN_LIST_TAGS,
-  MARKDOWN_PRE_CODE_TAGS,
-} from "settings";
-
-import { isTruthy } from "utils/types";
-
-const REMARK_PLUGINS = [glm, emoji, externalLinks];
-const REHYPE_PLUGINS = [sanitize];
+const RenderMarkdownInner = lazy(() =>
+  tracePromise("RenderMarkdown::lazy-import::RenderMarkdownInner", () =>
+    import("./RenderMarkdownInner").then(({ RenderMarkdownInner }) => ({
+      default: RenderMarkdownInner,
+    }))
+  )
+);
 
 export interface RenderMarkdownProps {
   text?: string;
@@ -38,28 +28,21 @@ const _RenderMarkdown: React.FC<RenderMarkdownProps> = ({
   allowLinks = true,
   allowImages = true,
   allowLists = true,
-}) => {
-  const allowedElements: string[] = [
-    ...(allowBasicFormatting ? MARKDOWN_BASIC_FORMATTING_TAGS : []),
-    ...(allowHeadings ? MARKDOWN_HEADING_TAGS : []),
-    ...(allowImages ? MARKDOWN_IMAGE_TAGS : []),
-    ...(allowLinks ? MARKDOWN_LINK_TAGS : []),
-    ...(allowLists ? MARKDOWN_LIST_TAGS : []),
-    ...(allowPreAndCode ? MARKDOWN_PRE_CODE_TAGS : []),
-  ].filter(isTruthy);
-
-  if (!text) return null;
-
-  return (
-    <ReactMarkdown
-      remarkPlugins={REMARK_PLUGINS}
-      rehypePlugins={REHYPE_PLUGINS}
-      linkTarget="_blank"
-      allowedElements={allowedElements}
+}) => (
+  <Suspense fallback={<div>{text}</div>}>
+    <RenderMarkdownInner
+      {...{
+        allowBasicFormatting,
+        allowPreAndCode,
+        allowHeadings,
+        allowLinks,
+        allowImages,
+        allowLists,
+      }}
     >
       {text}
-    </ReactMarkdown>
-  );
-};
+    </RenderMarkdownInner>
+  </Suspense>
+);
 
 export const RenderMarkdown = React.memo(_RenderMarkdown);

--- a/src/components/organisms/RenderMarkdown/RenderMarkdownInner.tsx
+++ b/src/components/organisms/RenderMarkdown/RenderMarkdownInner.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import ReactMarkdown from "react-markdown";
+import glm from "remark-gfm";
+import emoji from "remark-emoji";
+import externalLinks from "remark-external-links";
+import sanitize from "rehype-sanitize";
+
+import {
+  MARKDOWN_BASIC_FORMATTING_TAGS,
+  MARKDOWN_HEADING_TAGS,
+  MARKDOWN_IMAGE_TAGS,
+  MARKDOWN_LINK_TAGS,
+  MARKDOWN_LIST_TAGS,
+  MARKDOWN_PRE_CODE_TAGS,
+} from "settings";
+
+import { isTruthy } from "utils/types";
+
+const REMARK_PLUGINS = [glm, emoji, externalLinks];
+const REHYPE_PLUGINS = [sanitize];
+
+export interface RenderMarkdownProps {
+  text?: string;
+  allowBasicFormatting?: boolean;
+  allowPreAndCode?: boolean;
+  allowHeadings?: boolean;
+  allowLinks?: boolean;
+  allowImages?: boolean;
+  allowLists?: boolean;
+}
+
+const _RenderMarkdownInner: React.FC<RenderMarkdownProps> = ({
+  text,
+  allowBasicFormatting = true,
+  allowPreAndCode = true,
+  allowHeadings = true,
+  allowLinks = true,
+  allowImages = true,
+  allowLists = true,
+}) => {
+  const allowedElements: string[] = [
+    ...(allowBasicFormatting ? MARKDOWN_BASIC_FORMATTING_TAGS : []),
+    ...(allowHeadings ? MARKDOWN_HEADING_TAGS : []),
+    ...(allowImages ? MARKDOWN_IMAGE_TAGS : []),
+    ...(allowLinks ? MARKDOWN_LINK_TAGS : []),
+    ...(allowLists ? MARKDOWN_LIST_TAGS : []),
+    ...(allowPreAndCode ? MARKDOWN_PRE_CODE_TAGS : []),
+  ].filter(isTruthy);
+
+  if (!text) return null;
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={REHYPE_PLUGINS}
+      linkTarget="_blank"
+      allowedElements={allowedElements}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+};
+
+export const RenderMarkdownInner = React.memo(_RenderMarkdownInner);


### PR DESCRIPTION
Refactored `RenderMarkdown` to extract `RenderMarkdownInner` component + lazy load it with `React.lazy` / `Suspense`.

This has the effect of splitting all of the markdown rendering dependencies/plugins/etc (eg. `react-markdown`, `remark-gfm`, `remark-emoji`, `remark-external-links`, `rehype-sanitize`) into their own bundle chunk.

I pass through the raw `text` as the fallback for `Suspense`, so even before the markdown rendering chunk is loaded, the text can still be viewed in its raw form, allowing the site to still be usable even while the chunk is loading.

---

partially fixes sparkletown/internal-sparkle-issues#839

---

## Results

The overall bundle size only increases ever so slightly (from `3.49 MB` to `3.5 MB`), but we end up splitting off a new chunk of `202.07 KB`, reducing chunk 2 from `2.98 MB` to `2.78 MB`.

### Before Refactor

```
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  757.37 KB  build/static/js/2.0ff36f07.chunk.js
  133.44 KB  build/static/css/main.19c8cac9.chunk.css
  129.2 KB   build/static/js/main.409bffc0.chunk.js
  9.48 KB    build/static/js/3.a560293f.chunk.js
  1.86 KB    build/static/css/2.ca756f56.chunk.css
  1.17 KB    build/static/js/runtime-main.3a521cfb.js
```

![image](https://user-images.githubusercontent.com/753891/124539235-68b74500-de60-11eb-8923-702d9db740f8.png)

![image](https://user-images.githubusercontent.com/753891/124540497-db292480-de62-11eb-8cf3-3f2311dc4cbd.png)

### After Refactor

```
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  698.71 KB (-58.66 KB)  build/static/js/2.813c8d58.chunk.js
  133.44 KB (+1 B)       build/static/css/main.6c272471.chunk.css
  131 KB (+1.8 KB)       build/static/js/main.8a2ac429.chunk.js
  58.69 KB (+49.2 KB)    build/static/js/3.e0d513cf.chunk.js
  9.48 KB                build/static/js/5.1e631716.chunk.js
  1.86 KB                build/static/css/2.ca756f56.chunk.css
  1.19 KB (+24 B)        build/static/js/runtime-main.b2055cca.js
  549 B                  build/static/js/4.a824b5b7.chunk.js
```

![image](https://user-images.githubusercontent.com/753891/124539345-a025f180-de60-11eb-904e-16f9e82c8a7c.png)

![image](https://user-images.githubusercontent.com/753891/124540911-b2555f00-de63-11eb-95b2-a28c2ef90abe.png)

![image](https://user-images.githubusercontent.com/753891/124541043-f9dbeb00-de63-11eb-9e77-f216e315b8be.png)
