### PR TITLE
Add ChunkLoadError handling to BugsnagErrorBoundary

### DIFF
--- a/src/bugsnag/BugsnagErrorBoundary.tsx
+++ b/src/bugsnag/BugsnagErrorBoundary.tsx
@@ -1,0 +1,38 @@
+// NOTE: do not include any other files here, try to keep this component separate from the rest
+
+import React from "react";
+import { OnErrorCallback } from "@bugsnag/core";
+import Bugsnag from "@bugsnag/js";
+
+import { isBugsnagStarted } from "./init";
+import { ErrorPrompt } from "./ErrorPrompt";
+
+interface BugsnagErrorBoundaryProps {
+  onError?: OnErrorCallback;
+  FallbackComponent?: React.ComponentType<{
+    error: Error;
+    info: React.ErrorInfo;
+    clearError: () => void;
+  }>;
+}
+
+const ErrorBoundaryStub: React.FC<BugsnagErrorBoundaryProps> = ({
+  children,
+}) => {
+  // NOTE: has same interface as Bugsnag's error boundary component to prevent React complaining props are being set to a React.Fragment
+  return <>{children}</>;
+};
+
+const MaybeErrorBoundary = isBugsnagStarted
+  ? Bugsnag.getPlugin("react")?.createErrorBoundary(React) ?? ErrorBoundaryStub
+  : ErrorBoundaryStub;
+
+export const BugsnagErrorBoundary: React.FC<BugsnagErrorBoundaryProps> = ({
+  children,
+}) => {
+  return (
+    <MaybeErrorBoundary FallbackComponent={ErrorPrompt}>
+      {children}
+    </MaybeErrorBoundary>
+  );
+};

