### PR TITLE
[env/github] make unclickable rooms look unclickable

### DIFF
--- a/src/components/templates/PartyMap/components/Map/MapRoom.tsx
+++ b/src/components/templates/PartyMap/components/Map/MapRoom.tsx
@@ -51,8 +51,9 @@ export const MapRoom: React.FC<MapRoomProps> = ({
   }, [dispatch]);
 
   const containerClasses = classNames("maproom", {
-    "maproom--covert--unclickable": isUnclickable,
-    "maproom--covert--iframe": isMapFrame,
+    "maproom--covert": isCovertRoom,
+    "maproom--unclickable": isUnclickable,
+    "maproom--iframe": isMapFrame,
     "maproom--always-show-label":
       shouldShowLabel &&
       (venue.roomVisibility === RoomVisibility.nameCount ||


### PR DESCRIPTION
makes sure the correct styles match the correct elements. already fixed in staging but for some reason not in env/github
I don't think there is an issue to link- this was just discussed over slack/zoom.