### PR TITLE
[scripts] refactor engineering scripts to be more robust when importing shared platform code + improve generateTables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5838,11 +5838,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
     "@types/lodash": {
       "version": "4.14.155",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
@@ -27225,24 +27220,13 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
       "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
       }
     },
     "tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14595,6 +14595,12 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
+    "ignore-styles": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
+      "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
+      "dev": true
+    },
     "image-q": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "firebase-admin": "^9.1.1",
     "firebase-tools": "^8.6.0",
     "gifwrap": "^0.9.2",
+    "ignore-styles": "^5.0.1",
     "phin": "^3.5.0",
     "source-map-explorer": "^2.5.2",
     "ts-node": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "phin": "^3.5.0",
     "source-map-explorer": "^2.5.2",
     "ts-node": "^9.1.1",
+    "tsconfig-paths": "^3.10.1",
     "typescript": "^4.2.4",
     "uuidv4": "^6.2.3"
   }

--- a/scripts/add-auditorium-sections.ts
+++ b/scripts/add-auditorium-sections.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import {
   checkFileExists,

--- a/scripts/bootstrap-new-environment.ts
+++ b/scripts/bootstrap-new-environment.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/clone-data-across-firebase-projects.ts
+++ b/scripts/clone-data-across-firebase-projects.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/clone-events-across-firebase-projects.ts
+++ b/scripts/clone-events-across-firebase-projects.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/configure-venue-access.ts
+++ b/scripts/configure-venue-access.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/count-documents.ts
+++ b/scripts/count-documents.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/count-users-entered-venue.ts
+++ b/scripts/count-users-entered-venue.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/create-jazz-bar.ts
+++ b/scripts/create-jazz-bar.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import admin from "firebase-admin";
 

--- a/scripts/create-users.ts
+++ b/scripts/create-users.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { v4 as uuidv4 } from "uuid";
 

--- a/scripts/duplicate-venue.ts
+++ b/scripts/duplicate-venue.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-badges.ts
+++ b/scripts/get-badges.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-events.ts
+++ b/scripts/get-events.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-users.ts
+++ b/scripts/get-users.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-venue-owners.ts
+++ b/scripts/get-venue-owners.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-venues.ts
+++ b/scripts/get-venues.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/get-visitors.ts
+++ b/scripts/get-visitors.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import fs from "fs";
 import { resolve } from "path";

--- a/scripts/load-test-user-location.ts
+++ b/scripts/load-test-user-location.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/scripts/rescale-placement.ts
+++ b/scripts/rescale-placement.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import admin from "firebase-admin";
 

--- a/scripts/resize-images.ts
+++ b/scripts/resize-images.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 /*
   To run:

--- a/scripts/update-admin-role-users.ts
+++ b/scripts/update-admin-role-users.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import {
   checkFileExists,

--- a/scripts/upload-function-config-service-account.ts
+++ b/scripts/upload-function-config-service-account.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 import { exec } from "child_process";

--- a/scripts/upload-table-config.ts
+++ b/scripts/upload-table-config.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm -r ts-node/register
+#!/usr/bin/env node -r esm -r ts-node/register -r tsconfig-paths/register -r ignore-styles
 
 import { resolve } from "path";
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,8 +14,11 @@ import { RoomType } from "types/rooms";
 
 import { FIVE_MINUTES_MS } from "utils/time";
 
+// @ts-ignore -- ignore TypeScript errors from the following *.png import to avoid type errors when using scripts/
 import sparkleNavLogo from "assets/icons/sparkle-nav-logo.png";
+// @ts-ignore -- ignore TypeScript errors from the following *.png import to avoid type errors when using scripts/
 import defaultMapIcon from "assets/icons/default-map-icon.png";
+// @ts-ignore -- ignore TypeScript errors from the following *.png import to avoid type errors when using scripts/
 import sparkleverseLogo from "assets/images/sparkleverse-logo.png";
 
 export const SPARKLE_HOMEPAGE_URL = "https://sparklespaces.com/";

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -11,6 +11,7 @@ export interface GenerateTablesProps {
   appendTableNumber?: boolean;
   startFrom?: number;
   subtitle?: string;
+  makeReference?: (props: Omit<GenerateTablesProps, "makeReference">) => string;
 }
 
 /**
@@ -25,29 +26,34 @@ export interface GenerateTablesProps {
  * @param startFrom what number should we start from when generating table numbers in the title
  * @param subtitle what should the tables subtitle be
  */
-export const generateTables = ({
-  num,
-  capacity,
-  rows = DEFAULT_TABLE_ROWS,
-  columns = DEFAULT_TABLE_COLUMNS,
-  titlePrefix = "Table",
-  appendTableNumber = true,
-  startFrom = 1,
-  subtitle,
-}: GenerateTablesProps): Table[] =>
-  Array.from(Array(num)).map((_, idx) => {
+export const generateTables = (props: GenerateTablesProps): Table[] => {
+  const {
+    num,
+    capacity,
+    rows = DEFAULT_TABLE_ROWS,
+    columns = DEFAULT_TABLE_COLUMNS,
+    titlePrefix = "Table",
+    appendTableNumber = true,
+    startFrom = 1,
+    subtitle,
+  } = props;
+
+  return Array.from(Array(num)).map((_, idx) => {
     const tableNumber = startFrom + idx;
 
     const title = appendTableNumber
       ? `${titlePrefix} ${tableNumber}`
       : titlePrefix;
 
+    const reference = props.makeReference?.(props) ?? title;
+
     return {
       title,
       subtitle,
-      reference: title,
+      reference,
       capacity,
       rows,
       columns,
     };
   });
+};

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -10,6 +10,7 @@ export interface GenerateTablesProps {
   titlePrefix?: string;
   appendTableNumber?: boolean;
   startFrom?: number;
+  subtitle?: string;
 }
 
 /**
@@ -22,6 +23,7 @@ export interface GenerateTablesProps {
  * @param titlePrefix what should the tables be called (will have the table number appended to it)
  * @param appendTableNumber whether to append the table number to the title or not
  * @param startFrom what number should we start from when generating table numbers in the title
+ * @param subtitle what should the tables subtitle be
  */
 export const generateTables = ({
   num,
@@ -31,6 +33,7 @@ export const generateTables = ({
   titlePrefix = "Table",
   appendTableNumber = true,
   startFrom = 1,
+  subtitle,
 }: GenerateTablesProps): Table[] =>
   Array.from(Array(num)).map((_, idx) => {
     const tableNumber = startFrom + idx;
@@ -41,6 +44,7 @@ export const generateTables = ({
 
     return {
       title,
+      subtitle,
       reference: title,
       capacity,
       rows,

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -2,6 +2,16 @@ import { DEFAULT_TABLE_ROWS, DEFAULT_TABLE_COLUMNS } from "settings";
 
 import { Table } from "types/Table";
 
+export interface GenerateTablesProps {
+  num: number;
+  capacity: number;
+  rows?: number;
+  columns?: number;
+  titlePrefix?: string;
+  appendTableNumber?: boolean;
+  startFrom?: number;
+}
+
 /**
  * Generate an array of Table configs that can be used with Jazz Bar/similar.
  *
@@ -13,15 +23,7 @@ import { Table } from "types/Table";
  * @param appendTableNumber whether to append the table number to the title or not
  * @param startFrom what number should we start from when generating table numbers in the title
  */
-export const generateTables: (props: {
-  num: number;
-  capacity: number;
-  rows?: number;
-  columns?: number;
-  titlePrefix?: string;
-  appendTableNumber?: boolean;
-  startFrom?: number;
-}) => Table[] = ({
+export const generateTables = ({
   num,
   capacity,
   rows = DEFAULT_TABLE_ROWS,
@@ -29,7 +31,7 @@ export const generateTables: (props: {
   titlePrefix = "Table",
   appendTableNumber = true,
   startFrom = 1,
-}) =>
+}: GenerateTablesProps): Table[] =>
   Array.from(Array(num)).map((_, idx) => {
     const tableNumber = startFrom + idx;
 


### PR DESCRIPTION
- added `tsconfig-paths` and `ignore-styles` to `devDependencies` to allow engineering helper scripts to use typescript alias paths + ignore webpack asset imports (eg. images, css styling, etc)
- update the shebangs on all of our `scripts/`
- allow `subtitle` to be passed into `generateTables`
- refactor `generateTables` to accept optional makeReference func prop
- etc ([see commits](https://github.com/sparkletown/sparkle/pull/1821/commits))

---

@sunny-viktoryia also has a PR up for making some changes to the `generateTables` script:

- https://github.com/sparkletown/sparkle/pull/1531

It may just be easier to get this one merged first then handle updating that one for any (minor) merge conflicts rather than trying to bundle it in together with the changes here.

---

### Context about engineering script improvements / bug fixes

When importing from platform code, our engineering scripts previously had no idea how to load the aliased imports. `tsconfig-paths` is required to solve errors like this:

```bash
⇒  ./upload-table-config.ts
/Users/devalias/dev/sparkle/sparkle/src/utils/table.ts:1

Error: Cannot find module 'settings'

Require stack:
- /Users/devalias/dev/sparkle/sparkle/src/utils/table.ts
- /Users/devalias/dev/sparkle/sparkle/scripts/upload-table-config.ts
    at Object.<anonymous> (/Users/devalias/dev/sparkle/sparkle/src/utils/table.ts:1)
```

Once we fixed that and could load the `settings` import, we hit the next issue, that requires us to `@ts-ignore` the TypeScript issues that the script thinks exists from the platform code importing the `*.png` files. This isn't an issue in the platform itself due to how babel/webpack/etc transpile our code, but the scripts just get confused and break.

```
⇒  ./upload-table-config.ts

/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:513
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
../src/settings.ts:18:28 - error TS2307: Cannot find module 'assets/icons/sparkle-nav-logo.png' or its corresponding type declarations.

18 import sparkleNavLogo from "assets/icons/sparkle-nav-logo.png";
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/settings.ts:20:28 - error TS2307: Cannot find module 'assets/icons/default-map-icon.png' or its corresponding type declarations.

20 import defaultMapIcon from "assets/icons/default-map-icon.png";
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/settings.ts:22:30 - error TS2307: Cannot find module 'assets/images/sparkleverse-logo.png' or its corresponding type declarations.

22 import sparkleverseLogo from "assets/images/sparkleverse-logo.png";
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    at createTSError (/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:513:12)
    at reportTSError (/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:517:19)
    at getOutput (/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:752:36)
    at Object.compile (/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:968:32)
    at Object.m._compile (/Users/devalias/dev/sparkle/sparkle/node_modules/ts-node/src/index.ts:1056:42)
    at Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Ph (/Users/devalias/dev/sparkle/sparkle/node_modules/esm/esm.js:1:286187)
    at u (/Users/devalias/dev/sparkle/sparkle/node_modules/esm/esm.js:1:288319)
    at o (/Users/devalias/dev/sparkle/sparkle/node_modules/esm/esm.js:1:287137)
    at /Users/devalias/dev/sparkle/sparkle/node_modules/esm/esm.js:1:284879
```

Once we've silenced those errors, we hit out final problem, where the script doesn't know not to try and import the `*.png` files as literal code, which it obviously can't parse. This results in errors such as the following; which we fix by using the (poorly named since it isn't just about styles) `ignore-styles` lib:

```
⇒  ./upload-table-config.ts
/Users/devalias/dev/sparkle/sparkle/src/assets/icons/sparkle-nav-logo.png:1
�PNG

�PNG

SyntaxError: Invalid or unexpected token
    at Object.compileFunction (vm.js:381:18)
    at Generator.next (<anonymous>)
    at Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
```

After all of this, we can finally just run our script as normal/intended again! 🎉 

```
⇒  ./upload-table-config.ts

---------------------------------------------------------
Generate/upload table config (from newTables const, edit the script)

Usage: upload-table-config.ts PROJECT_ID VENUE_ID [CREDENTIAL_PATH]

Example: upload-table-config.ts co-reality-map myvenue [theMatchingAccountServiceKey.json]
---------------------------------------------------------
```

---

### Context about new additions to `generateTables`

With the new changes to `generateTables`, we can do something like the following to use UUID's for the generated table references:

```typescript
const newTables: Table[] = [
  ...generateTables({
    num: 80,
    capacity: 9,
    columns: 3,
    rows: 3,
    titlePrefix: "Pick your own topic",
    appendTableNumber: false,
    subtitle: "Click the pencil icon to set your table topic!",
    makeReference: () => uuid(),
  }),
];
```

This both gives them a unique identifier, as well as decoupling the reference from the table title, which in many cases was hacky/brittle. Since the table reference is used for the Twilio video room names I believe, this will also make those harder to guess.

Eventually we should probably move to this being our default, but for now the existing default was left in the `generateTables` script so that it can match the logic used for generating default tables in a venue when none exist (which happens in platform code, rather than in the database; and can 'kick people off' if we run the script to generate new tables that then changes the table reference.