### PR TITLE
[env/github] Set default profile photo on Okta login

### DIFF
--- a/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
+++ b/src/components/molecules/ProfilePictureInput/ProfilePictureInput.tsx
@@ -74,8 +74,10 @@ export const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputPro
     setValue("pictureUrl", pictureUrlRef, true);
   };
 
-  const githubImageSrc =
-    githubHandle && `https://github.com/${githubHandle}.png?size=120`;
+  // NOTE: if githubHandle is invalid, the resulting avatar will be invalid as well e.g. https://github.com/invalid-github-handle.png?size=120
+  const githubImageSrc = githubHandle
+    ? `https://github.com/${githubHandle}.png?size=120`
+    : "/avatars/default-octocat-3.png";
 
   // Set GitHub image as a default picture
   useEffect(() => {
@@ -91,7 +93,7 @@ export const ProfilePictureInput: React.FunctionComponent<ProfilePictureInputPro
         onClick={() => uploadRef.current?.click()}
       >
         <img
-          src={pictureUrl || "/avatars/default-octocat-3.png"}
+          src={pictureUrl}
           className="profile-icon profile-picture-preview"
           alt="your profile"
         />


### PR DESCRIPTION
Possible fix for corner cases of https://github.com/sparkletown/internal-sparkle-issues/issues/927

Initially a default avatar image was shown when there was a missing `githubHandle` and there wasn't one already set as `pictureUrl`  . This gave wrong impression the avatar image was already pre-selected/uploaded.

Now `<ProfilePictureInput>` sets the actual value of `githubImageSrc` (and by extension `pictureUrl` when missing ) to be the default `/avatars/default-octocat-3.png`

There is still one edge case remaining, an invalid `githubHandle` that may produce invalid avatar URL e.g. `https://github.com/invalid-github-handle.png?size=120`. But this should be visible to user and not misinform there is a pre-set avatar so they can take the appropriate action.