### PR TITLE
Use EmptyProvider instead of React.Fragment in Provided

### DIFF
--- a/src/components/organisms/AppRouter/Provided.tsx
+++ b/src/components/organisms/AppRouter/Provided.tsx
@@ -7,6 +7,13 @@ import {
   RelatedVenuesProviderProps,
 } from "hooks/useRelatedVenues";
 
+interface EmptyProviderProps {
+  venueId?: string;
+}
+const EmptyProvider: React.FC<EmptyProviderProps> = ({ children }) => {
+  return <>{children}</>;
+};
+
 export interface ProvidedProps {
   withWorldUsers?: boolean;
   withRelatedVenues?: boolean;
@@ -21,11 +28,11 @@ export const Provided: React.FC<ProvidedProps> = ({
 
   const MaybeWorldUsersProvider: React.FC<WorldUsersProviderProps> = withWorldUsers
     ? WorldUsersProvider
-    : React.Fragment;
+    : EmptyProvider;
 
   const MaybeRelatedVenuesProvider: React.FC<RelatedVenuesProviderProps> = withRelatedVenues
     ? RelatedVenuesProvider
-    : React.Fragment;
+    : EmptyProvider;
 
   return (
     <MaybeWorldUsersProvider venueId={venueId}>

--- a/src/components/organisms/AppRouter/Provided.tsx
+++ b/src/components/organisms/AppRouter/Provided.tsx
@@ -7,7 +7,7 @@ import {
   RelatedVenuesProviderProps,
 } from "hooks/useRelatedVenues";
 
-interface EmptyProviderProps {
+export interface EmptyProviderProps {
   venueId?: string;
 }
 

--- a/src/components/organisms/AppRouter/Provided.tsx
+++ b/src/components/organisms/AppRouter/Provided.tsx
@@ -10,6 +10,7 @@ import {
 interface EmptyProviderProps {
   venueId?: string;
 }
+
 const EmptyProvider: React.FC<EmptyProviderProps> = ({ children }) => {
   return <>{children}</>;
 };


### PR DESCRIPTION
In order not to have console errors in browsers when using `React.Fragment` like in the image,
a default no-operation `EmptyProvider` wraps `children` in `Provided`

![sparkle-admin-flashes-03](https://user-images.githubusercontent.com/79229621/125277586-e7552c00-e311-11eb-92e6-72f8536ecdff.png)
