### PR TITLE
fix WithNavigationBar to restore height: 100%

### DIFF
--- a/src/components/organisms/WithNavigationBar/WithNavigationBar.scss
+++ b/src/components/organisms/WithNavigationBar/WithNavigationBar.scss
@@ -1,6 +1,8 @@
 @import "scss/constants.scss";
 
 .navbar-margin {
+  height: 100%;
+
   padding-top: $navbar-height;
   padding-bottom: $footer-height;
 }


### PR DESCRIPTION
Some changes made in #1251 caused the `height: 100%` to be removed from `WithNavigationBar`, which lead to some spaces such as the `Embeddable` template breaking/displaying weirdly.

This PR is a 1 line change to fix that back up again.

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/747