### PR TITLE
render LoadingPage while we wait for the redirect to complete in TemplateWrapper instead of showing invalid error

### DIFF
--- a/src/pages/VenuePage/TemplateWrapper.tsx
+++ b/src/pages/VenuePage/TemplateWrapper.tsx
@@ -84,20 +84,24 @@ export const TemplateWrapper: React.FC<TemplateWrapperProps> = ({ venue }) => {
     case VenueTemplate.artcar:
       if (venue.zoomUrl) {
         window.location.replace(venue.zoomUrl);
+
+        // Note that we are explicitly returning here so that none of the rest of this component has a chance to render
+        return <LoadingPage />;
+      } else {
+        template = (
+          <p>
+            Venue {venue.name} should redirect to a URL, but none was set.
+            <br />
+            <button
+              role="link"
+              className="btn btn-primary"
+              onClick={() => history.goBack()}
+            >
+              Go Back
+            </button>
+          </p>
+        );
       }
-      template = (
-        <p>
-          Venue {venue.name} should redirect to a URL, but none was set.
-          <br />
-          <button
-            role="link"
-            className="btn btn-primary"
-            onClick={() => history.goBack()}
-          >
-            Go Back
-          </button>
-        </p>
-      );
       break;
 
     // Note: This is the template that is used for Auditorium (v1)


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/661

Previously while waiting for the redirect, `TemplateWrapper` would 'fall through' and show the 'no venue' error, even when it eventually got there. We now `return <LoadingPage />` after starting the redirect to prevent this.