### PR TITLE
removed background image library text if collection is empty

### DIFF
--- a/src/components/molecules/ImageInput/ImageCollectionInput.tsx
+++ b/src/components/molecules/ImageInput/ImageCollectionInput.tsx
@@ -75,6 +75,8 @@ export const ImageCollectionInput: React.FC<ImageInputProps> = (props) => {
     []
   );
 
+  const hasImageCollections = !!imageCollection.length;
+
   // this keeps the component state synchronised with the parent form state
   useEffect(() => {
     if (selectedCollectionImageUrl) {
@@ -131,11 +133,11 @@ export const ImageCollectionInput: React.FC<ImageInputProps> = (props) => {
         value={imageUrlForPreview}
       />
       {error?.message && <span className="input-error">{error.message}</span>}
-      {imageCollection.length ? (
+      {hasImageCollections && (
         <div style={{ marginTop: 10, fontSize: "16px" }}>
           {`Or choose one of our popular ${imageType}`}
         </div>
-      ) : null}
+      )}
       <div
         style={{
           display: "flex",

--- a/src/components/molecules/ImageInput/ImageCollectionInput.tsx
+++ b/src/components/molecules/ImageInput/ImageCollectionInput.tsx
@@ -131,9 +131,11 @@ export const ImageCollectionInput: React.FC<ImageInputProps> = (props) => {
         value={imageUrlForPreview}
       />
       {error?.message && <span className="input-error">{error.message}</span>}
-      <div style={{ marginTop: 10, fontSize: "16px" }}>
-        {`Or choose one of our popular ${imageType}`}
-      </div>
+      {imageCollection.length ? (
+        <div style={{ marginTop: 10, fontSize: "16px" }}>
+          {`Or choose one of our popular ${imageType}`}
+        </div>
+      ) : null}
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
Closes https://github.com/sparkletown/internal-sparkle-issues/issues/716

Done as per https://github.com/sparkletown/internal-sparkle-issues/issues/716#issuecomment-839728182

'Select background image' info text won't appear unless background library collection is not empty