### PR TITLE
fixed external link redirect

### DIFF
--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -71,7 +71,8 @@ export const EventModal: React.FC<EventModalProps> = ({
       eventVenue?.rooms?.filter(
         (venueRoom) => getUrlParamFromString(venueRoom.title) === room
       ) || [];
-// @debt fix this hack on 24.07.2021
+
+    // @debt fix this hack on 24.07.2021
     if (selectedRoom) {
       openUrl(selectedRoom?.url);
 

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -45,12 +45,10 @@ export const EventModal: React.FC<EventModalProps> = ({
     () =>
       eventVenue?.rooms?.find((room) => {
         const { room: eventRoom = "" } = event;
-
         const noTrailSlashUrl = getUrlWithoutTrailingSlash(room.url);
 
         const [roomName] = getLastUrlParam(noTrailSlashUrl);
         const roomUrlParam = getUrlParamFromString(eventRoom);
-
         return roomUrlParam.endsWith(`${roomName}`);
       }),
     [eventVenue, event]
@@ -63,12 +61,21 @@ export const EventModal: React.FC<EventModalProps> = ({
 
   const eventLocationToDisplay =
     (event.room || eventVenue?.name) ?? event.venueId;
-
   const goToEventLocation = () => {
     onHide();
 
     const { room = "" } = event;
     const roomUrlParam = getUrlParamFromString(room);
+    const [selectedRoom] =
+      eventVenue?.rooms?.filter(
+        (venueRoom) => getUrlParamFromString(venueRoom.title) === room
+      ) || [];
+
+    if (selectedRoom) {
+      openUrl(selectedRoom?.url);
+
+      return;
+    }
 
     if (!eventRoom) {
       openUrl(roomUrlParam);

--- a/src/components/organisms/EventModal/EventModal.tsx
+++ b/src/components/organisms/EventModal/EventModal.tsx
@@ -66,11 +66,12 @@ export const EventModal: React.FC<EventModalProps> = ({
 
     const { room = "" } = event;
     const roomUrlParam = getUrlParamFromString(room);
+    // @debt fix this hack on 24.07.2021
     const [selectedRoom] =
       eventVenue?.rooms?.filter(
         (venueRoom) => getUrlParamFromString(venueRoom.title) === room
       ) || [];
-
+// @debt fix this hack on 24.07.2021
     if (selectedRoom) {
       openUrl(selectedRoom?.url);
 


### PR DESCRIPTION
Closes https://github.com/sparkletown/internal-sparkle-issues/issues/946

* Fixed incorrect event redirect to non-working url
* If room has an external URL, then an event that points to that room will redirect directly to that URL