--- a/src/bugsnag/ErrorPrompt.scss
+++ b/src/bugsnag/ErrorPrompt.scss
@@ -1,0 +1,109 @@
+// NOTE: do not include any other files here, keep these styles separate from the rest
+
+.ErrorPrompt {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  background: rgba(0, 0, 0, 0.6);
+  padding: max(4em, 5%) max(4em, 20%);
+
+  &__modal {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 30px;
+
+    position: relative;
+    min-width: 50%;
+
+    background: #232225;
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+    border-radius: 24px;
+  }
+
+  &__row {
+    margin-top: 2em;
+    width: 100%;
+    display: flex;
+
+    & > * + * {
+      margin: 0 1em;
+    }
+
+    &--vertical {
+      flex-wrap: wrap;
+
+      & > * + * {
+        margin: 1em 0;
+      }
+    }
+  }
+
+  &__title {
+    font-family: "Rubik", sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 20px;
+    line-height: 22px;
+
+    text-align: center;
+
+    color: #ffffff;
+
+    flex: none;
+    order: 0;
+    align-self: stretch;
+    flex-grow: 0;
+    margin: 10px 0;
+  }
+
+  &__message {
+    width: 100%;
+  }
+
+  &__name {
+    font-weight: bold;
+  }
+
+  &__value--preformatted {
+    min-height: 15em;
+    max-height: 30em;
+    min-width: 10em;
+    max-width: 100%;
+    overflow: auto;
+    text-align: start;
+    font-family: monospace;
+  }
+
+  &__buttons {
+    width: 50%;
+    display: flex;
+    align-content: center;
+    justify-content: space-around;
+    align-items: center;
+  }
+
+  &__button {
+    height: 2.5em;
+    min-width: 10em;
+    padding: 4px 1em;
+    border-radius: 24px;
+    border: none;
+    cursor: pointer;
+  }
+
+  &__button--primary {
+    color: #ffffff;
+    background: #7c46fb;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+  }
+
+  &__button--normal {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(10px);
+  }
+}

--- a/src/bugsnag/ErrorPrompt.tsx
+++ b/src/bugsnag/ErrorPrompt.tsx
@@ -1,0 +1,123 @@
+// NOTE: do not include any other files here, try to keep this component separate from the rest
+
+import React from "react";
+
+import "./ErrorPrompt.scss";
+
+const CHUNK_NOT_IN_CACHE = /Loading chunk [\d]+ failed/;
+
+const LOAD_ERROR_TITLE = "Loading Error";
+const LOAD_ERROR_MESSAGE = `
+Apologies for the interruption.
+There seems to be a problem loading necessary file for the proper functioning of this app.
+
+This can happen if there has been an update.
+Please try reloading the page to get the newer version.
+
+In case the problem persists, please contact \u2728 Sparkle and provide the error details.
+`;
+
+const UNEXPECTED_ERROR_TITLE = "Unexpected Error";
+const UNEXPECTED_ERROR_MESSAGE = `
+You can try clearing the error in hope the app will keep working as expected
+or if that doesn't help - reload the page.
+
+In case the problem persists, please contact \u2728 Sparkle and provide the error details.
+`;
+
+interface ChunkLoadError extends Error {
+  type?: string;
+  request?: string;
+}
+
+export interface FallbackComponentProps {
+  error: Error | ChunkLoadError;
+  info: React.ErrorInfo;
+  clearError: () => void;
+}
+
+export const isChunkLoadError = (error?: unknown): error is ChunkLoadError =>
+  error instanceof Error && error.name === "ChunkLoadError";
+
+export const ErrorPrompt: React.FC<FallbackComponentProps> = ({
+  error,
+  info,
+  clearError,
+}) => {
+  const chunkLoadError = isChunkLoadError(error) ? error : undefined;
+
+  // To avoid reload on syntax error, check the file is not in browser cache as well
+  // @see https://github.com/webpack/webpack.js.org/issues/4479#issuecomment-649416798
+  const isMissingInCache = CHUNK_NOT_IN_CACHE.test(error.message);
+
+  const title =
+    chunkLoadError && isMissingInCache
+      ? LOAD_ERROR_TITLE
+      : UNEXPECTED_ERROR_TITLE;
+
+  const messageLines = (isMissingInCache
+    ? LOAD_ERROR_MESSAGE
+    : UNEXPECTED_ERROR_MESSAGE
+  )
+    .split("\n\n")
+    .map((line, key) => <p key={key}>{line}</p>);
+
+  return (
+    <div className="ErrorPrompt">
+      <div className="ErrorPrompt__modal">
+        <h4 className="ErrorPrompt__title">{title}</h4>
+        <div className="ErrorPrompt__row--vertical ErrorPrompt__message">
+          {messageLines}
+        </div>
+        <div className="ErrorPrompt__row ErrorPrompt__buttons">
+          {!isMissingInCache && (
+            <button
+              className="ErrorPrompt__button ErrorPrompt__button--normal"
+              type="button"
+              onClick={clearError}
+            >
+              Clear Error
+            </button>
+          )}
+
+          <button
+            className="ErrorPrompt__button ErrorPrompt__button--primary"
+            type="button"
+            onClick={() => window.location.reload()}
+          >
+            Reload Page
+          </button>
+        </div>
+
+        {!isMissingInCache && (
+          <div className="ErrorPrompt__row">
+            <span className="ErrorPrompt__name">Error Description:</span>
+            <span className="ErrorPrompt__value--inline">{error.message}</span>
+          </div>
+        )}
+        {isMissingInCache && chunkLoadError && (
+          <div className="ErrorPrompt__row">
+            <span className="ErrorPrompt__name">Missing File:</span>
+            <span className="ErrorPrompt__value--inline">
+              {chunkLoadError.request}
+            </span>
+          </div>
+        )}
+        {isMissingInCache && chunkLoadError && (
+          <div className="ErrorPrompt__row">
+            <span className="ErrorPrompt__name">Type of Error:</span>
+            <span className="ErrorPrompt__value--inline">
+              {chunkLoadError.type}
+            </span>
+          </div>
+        )}
+        <div className="ErrorPrompt__row ErrorPrompt__row--vertical">
+          <div className="ErrorPrompt__name">Component Stack:</div>
+          <textarea className="ErrorPrompt__value--preformatted" readOnly>
+            {info.componentStack}
+          </textarea>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/bugsnag/index.ts
+++ b/src/bugsnag/index.ts
@@ -1,0 +1,2 @@
+export { addToBugsnagEventOnError, isBugsnagStarted } from "./init";
+export { BugsnagErrorBoundary } from "./BugsnagErrorBoundary";

--- a/src/bugsnag/init.ts
+++ b/src/bugsnag/init.ts
@@ -1,0 +1,113 @@
+import firebase from "firebase/app";
+
+import Bugsnag from "@bugsnag/js";
+import BugsnagPluginReact from "@bugsnag/plugin-react";
+
+import {
+  BUGSNAG_API_KEY,
+  BUILD_BRANCH,
+  BUILD_SHA1,
+  BUILD_TAG,
+  BUILD_PULL_REQUESTS,
+} from "secrets";
+
+if (BUGSNAG_API_KEY) {
+  const DEVELOPMENT = "development";
+  const TEST = "test";
+  const STAGING = "staging";
+  const PRODUCTION = "production";
+  const SPARKLE_ENVS = [
+    "sparkleverse",
+    "sparkle1",
+    "sparkle2",
+    "sparkle3",
+    "sparkle4",
+    "sparkle5",
+    "sparkle6",
+    "sparkle7",
+    "sparkle8",
+    "sparkle9",
+    "sparkle10",
+    "bigtop",
+    "deloitte",
+    "env/kotr",
+    "env/memrise",
+    "env/unesco",
+    "env/ohbm",
+    "env/pa",
+    "env/demo",
+    "env/unity",
+    "env/clever",
+    "env/burn",
+    "env/burn-staging",
+    "env/github",
+    "env/summit-hack",
+  ];
+
+  const releaseStage = () => {
+    if (
+      window.location.host.includes("localhost") ||
+      process.env.NODE_ENV === DEVELOPMENT
+    ) {
+      return DEVELOPMENT;
+    }
+
+    if (process.env.NODE_ENV === TEST) {
+      return TEST;
+    }
+
+    if (
+      window.location.host.includes(STAGING) ||
+      BUILD_BRANCH?.includes(STAGING)
+    ) {
+      return STAGING;
+    }
+
+    if (BUILD_BRANCH?.includes("master")) {
+      return PRODUCTION;
+    }
+
+    if (BUILD_BRANCH !== undefined && SPARKLE_ENVS.includes(BUILD_BRANCH)) {
+      return BUILD_BRANCH;
+    }
+
+    return process.env.NODE_ENV;
+  };
+
+  Bugsnag.start({
+    apiKey: BUGSNAG_API_KEY,
+    plugins: [new BugsnagPluginReact()],
+    appType: "client",
+    appVersion: BUILD_SHA1,
+    enabledReleaseStages: [STAGING, PRODUCTION, ...SPARKLE_ENVS], // don't track errors in development/test
+    releaseStage: releaseStage(),
+    maxEvents: 25,
+    metadata: {
+      BUILD_SHA1,
+      BUILD_TAG,
+      BUILD_BRANCH,
+      BUILD_PULL_REQUESTS,
+    },
+    onError: (event) => {
+      const { currentUser } = firebase.auth();
+
+      if (!currentUser) return;
+
+      // Add user context to help locate related errors for support
+      event.setUser(
+        currentUser.uid,
+        currentUser.email || undefined,
+        currentUser.displayName || undefined
+      );
+    },
+  });
+}
+
+// NOTE: the assumption is that BugSnag is started for any non-falsy API key, see previous if block
+export const isBugsnagStarted = !!BUGSNAG_API_KEY;
+
+export const addToBugsnagEventOnError: typeof Bugsnag.addOnError = BUGSNAG_API_KEY
+  ? (fn) => Bugsnag.addOnError(fn)
+  : () => {
+      // Bugsnag isn't started, this stub will prevent console warnings saying .addOnError() has been called before .start()
+    };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,6 @@ import "./wdyr";
 import React, { useEffect } from "react";
 import { render } from "react-dom";
 
-import Bugsnag from "@bugsnag/js";
-import BugsnagPluginReact from "@bugsnag/plugin-react";
 import LogRocket from "logrocket";
 // eslint-disable-next-line no-restricted-imports
 import mixpanel from "mixpanel-browser";
@@ -35,11 +33,7 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import {
-  BUGSNAG_API_KEY,
-  BUILD_BRANCH,
-  BUILD_PULL_REQUESTS,
   BUILD_SHA1,
-  BUILD_TAG,
   LOGROCKET_APP_ID,
   MIXPANEL_PROJECT_TOKEN,
   STRIPE_PUBLISHABLE_KEY,
@@ -68,6 +62,8 @@ import { AppRouter } from "components/organisms/AppRouter";
 
 import { LoadingPage } from "components/molecules/LoadingPage/LoadingPage";
 
+import { BugsnagErrorBoundary, addToBugsnagEventOnError } from "bugsnag";
+
 import "scss/global.scss";
 import { ThemeProvider } from "styled-components";
 import { theme } from "theme/theme";
@@ -79,7 +75,7 @@ if (LOGROCKET_APP_ID) {
     release: BUILD_SHA1,
   });
 
-  Bugsnag.addOnError((event) => {
+  addToBugsnagEventOnError((event) => {
     event.addMetadata("logrocket", "sessionUrl", LogRocket.sessionURL);
   });
 }
@@ -136,103 +132,6 @@ const rrfProps = {
   dispatch: store.dispatch,
   createFirestoreInstance,
 };
-
-if (BUGSNAG_API_KEY) {
-  const DEVELOPMENT = "development";
-  const TEST = "test";
-  const STAGING = "staging";
-  const PRODUCTION = "production";
-  const SPARKLE_ENVS = [
-    "sparkleverse",
-    "sparkle1",
-    "sparkle2",
-    "sparkle3",
-    "sparkle4",
-    "sparkle5",
-    "sparkle6",
-    "sparkle7",
-    "sparkle8",
-    "sparkle9",
-    "sparkle10",
-    "bigtop",
-    "deloitte",
-    "env/kotr",
-    "env/memrise",
-    "env/unesco",
-    "env/ohbm",
-    "env/pa",
-    "env/demo",
-    "env/unity",
-    "env/clever",
-    "env/burn",
-    "env/burn-staging",
-    "env/github",
-    "env/summit-hack",
-  ];
-
-  const releaseStage = () => {
-    if (
-      window.location.host.includes("localhost") ||
-      process.env.NODE_ENV === DEVELOPMENT
-    ) {
-      return DEVELOPMENT;
-    }
-
-    if (process.env.NODE_ENV === TEST) {
-      return TEST;
-    }
-
-    if (
-      window.location.host.includes(STAGING) ||
-      BUILD_BRANCH?.includes(STAGING)
-    ) {
-      return STAGING;
-    }
-
-    if (BUILD_BRANCH?.includes("master")) {
-      return PRODUCTION;
-    }
-
-    if (BUILD_BRANCH !== undefined && SPARKLE_ENVS.includes(BUILD_BRANCH)) {
-      return BUILD_BRANCH;
-    }
-
-    return process.env.NODE_ENV;
-  };
-
-  Bugsnag.start({
-    apiKey: BUGSNAG_API_KEY,
-    plugins: [new BugsnagPluginReact()],
-    appType: "client",
-    appVersion: BUILD_SHA1,
-    enabledReleaseStages: [STAGING, PRODUCTION, ...SPARKLE_ENVS], // don't track errors in development/test
-    releaseStage: releaseStage(),
-    maxEvents: 25,
-    metadata: {
-      BUILD_SHA1,
-      BUILD_TAG,
-      BUILD_BRANCH,
-      BUILD_PULL_REQUESTS,
-    },
-    onError: (event) => {
-      const { currentUser } = firebase.auth();
-
-      if (!currentUser) return;
-
-      // Add user context to help locate related errors for support
-      event.setUser(
-        currentUser.uid,
-        currentUser.email || undefined,
-        currentUser.displayName || undefined
-      );
-    },
-  });
-}
-
-// When BUGSNAG_API_KEY not set, stub out BugsnagErrorBoundary with a noop
-const BugsnagErrorBoundary = BUGSNAG_API_KEY
-  ? Bugsnag.getPlugin("react")?.createErrorBoundary(React) ?? React.Fragment
-  : React.Fragment;
 
 if (MIXPANEL_PROJECT_TOKEN) {
   mixpanel.init(MIXPANEL_PROJECT_TOKEN, { batch_requests: true });


### PR DESCRIPTION
Attempts to provide fallback to chunk loading error i.e. https://github.com/sparkletown/internal-sparkle-issues/issues/913.


Steps to reproduce:
```powershell
npm i -g serve
npm run build:bundle-stats; npm run analyze:bundle-stats;
Remove-Item -Path .\build\static\js\14.ca05937b.chunk.js
serve --debug -C -n -l 3000 -s build
```

Navigate to the URL that will require the deleted chunk (E.g. `npm run analyze:bundle-stats` provided the chunk file name for the `AdminSubroute` component )
![sparkle-error-boundary-03](https://user-images.githubusercontent.com/79229621/126141262-39638038-3f3d-426f-bf53-e2e792c16f10.png)

By adding `ErrorPrompt` now there can be user friendly(-er) messages ( @sofisparkle wording or general UI/UX input desired ):

![sparkle-error-boundary-01](https://user-images.githubusercontent.com/79229621/126141916-9bda35fb-95b1-41ca-9767-3cfc7a790d81.png)

![sparkle-error-boundary-02](https://user-images.githubusercontent.com/79229621/126141904-88b1cad7-4795-4de8-b21a-409a2517ffca.png)

