### PR TITLE
Alexey petrov/sort schedule rooms alphabetically

### DIFF
--- a/src/components/molecules/Schedule/Schedule.tsx
+++ b/src/components/molecules/Schedule/Schedule.tsx
@@ -66,10 +66,23 @@ export const Schedule: React.FC<ScheduleProps> = ({
     [scheduleStartHour, scheduleDate]
   );
 
+  const sortedEvents = useMemo(
+    () =>
+      locatedEvents.sort((a, b) => {
+        const nameA =
+          a.location.roomTitle ?? a.location.venueName ?? a.location.venueId;
+        const nameB =
+          b.location.roomTitle ?? b.location.venueName ?? b.location.venueId;
+
+        return nameA.localeCompare(nameB);
+      }),
+    [locatedEvents]
+  );
+
   // pairs (venueId, roomTitle) are unique because they are grouped earlier (see NavBarSchedule#schedule)
   const roomCells = useMemo(
     () =>
-      locatedEvents.map(({ location, events }) => (
+      sortedEvents.map(({ location, events }) => (
         <div
           key={`RoomCell-${location.venueId}-${location.roomTitle}`}
           className="Schedule__room"
@@ -82,7 +95,7 @@ export const Schedule: React.FC<ScheduleProps> = ({
           </span>
         </div>
       )),
-    [locatedEvents]
+    [sortedEvents]
   );
 
   const hoursRow = useMemo(

--- a/src/components/molecules/Schedule/Schedule.tsx
+++ b/src/components/molecules/Schedule/Schedule.tsx
@@ -29,6 +29,7 @@ import { ScheduleRoomEvents } from "components/molecules/ScheduleRoomEvents";
 import { calcStartPosition } from "./utils";
 
 import "./Schedule.scss";
+import { sortScheduleRoomsAlphabetically } from "utils/schedule";
 
 export interface ScheduleProps {
   locatedEvents: LocationEvents[];
@@ -67,15 +68,7 @@ export const Schedule: React.FC<ScheduleProps> = ({
   );
 
   const sortedEvents = useMemo(
-    () =>
-      locatedEvents.sort((a, b) => {
-        const nameA =
-          a.location.roomTitle ?? a.location.venueName ?? a.location.venueId;
-        const nameB =
-          b.location.roomTitle ?? b.location.venueName ?? b.location.venueId;
-
-        return nameA.localeCompare(nameB);
-      }),
+    () => sortScheduleRoomsAlphabetically(locatedEvents),
     [locatedEvents]
   );
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,8 +87,6 @@ export const DUST_STORM_TEXT_1 = `A dust storm is ripping across the ${PLAYA_VEN
 export const DUST_STORM_TEXT_2 =
   "Your only option is to seek shelter in a nearby venue!";
 
-export const GITHUB_MAIN_STAGE_NAME = "Main Stage";
-
 // How often to refresh events schedule
 export const REFETCH_SCHEDULE_MS = 10 * 60 * 1000; // 10 mins
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,6 +87,8 @@ export const DUST_STORM_TEXT_1 = `A dust storm is ripping across the ${PLAYA_VEN
 export const DUST_STORM_TEXT_2 =
   "Your only option is to seek shelter in a nearby venue!";
 
+export const GITHUB_MAIN_STAGE_NAME = "Main Stage";
+
 // How often to refresh events schedule
 export const REFETCH_SCHEDULE_MS = 10 * 60 * 1000; // 10 mins
 

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,0 +1,17 @@
+import { GITHUB_MAIN_STAGE_NAME } from "settings";
+import { LocationEvents } from "types/venues";
+
+export const sortScheduleRoomsAlphabetically = (rooms: LocationEvents[]) => {
+  return rooms.sort((a, b) => {
+    const nameA =
+      a.location.roomTitle ?? a.location.venueName ?? a.location.venueId;
+    const nameB =
+      b.location.roomTitle ?? b.location.venueName ?? b.location.venueId;
+
+    if (nameA === GITHUB_MAIN_STAGE_NAME) {
+      return -1;
+    }
+
+    return nameA.localeCompare(nameB);
+  });
+};

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,4 +1,3 @@
-import { GITHUB_MAIN_STAGE_NAME } from "settings";
 import { LocationEvents } from "types/venues";
 
 export const sortScheduleRoomsAlphabetically = (rooms: LocationEvents[]) => {
@@ -7,10 +6,6 @@ export const sortScheduleRoomsAlphabetically = (rooms: LocationEvents[]) => {
       a.location.roomTitle ?? a.location.venueName ?? a.location.venueId;
     const nameB =
       b.location.roomTitle ?? b.location.venueName ?? b.location.venueId;
-
-    if (nameA === GITHUB_MAIN_STAGE_NAME) {
-      return -1;
-    }
 
     return nameA.localeCompare(nameB);
   });


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/884

* Added sorting for schedule room list
* Exception is 'Main Stage' room ( github related, always displays first in the list right after the 'my daily schedule' ( bookmarked events ) )