### PR TITLE
remove hardcoded user statuses

### DIFF
--- a/src/components/atoms/UserStatusDropdown/UserStatusDropdown.tsx
+++ b/src/components/atoms/UserStatusDropdown/UserStatusDropdown.tsx
@@ -1,11 +1,9 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
 import { Dropdown, DropdownButton } from "react-bootstrap";
 
-import { USER_STATUSES } from "settings";
+import { UserStatus } from "types/User";
 
 import { useProfileStatus } from "hooks/useProfileStatus";
-
-import { UserStatus } from "types/User";
 
 import "./UserStatusDropdown.scss";
 
@@ -14,18 +12,28 @@ export interface UserStatusDropdownProps {
 }
 
 export const UserStatusDropdown: React.FC<UserStatusDropdownProps> = ({
-  userStatuses,
+  userStatuses = [],
 }) => {
   const { status, changeUserStatus } = useProfileStatus();
 
-  const allUserStatuses = useMemo(
-    () => (userStatuses ? [...USER_STATUSES, ...userStatuses] : USER_STATUSES),
-    [userStatuses]
-  );
+  // This will check if the user status from the database exists in the venue user statuses and if it doesn't, it will fallback to the first one from the list.
+  useEffect(() => {
+    const hasUserStatuses = !!userStatuses.length;
+
+    if (!status || !hasUserStatuses) return;
+
+    const statusTexts = userStatuses.map((userStatus) => userStatus.status);
+
+    const defaultUserStatus = userStatuses[0].status;
+
+    if (!statusTexts.includes(status)) {
+      changeUserStatus(defaultUserStatus);
+    }
+  }, [changeUserStatus, status, userStatuses]);
 
   const userStatusDropdownOptions = useMemo(
     () =>
-      allUserStatuses.map((userStatus) => (
+      userStatuses.map((userStatus) => (
         <Dropdown.Item
           key={userStatus.status}
           onClick={() => changeUserStatus(userStatus.status)}
@@ -33,7 +41,7 @@ export const UserStatusDropdown: React.FC<UserStatusDropdownProps> = ({
           {userStatus.status}
         </Dropdown.Item>
       )),
-    [allUserStatuses, changeUserStatus]
+    [userStatuses, changeUserStatus]
   );
 
   return (

--- a/src/components/molecules/NavBar/NavBar.scss
+++ b/src/components/molecules/NavBar/NavBar.scss
@@ -249,4 +249,8 @@ $border-radius: 28px;
       margin-right: $spacing--sm;
     }
   }
+
+  &__profile-popover {
+    height: 100%;
+  }
 }

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -54,7 +54,7 @@ const TicketsPopover: React.FC<{ futureUpcoming: UpcomingEvent[] }> = (
 
 const ProfilePopover = (
   <Popover id="profile-popover">
-    <Popover.Content>
+    <Popover.Content className="NavBar__profile-popover">
       <ProfilePopoverContent />
     </Popover.Content>
   </Popover>

--- a/src/components/molecules/UserStatusManager/UserStatusManager.tsx
+++ b/src/components/molecules/UserStatusManager/UserStatusManager.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { Button } from "react-bootstrap";
 
-import { USER_STATUSES } from "settings";
-
 import { UserStatus } from "types/User";
 
 import { Checkbox } from "components/atoms/Checkbox";
@@ -10,10 +8,6 @@ import { Checkbox } from "components/atoms/Checkbox";
 import { UserStatusPanel } from "./components/UserStatusPanel";
 
 import "./UserStatusManager.scss";
-
-const renderDefaultUserStatuses = USER_STATUSES.map((userStatus) => (
-  <UserStatusPanel key={userStatus.status} userStatus={userStatus} disabled />
-));
 
 export interface UserStatusManagerProps {
   venueId?: string;
@@ -89,7 +83,6 @@ export const UserStatusManager: React.FC<UserStatusManagerProps> = ({
       </div>
       {checked && (
         <>
-          {renderDefaultUserStatuses}
           {renderVenueUserStatuses}
           <Button onClick={onAdd}>Add a status</Button>
         </>

--- a/src/components/organisms/ProfileModal/ProfilePopoverContent.scss
+++ b/src/components/organisms/ProfileModal/ProfilePopoverContent.scss
@@ -16,6 +16,7 @@ $profile-popover--margin-top: 12px;
   overflow: auto;
   padding: $spacing--md;
   background: $black;
+  height: 100%;
   background-image: linear-gradient(
     0deg,
     rgba($white, 0.05) 0%,

--- a/src/hooks/useVenueUserStatuses.ts
+++ b/src/hooks/useVenueUserStatuses.ts
@@ -1,8 +1,4 @@
-import {
-  ONLINE_USER_STATUS,
-  DEFAULT_SHOW_USER_STATUSES,
-  USER_STATUSES,
-} from "settings";
+import { DEFAULT_USER_STATUS, DEFAULT_SHOW_USER_STATUSES } from "settings";
 
 import { User } from "types/User";
 
@@ -15,9 +11,7 @@ export const useVenueUserStatuses = (venueId?: string, user?: WithId<User>) => {
 
   const venueStatuses = sovereignVenue?.userStatuses ?? [];
 
-  const statuses = [...USER_STATUSES, ...venueStatuses];
-
-  const userStatus = statuses.find(
+  const userStatus = venueStatuses.find(
     (userStatus) => userStatus.status === user?.status
   );
 
@@ -25,6 +19,6 @@ export const useVenueUserStatuses = (venueId?: string, user?: WithId<User>) => {
     venueUserStatuses: venueStatuses,
     isStatusEnabledForVenue:
       sovereignVenue?.showUserStatus ?? DEFAULT_SHOW_USER_STATUSES,
-    userStatus: userStatus ?? ONLINE_USER_STATUS,
+    userStatus: userStatus ?? DEFAULT_USER_STATUS,
   };
 };

--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -35,9 +35,8 @@ import {
   HAS_GRID_TEMPLATES,
   HAS_REACTIONS_TEMPLATES,
   BACKGROUND_IMG_TEMPLATES,
-  USER_STATUSES,
   DEFAULT_SHOW_SCHEDULE,
-  ONLINE_USER_STATUS,
+  DEFAULT_USER_STATUS,
   DEFAULT_SHOW_USER_STATUSES,
   DEFAULT_AUDIENCE_COLUMNS_NUMBER,
   DEFAULT_AUDIENCE_ROWS_NUMBER,
@@ -964,7 +963,7 @@ const DetailsFormLeft: React.FC<DetailsFormLeftProps> = ({
   const addUserStatus = () =>
     setUserStatuses([
       ...userStatuses,
-      { status: "", color: ONLINE_USER_STATUS.color },
+      { status: "", color: DEFAULT_USER_STATUS.color },
     ]);
 
   const updateStatusColor = (color: string, index: number) => {
@@ -977,10 +976,9 @@ const DetailsFormLeft: React.FC<DetailsFormLeftProps> = ({
     event: React.FormEvent<HTMLInputElement>,
     index: number
   ) => {
-    const allUserStatuses = [...USER_STATUSES, ...userStatuses];
     const statuses = [...userStatuses];
 
-    const userStatusExists = allUserStatuses.find(
+    const userStatusExists = statuses.find(
       (userStatus) => userStatus.status === event.currentTarget.value
     );
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -628,17 +628,10 @@ export const SEARCH_DEBOUNCE_TIME = 200; // ms
 export const DEFAULT_DISPLAYED_POSTER_PREVIEW_COUNT = 48;
 export const DEFAULT_DISPLAYED_VIDEO_PREVIEW_COUNT = 12;
 
-export const ONLINE_USER_STATUS = {
+export const DEFAULT_USER_STATUS = {
   status: DefaultUserStatus.online,
   color: "#53E52A",
 };
-
-export const BUSY_USER_STATUS = {
-  status: DefaultUserStatus.busy,
-  color: "#F44336",
-};
-
-export const USER_STATUSES = [ONLINE_USER_STATUS, BUSY_USER_STATUS];
 
 // SCHEDULE
 export const DEFAULT_SHOW_SCHEDULE = true;


### PR DESCRIPTION
- Removes the hard coded user statuses from the admin and status dropdown
- Handle an edge case, where the user status can be outdated and shown incorrectly due to database changes. Comment added in the code.
- Fix a bug where user statuses were cut if the list was too long.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/720#issuecomment-876860333
Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/720#issuecomment-876858552