### PR TITLE
quick fix for toggle/etc styles in DetailsForm in admin (v1)

### DIFF
--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -73,6 +73,9 @@ import { WizardPage } from "./VenueWizard";
 import QuestionInput from "./QuestionInput";
 import EntranceInput from "./EntranceInput";
 
+// @debt refactor any needed styles out of this file (eg. toggles, etc) and into DetailsForm.scss/similar, then remove this import
+import "../Admin.scss";
+
 import "./Venue.scss";
 
 export type FormValues = Partial<Yup.InferType<typeof validationSchema>>; // bad typing. If not partial, react-hook-forms should force defaultValues to conform to FormInputs but it doesn't
@@ -285,8 +288,9 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
     VenuePlacementState.AdminPlaced;
   const placementAddress = state.detailsPage?.venue?.placement?.addressText;
 
+  // @debt refactor any needed styles out of Admin.scss (eg. toggles, etc) and into DetailsForm.scss/similar, then remove the admin-dashboard class from this container
   return (
-    <div className="page page--admin">
+    <div className="page page--admin admin-dashboard">
       <div className="page-side page-side--admin">
         <div className="page-container-left page-container-left">
           <div className="page-container-left-content">


### PR DESCRIPTION
`DetailsForm` seems to rely on some styles that are currently defined in `Admin.scss` (or another file with similar styles that were defined in 'global scope'). When we split our bundle in https://github.com/sparkletown/sparkle/pull/1737 (or a similar PR around that time), these styles seemed to be lost in the process.

This PR is a quick hacky fix to import the styles from `Admin.scss`, and adds some `@debt` notes to properly clean this up and separate the needed styles to the correct location in future.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/900

---

Note that there is also another PR (see below) that will fix this + also clean up associated tech debt, but given it's larger in scope, I figured getting a quick fix out sooner was better to unbreak the admin tooling:

- https://github.com/sparkletown/sparkle/pull/1775