### PR TITLE
fix admin v1 edit venue functionality

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -636,17 +636,17 @@ exports.updateVenue = functions.https.onCall(async (data, context) => {
 
   // @debt this is missing from updateVenue_v2, why is that? Do we need it there/here?
   //   I expect this may be legacy functionality related to the Playa template?
-  if (
-    !data.placement.state ||
-    data.placement.state === PlacementState.SelfPlaced
-  ) {
-    updated.placement = {
-      ...data.placement,
-      state: PlacementState.SelfPlaced,
-    };
-  } else if (data.placementRequests) {
-    updated.placementRequests = data.placementRequests;
-  }
+  // if (
+  //   !data.placement.state ||
+  //   data.placement.state === PlacementState.SelfPlaced
+  // ) {
+  //   updated.placement = {
+  //     ...data.placement,
+  //     state: PlacementState.SelfPlaced,
+  //   };
+  // } else if (data.placementRequests) {
+  //   updated.placementRequests = data.placementRequests;
+  // }
 
   // @debt the logic here differs from updateVenue_v2, which only sets this field when data.showGrid is a boolean
   if (data.columns) {

--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -183,14 +183,24 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
             user
           );
 
-          if (sovereignVenueId)
+          //@debt Create separate function that updates the userStatuses separately by venue id.
+          if (sovereignVenueId && sovereignVenue)
             await updateVenue(
               {
-                ...(vals as VenueInput),
+                name: sovereignVenue.name,
+                subtitle:
+                  sovereignVenue.config?.landingPageConfig.subtitle ?? "",
+                description:
+                  sovereignVenue.config?.landingPageConfig.description ?? "",
+                adultContent: sovereignVenue.adultContent ?? false,
+                profile_questions: sovereignVenue.profile_questions,
+                code_of_conduct_questions:
+                  sovereignVenue.code_of_conduct_questions,
                 id: sovereignVenueId,
                 parentId: sovereignVenue?.parentId,
                 userStatuses,
                 showUserStatus: showUserStatuses,
+                template: sovereignVenue.template,
               },
               user
             ).then(() => {

--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -187,6 +187,7 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
           if (sovereignVenueId && sovereignVenue)
             await updateVenue(
               {
+                id: sovereignVenueId,
                 name: sovereignVenue.name,
                 subtitle:
                   sovereignVenue.config?.landingPageConfig.subtitle ?? "",
@@ -196,8 +197,6 @@ export const DetailsForm: React.FC<DetailsFormProps> = ({
                 profile_questions: sovereignVenue.profile_questions,
                 code_of_conduct_questions:
                   sovereignVenue.code_of_conduct_questions,
-                id: sovereignVenueId,
-                parentId: sovereignVenue?.parentId,
                 userStatuses,
                 showUserStatus: showUserStatuses,
                 template: sovereignVenue.template,


### PR DESCRIPTION
When editing a venue with `parentId` the function updates the sovereign venue with the values from the current one, because they were provided with spread operator. Now the sovereign venue data is being passed instead.