### PR TITLE
Bump redux from 4.0.5 to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23950,12 +23950,11 @@
       "integrity": "sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw=="
     },
     "redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-devtools-extension": {
@@ -26505,7 +26504,8 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-use": "^17.2.3",
     "react-webcam": "^5.2.0",
     "read": "^1.0.7",
-    "redux": "^4.0.5",
+    "redux": "^4.1.0",
     "redux-devtools-extension": "^2.13.8",
     "redux-firestore": "sparkletown/redux-firestore#fix/introduce-batch-store-updates-on-addition",
     "redux-thunk": "^2.3.0",


### PR DESCRIPTION
Bumps `redux` from `4.05` to `4.1.0`.

Changelog:

- https://github.com/reduxjs/redux/releases/tag/v4.1.0
  - > This release shrinks our bundle size via error message extraction, updates several error messages for clarity, and optimizes our list of runtime dependencies.
  - > Overall, version 4.1 shrinks from 2.6K min+gz to 1.6K min+gz thanks to these changes.

This is also a pre-requisite to upgrading to `@reduxjs/toolkit` `1.6.0`, which will come in a followup PR:

- https://github.com/reduxjs/redux-toolkit/releases/tag/v1.6.0