### PR TITLE
fix TypeError: Cannot read property 'app_id' of undefined + add assertValidAgoraConfig

### DIFF
--- a/functions/src/utils/agora.js
+++ b/functions/src/utils/agora.js
@@ -10,18 +10,17 @@ const AGORA_APP_CERTIFICATE = AGORA_CONFIG.app_certificate;
 const expirationTimeInSeconds = 3600;
 
 const assertValidAgoraConfig = () => {
-  if (typeof AGORA_APP_ID !== "string" && AGORA_APP_ID.length <= 0)
-    throw new Error(
-      "required configuration missing, AGORA_APP_ID must be a string"
-    );
+  if (typeof AGORA_APP_ID !== "string")
+    throw new Error("AGORA_APP_ID must be a string");
 
-  if (
-    typeof AGORA_APP_CERTIFICATE !== "string" &&
-    AGORA_APP_CERTIFICATE.length <= 0
-  )
-    throw new Error(
-      "required configuration missing, AGORA_APP_CERTIFICATE must be a string"
-    );
+  if (AGORA_APP_ID.length <= 0)
+    throw new Error("AGORA_APP_ID must not be empty");
+
+  if (typeof AGORA_APP_CERTIFICATE !== "string")
+    throw new Error("AGORA_APP_CERTIFICATE must be a string");
+
+  if (AGORA_APP_CERTIFICATE.length <= 0)
+    throw new Error("AGORA_APP_CERTIFICATE must not be empty");
 };
 
 const getExpirationTime = () => {
@@ -34,11 +33,12 @@ const generateAgoraTokenForAccount = ({ channelName, account, role }) => {
   assertValidAgoraConfig();
 
   // @debt we should enforce a stricter security requirement on channelName. Maybe use UUIDs?
-  if (typeof channelName !== "string" && channelName.length <= 0)
+  if (typeof channelName !== "string")
     throw new Error("channelName must be a string");
+  if (channelName.length <= 0) throw new Error("channelName must not be empty");
 
-  if (typeof account !== "string" && account.length <= 0)
-    throw new Error("account must be a string");
+  if (typeof account !== "string") throw new Error("account must be a string");
+  if (account.length <= 0) throw new Error("account must not be empty");
 
   if (![RtcRole.PUBLISHER, RtcRole.SUBSCRIBER].includes(role))
     throw new Error("role must be a valid value from the RtcRole enum");

--- a/functions/src/utils/agora.js
+++ b/functions/src/utils/agora.js
@@ -2,13 +2,27 @@ const functions = require("firebase-functions");
 
 const { RtcTokenBuilder, RtcRole } = require("agora-access-token");
 
-const AGORA_CONFIG = functions.config().agora;
-
-const appId = AGORA_CONFIG.app_id;
-const appCertificate = AGORA_CONFIG.app_certificate;
+const AGORA_CONFIG = functions.config().agora || {};
+const AGORA_APP_ID = AGORA_CONFIG.app_id;
+const AGORA_APP_CERTIFICATE = AGORA_CONFIG.app_certificate;
 
 // @debt should we move this into AGORA_CONFIG, or maybe venue config in firestore or similar?
 const expirationTimeInSeconds = 3600;
+
+const assertValidAgoraConfig = () => {
+  if (typeof AGORA_APP_ID !== "string" && AGORA_APP_ID.length <= 0)
+    throw new Error(
+      "required configuration missing, AGORA_APP_ID must be a string"
+    );
+
+  if (
+    typeof AGORA_APP_CERTIFICATE !== "string" &&
+    AGORA_APP_CERTIFICATE.length <= 0
+  )
+    throw new Error(
+      "required configuration missing, AGORA_APP_CERTIFICATE must be a string"
+    );
+};
 
 const getExpirationTime = () => {
   const currentTimestamp = Math.floor(Date.now() / 1000);
@@ -17,6 +31,8 @@ const getExpirationTime = () => {
 };
 
 const generateAgoraTokenForAccount = ({ channelName, account, role }) => {
+  assertValidAgoraConfig();
+
   // @debt we should enforce a stricter security requirement on channelName. Maybe use UUIDs?
   if (typeof channelName !== "string" && channelName.length <= 0)
     throw new Error("channelName must be a string");
@@ -28,8 +44,8 @@ const generateAgoraTokenForAccount = ({ channelName, account, role }) => {
     throw new Error("role must be a valid value from the RtcRole enum");
 
   return RtcTokenBuilder.buildTokenWithAccount(
-    appId,
-    appCertificate,
+    AGORA_APP_ID,
+    AGORA_APP_CERTIFICATE,
     channelName,
     account,
     role,
@@ -37,6 +53,7 @@ const generateAgoraTokenForAccount = ({ channelName, account, role }) => {
   );
 };
 
+exports.assertValidAgoraConfig = assertValidAgoraConfig;
 exports.getExpirationTime = getExpirationTime;
 exports.generateAgoraTokenForAccount = generateAgoraTokenForAccount;
 exports.RtcRole = RtcRole;

--- a/functions/video.js
+++ b/functions/video.js
@@ -1,7 +1,11 @@
 const functions = require("firebase-functions");
 const { HttpsError } = require("firebase-functions/lib/providers/https");
 
-const { RtcRole, generateAgoraTokenForAccount } = require("./src/utils/agora");
+const {
+  RtcRole,
+  assertValidAgoraConfig,
+  generateAgoraTokenForAccount,
+} = require("./src/utils/agora");
 const { assertValidAuth } = require("./src/utils/assert");
 const { twilioVideoToken } = require("./src/utils/twilio");
 
@@ -30,6 +34,19 @@ exports.getAgoraToken = functions.https.onCall((data, context) => {
       "invalid-argument",
       "channelName is required, and must be a string"
     );
+  }
+
+  try {
+    assertValidAgoraConfig();
+  } catch (err) {
+    // Log the specific error details for further investigation
+    functions.logger.error("assertValidAgoraConfig() failed", {
+      error,
+      channelName: data.channelName,
+      account: context.auth.uid,
+    });
+
+    throw new HttpsError("internal", "agora config missing or invalid");
   }
 
   // TODO: Figure out how we decide between using RtcRole.PUBLISHER / RtcRole.SUBSCRIBER, and when they are used

--- a/functions/video.js
+++ b/functions/video.js
@@ -38,7 +38,7 @@ exports.getAgoraToken = functions.https.onCall((data, context) => {
 
   try {
     assertValidAgoraConfig();
-  } catch (err) {
+  } catch (error) {
     // Log the specific error details for further investigation
     functions.logger.error("assertValidAgoraConfig() failed", {
       error,


### PR DESCRIPTION
fixes `TypeError: Cannot read property 'app_id' of undefined` that happens when deploying functions to an environment that doesn't have the agora config keys (introduced in #1673) in it's function config:

```
Error: Error occurred while parsing your function triggers.

TypeError: Cannot read property 'app_id' of undefined
    at Object.<anonymous> (/home/circleci/project/functions/src/utils/agora.js:7:28)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Module.require (internal/modules/cjs/loader.js:1036:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/home/circleci/project/functions/video.js:4:51)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
```

eg. https://app.circleci.com/pipelines/github/sparkletown/sparkle/7911/workflows/532f21e2-65f5-48fc-8307-f6d4530fa80d/jobs/12245

---

partially fixes sparkletown/internal-sparkle-issues#748

partially fixes sparkletown/internal-sparkle-issues#859