### PR TITLE
refactor VenueChat and related for performance

### DIFF
--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import classNames from "classnames";
+import { isEqual } from "lodash";
 
 import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
 
@@ -25,7 +26,7 @@ export interface UserAvatarProps {
 }
 
 // @debt the UserProfilePicture component serves a very similar purpose to this, we should unify them as much as possible
-export const UserAvatar: React.FC<UserAvatarProps> = ({
+export const _UserAvatar: React.FC<UserAvatarProps> = ({
   user,
   containerClassName,
   imageClassName,
@@ -36,7 +37,9 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
   medium,
 }) => {
   const venueId = useVenueId();
+
   const { recentWorldUsers } = useRecentWorldUsers();
+
   const {
     userStatus,
     venueUserStatuses,
@@ -108,3 +111,5 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
     </div>
   );
 };
+
+export const UserAvatar = React.memo(_UserAvatar, isEqual);

--- a/src/components/molecules/Chatbox/Chatbox.tsx
+++ b/src/components/molecules/Chatbox/Chatbox.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useCallback } from "react";
+import { isEqual } from "lodash";
 
 import {
   DeleteMessage,
@@ -33,7 +34,7 @@ export interface ChatboxProps {
   displayPoll?: boolean;
 }
 
-export const Chatbox: React.FC<ChatboxProps> = ({
+export const _Chatbox: React.FC<ChatboxProps> = ({
   messages,
   venue,
   sendMessage,
@@ -128,3 +129,5 @@ export const Chatbox: React.FC<ChatboxProps> = ({
     </div>
   );
 };
+
+export const Chatbox = React.memo(_Chatbox, isEqual);

--- a/src/components/organisms/ChatSidebar/ChatSidebar.tsx
+++ b/src/components/organisms/ChatSidebar/ChatSidebar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import { isEqual } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faChevronRight,
@@ -22,7 +23,7 @@ export interface ChatSidebarProps {
   venue: WithId<AnyVenue>;
 }
 
-export const ChatSidebar: React.FC<ChatSidebarProps> = ({ venue }) => {
+export const _ChatSidebar: React.FC<ChatSidebarProps> = ({ venue }) => {
   const {
     isExpanded,
     toggleSidebar,
@@ -85,3 +86,5 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({ venue }) => {
     </div>
   );
 };
+
+export const ChatSidebar = React.memo(_ChatSidebar, isEqual);

--- a/src/components/organisms/ChatSidebar/components/VenueChat/VenueChat.tsx
+++ b/src/components/organisms/ChatSidebar/components/VenueChat/VenueChat.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isEqual } from "lodash";
 
 import { AnyVenue } from "types/venues";
 
@@ -14,7 +15,7 @@ export interface VenueChatProps {
   venue: WithId<AnyVenue>;
 }
 
-export const VenueChat: React.FC<VenueChatProps> = ({ venue }) => {
+export const _VenueChat: React.FC<VenueChatProps> = ({ venue }) => {
   const {
     sendMessage,
     deleteMessage,
@@ -36,3 +37,5 @@ export const VenueChat: React.FC<VenueChatProps> = ({ venue }) => {
     </div>
   );
 };
+
+export const VenueChat = React.memo(_VenueChat, isEqual);

--- a/src/hooks/useRoles.ts
+++ b/src/hooks/useRoles.ts
@@ -4,20 +4,24 @@ import { useSelector } from "./useSelector";
 
 export const useRoles = () => {
   const { user } = useUser();
+
   useFirestoreConnect({
     collection: "roles",
     where: [["users", "array-contains", user?.uid || ""]],
     storeAs: "userRoles",
   });
+
   useFirestoreConnect({
     collection: "roles",
     where: [["allowAll", "==", true]],
     storeAs: "allowAllRoles",
   });
-  const { userRoles, allowAllRoles } = useSelector((state) => ({
-    userRoles: state.firestore.data.userRoles,
-    allowAllRoles: state.firestore.data.allowAllRoles,
-  }));
+
+  const userRoles = useSelector((state) => state.firestore.data.userRoles);
+
+  const allowAllRoles = useSelector(
+    (state) => state.firestore.data.allowAllRoles
+  );
 
   // Note: null here means data is loaded, but there was none.
   // A value of undefined indicates data is not loaded yet.

--- a/src/hooks/useRoles.ts
+++ b/src/hooks/useRoles.ts
@@ -1,15 +1,21 @@
-import { useFirestoreConnect } from "./useFirestoreConnect";
+import { isEqual } from "lodash";
+
+import { isLoaded, useFirestoreConnect } from "./useFirestoreConnect";
 import { useUser } from "./useUser";
 import { useSelector } from "./useSelector";
 
 export const useRoles = () => {
   const { user } = useUser();
 
-  useFirestoreConnect({
-    collection: "roles",
-    where: [["users", "array-contains", user?.uid || ""]],
-    storeAs: "userRoles",
-  });
+  useFirestoreConnect(
+    user
+      ? {
+          collection: "roles",
+          where: [["users", "array-contains", user.uid]],
+          storeAs: "userRoles",
+        }
+      : undefined
+  );
 
   useFirestoreConnect({
     collection: "roles",
@@ -17,36 +23,38 @@ export const useRoles = () => {
     storeAs: "allowAllRoles",
   });
 
-  const userRoles = useSelector((state) => state.firestore.data.userRoles);
+  const {
+    isUserRolesLoaded,
+    isAllowAllRolesLoaded,
+    isRolesLoaded,
+    userRoles,
+    allowAllRoles,
+    roles,
+  } = useSelector((state) => {
+    const { userRoles, allowAllRoles } = state.firestore.data;
 
-  const allowAllRoles = useSelector(
-    (state) => state.firestore.data.allowAllRoles
-  );
+    const rolesForUser = userRoles ? Object.keys(userRoles) : [];
+    const rolesForAll = allowAllRoles ? Object.keys(allowAllRoles) : [];
+    const combinedRoles = [...rolesForUser, ...rolesForAll];
 
-  // Note: null here means data is loaded, but there was none.
-  // A value of undefined indicates data is not loaded yet.
-  // undefined should be returned so callers can show loading indications
+    return {
+      isUserRolesLoaded: isLoaded(userRoles),
+      userRoles: rolesForUser,
+
+      isAllowAllRolesLoaded: isLoaded(allowAllRoles),
+      allowAllRoles: rolesForAll,
+
+      isRolesLoaded: isLoaded(userRoles) && isLoaded(allowAllRoles),
+      roles: combinedRoles,
+    };
+  }, isEqual);
+
   return {
-    userRoles:
-      userRoles === undefined
-        ? undefined
-        : userRoles === null
-        ? []
-        : Object.keys(userRoles),
-    allowAllRoles:
-      allowAllRoles === undefined
-        ? undefined
-        : allowAllRoles === null
-        ? []
-        : Object.keys(allowAllRoles),
-    roles:
-      userRoles === undefined || allowAllRoles === undefined
-        ? undefined
-        : [
-            ...Object.keys(userRoles ?? []),
-            ...Object.keys(allowAllRoles ?? []),
-          ],
+    isUserRolesLoaded,
+    isAllowAllRolesLoaded,
+    isRolesLoaded,
+    userRoles,
+    allowAllRoles,
+    roles,
   };
 };
-
-export default useRoles;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,27 +1,32 @@
+import { useMemo } from "react";
 import { FirebaseReducer } from "react-redux-firebase";
+import { isEqual } from "lodash";
 
 import { User } from "types/User";
 
-import { WithId } from "utils/id";
+import { withId, WithId } from "utils/id";
 import { authSelector, profileSelector } from "utils/selectors";
 
 import { useSelector } from "hooks/useSelector";
 
-type UseUserResult = {
+export interface UseUserResult {
   user?: FirebaseReducer.AuthState;
   profile?: FirebaseReducer.Profile<User>;
   userWithId?: WithId<User>;
   userId?: string;
-};
+}
 
 export const useUser = (): UseUserResult => {
-  const auth = useSelector(authSelector);
-  const profile = useSelector(profileSelector);
+  const auth = useSelector(authSelector, isEqual);
+  const profile = useSelector(profileSelector, isEqual);
 
-  return {
-    user: !auth.isEmpty ? auth : undefined,
-    profile: !profile.isEmpty ? profile : undefined,
-    userWithId: auth && profile ? { ...profile, id: auth.uid } : undefined,
-    userId: auth && profile ? auth.uid : undefined,
-  };
+  return useMemo(
+    () => ({
+      user: !auth.isEmpty ? auth : undefined,
+      profile: !profile.isEmpty ? profile : undefined,
+      userWithId: auth && profile ? withId(profile, auth.uid) : undefined,
+      userId: auth && profile ? auth.uid : undefined,
+    }),
+    [auth, profile]
+  );
 };

--- a/src/hooks/useVenueChat.ts
+++ b/src/hooks/useVenueChat.ts
@@ -1,4 +1,5 @@
 import { useMemo, useCallback } from "react";
+import { isEqual } from "lodash";
 
 import { VENUE_CHAT_AGE_DAYS } from "settings";
 
@@ -29,6 +30,8 @@ import { useUser } from "./useUser";
 import { useWorldUsersByIdWorkaround } from "./users";
 import { useRoles } from "./useRoles";
 
+const noMessages: WithId<VenueChatMessage>[] = [];
+
 export const useConnectVenueChatMessages = (venueId?: string) => {
   useFirestoreConnect(
     venueId
@@ -49,7 +52,8 @@ export const useVenueChat = (venueId?: string) => {
 
   useConnectVenueChatMessages(venueId);
 
-  const chatMessages = useSelector(venueChatMessagesSelector) ?? [];
+  const chatMessages =
+    useSelector(venueChatMessagesSelector, isEqual) ?? noMessages;
 
   const isAdmin = Boolean(userRoles?.includes("admin"));
 

--- a/src/hooks/useVenueChat.ts
+++ b/src/hooks/useVenueChat.ts
@@ -59,13 +59,17 @@ export const useVenueChat = (venueId?: string) => {
 
   const venueChatAgeThresholdSec = getDaysAgoInSeconds(VENUE_CHAT_AGE_DAYS);
 
-  const filteredMessages = chatMessages
-    .filter(
-      (message) =>
-        message.deleted !== true &&
-        message.ts_utc.seconds > venueChatAgeThresholdSec
-    )
-    .sort(chatSort);
+  const filteredMessages = useMemo(
+    () =>
+      chatMessages
+        .filter(
+          (message) =>
+            message.deleted !== true &&
+            message.ts_utc.seconds > venueChatAgeThresholdSec
+        )
+        .sort(chatSort),
+    [chatMessages, venueChatAgeThresholdSec]
+  );
 
   const sendMessage: SendMessage = useCallback(
     async ({ message, isQuestion }) => {

--- a/src/hooks/useVenueChat.ts
+++ b/src/hooks/useVenueChat.ts
@@ -151,14 +151,11 @@ export const useVenueChat = (venueId?: string) => {
     [userId, worldUsersById, isAdmin, messages, allMessagesReplies]
   );
 
-  return useMemo(
-    () => ({
-      messagesToDisplay,
+  return {
+    messagesToDisplay,
 
-      sendMessage,
-      deleteMessage,
-      sendThreadReply,
-    }),
-    [messagesToDisplay, sendMessage, sendThreadReply, deleteMessage]
-  );
+    sendMessage,
+    deleteMessage,
+    sendThreadReply,
+  };
 };

--- a/src/hooks/useVenueUserStatuses.ts
+++ b/src/hooks/useVenueUserStatuses.ts
@@ -1,20 +1,23 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { updateUserOnlineStatus } from "api/profile";
 
 import { DEFAULT_USER_STATUS, DEFAULT_SHOW_USER_STATUSES } from "settings";
 
-import { User } from "types/User";
+import { User, UserStatus } from "types/User";
 
 import { WithId } from "utils/id";
 
 import { useSovereignVenue } from "./useSovereignVenue";
 import { useUser } from "./useUser";
 
+const emptyStatuses: UserStatus[] = [];
+
 export const useVenueUserStatuses = (venueId?: string, user?: WithId<User>) => {
   const { sovereignVenue } = useSovereignVenue({ venueId });
   const { userId, profile } = useUser();
 
+  // @debt replace this with useAsync / useAsyncFn / similar
   const changeUserStatus = useCallback(
     (newStatus?: string) => {
       if (!userId) return;
@@ -27,20 +30,22 @@ export const useVenueUserStatuses = (venueId?: string, user?: WithId<User>) => {
     [userId]
   );
 
-  const venueStatuses = sovereignVenue?.userStatuses ?? [];
+  const venueUserStatuses = sovereignVenue?.userStatuses ?? emptyStatuses;
 
-  const userStatus = venueStatuses.find(
-    (userStatus) => userStatus.status === user?.status
+  const userStatus = useMemo(
+    () =>
+      venueUserStatuses.find(({ status }) => status === user?.status) ?? {
+        status: profile?.status ?? DEFAULT_USER_STATUS.status,
+        color: venueUserStatuses[0]?.color ?? DEFAULT_USER_STATUS.color,
+      },
+    [profile?.status, user?.status, venueUserStatuses]
   );
 
   return {
     changeUserStatus,
-    venueUserStatuses: venueStatuses,
+    venueUserStatuses,
     isStatusEnabledForVenue:
       sovereignVenue?.showUserStatus ?? DEFAULT_SHOW_USER_STATUSES,
-    userStatus: userStatus ?? {
-      status: profile?.status ?? DEFAULT_USER_STATUS.status,
-      color: venueStatuses[0]?.color ?? DEFAULT_USER_STATUS.color,
-    },
+    userStatus,
   };
 };

--- a/src/pages/Admin/Admin_v2.tsx
+++ b/src/pages/Admin/Admin_v2.tsx
@@ -7,7 +7,7 @@ import { orderedVenuesSelector } from "utils/selectors";
 
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
-import useRoles from "hooks/useRoles";
+import { useRoles } from "hooks/useRoles";
 import { useIsAdminUser } from "hooks/roles";
 import { useAdminVenues } from "hooks/useAdminVenues";
 


### PR DESCRIPTION
Cleans up some tech debt, makes more effective use of memoing in `useSelector` in places, and uses `React.memo` to create 'pure' functional components.

This was all driven from using `whyDidYouRender` + the react performance profiler + `useDebugWarnLog` to track down and isolate the areas needing to be fixed up.