### PR TITLE
Bump @reduxjs/toolkit from 1.5.0 to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5157,14 +5157,21 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "@reduxjs/toolkit": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.0.tgz",
-      "integrity": "sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.0.tgz",
+      "integrity": "sha512-eGL50G+Vj5AG5uD0lineb6rRtbs96M8+hxbcwkHpZ8LQcmt0Bm33WyBSnj5AweLkjQ7ZP+KFRDHiLMznljRQ3A==",
       "requires": {
-        "immer": "^8.0.0",
-        "redux": "^4.0.0",
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
+          "integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
+        }
       }
     },
     "@restart/context": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.13",
-    "@reduxjs/toolkit": "^1.5.0",
+    "@reduxjs/toolkit": "^1.6.0",
     "@stripe/react-stripe-js": "^1.1.2",
     "@stripe/stripe-js": "^1.11.0",
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
Bumps `@reduxjs/toolkit` from `1.5.0` to `1.6.0`

Changelog:

- https://github.com/reduxjs/redux-toolkit/releases/tag/v1.6.0
  - > This release adds the new RTK Query data fetching APIs to Redux Toolkit. It also adds multiple new options to `createAsyncThunk` for including meta fields and working with results, updates dependencies to Redux 4.1 and Immer 9, and includes a complete rewrite of our build toolchain with additional "modern" build artifacts in the package.
    - https://redux-toolkit.js.org/rtk-query/overview

Note that this update has a dependency on `redux` `4.1.0`, as per:

- https://github.com/sparkletown/sparkle/pull/1794

We only use `@reduxjs/toolkit` in 1 file at the moment, and for a fairly minimal use case at that (we only use `createAsyncThunk`):

- `src/store/actions/Reactions.ts`

Note that `@reduxjs/toolkit` will be a major part of our future Redux patterns + cleaning up the existing tech debt around data storage/etc.