### PR TITLE
fix room toggle for hidden label

### DIFF
--- a/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
+++ b/src/pages/Admin/Venue/Rooms/RoomsForm.tsx
@@ -333,7 +333,7 @@ const RoomInnerForm: React.FC<RoomInnerFormProps> = (props) => {
                     {/* @debt pass the header into Toggler's 'label' prop instead of being external like this*/}
                     <div className="input-title">Is label hidden?</div>
                     <Toggler
-                      name="isLabeled"
+                      name="isLabelHidden"
                       forwardedRef={register}
                       disabled={disable}
                     />


### PR DESCRIPTION
The field used in the types and conditional rendering is called `isLabelHidden` but the toggle (useForm) in the admin was called `isLabeled`. You can see that in the previous PR for the feature: https://github.com/sparkletown/sparkle/pull/1632

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/914

P.S. People should test their stuff before merging. 🔥 