### PR TITLE
make the external room text look 'sparklier'

### DIFF
--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -30,11 +30,4 @@
     font-weight: $font-weight--300;
     font-size: $font-size--xl;
   }
-
-  &__link {
-    font-family: Rubik;
-    font-style: normal;
-    font-weight: $font-weight--500;
-    font-size: $font-size--xxl;
-  }
 }

--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -2,9 +2,11 @@
 
 .ExternalRoom {
   height: 100%;
+  width: 80%;
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 auto;
 
   &__message {
     padding: 60px;
@@ -29,5 +31,11 @@
     font-family: Rubik;
     font-weight: $font-weight--300;
     font-size: $font-size--xl;
+  }
+
+  &__link {
+    font-family: Rubik;
+    font-style: normal;
+    font-weight: $font-weight--500;
   }
 }

--- a/src/components/templates/ExternalRoom/ExternalRoom.tsx
+++ b/src/components/templates/ExternalRoom/ExternalRoom.tsx
@@ -27,15 +27,23 @@ export const ExternalRoom: React.FC<ExternalRoomProps> = ({ venue }) => {
       <div className="ExternalRoom__message">
         <SparkleLogo />
         <div className="ExternalRoom__content">
-          <h4 className="ExternalRoom__header">Thank you for visiting</h4>
-          <a
-            rel="noreferrer"
-            href={venue.zoomUrl}
-            target="_blank"
-            className="ExternalRoom__link"
-          >
-            {venue.zoomUrl}
-          </a>
+          <h4 className="ExternalRoom__header">
+            You will now be redirected to some incredible content! Please ensure
+            you{" "}
+            <a
+              rel="noreferrer"
+              href="https://support.google.com/chrome/answer/95472?hl=en&co=GENIE.Platform%3DDesktop"
+              target="_blank"
+            >
+              allow popups in your browser
+            </a>{" "}
+            and keep this tab open while you explore, so you can find your way
+            back easily. If you do not see a new tab open, please feel free to{" "}
+            <a rel="noreferrer" href={venue.zoomUrl} target="_blank">
+              click here
+            </a>
+            .
+          </h4>
         </div>
       </div>
     </div>

--- a/src/components/templates/ExternalRoom/ExternalRoom.tsx
+++ b/src/components/templates/ExternalRoom/ExternalRoom.tsx
@@ -38,9 +38,15 @@ export const ExternalRoom: React.FC<ExternalRoomProps> = ({ venue }) => {
               allow popups in your browser
             </a>{" "}
             and keep this tab open while you explore, so you can find your way
-            back easily. If you do not see a new tab open, please feel free to{" "}
-            <a rel="noreferrer" href={venue.zoomUrl} target="_blank">
-              click here
+            back easily. If you do not see a new tab open, please feel free to
+            click through to:{" "}
+            <a
+              rel="noreferrer"
+              href={venue.zoomUrl}
+              target="_blank"
+              className="ExternalRoom__link"
+            >
+              {venue.zoomUrl}
             </a>
             .
           </h4>


### PR DESCRIPTION
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/961

<img width="1440" alt="Screen Shot 2021-07-27 at 11 40 09 AM" src="https://user-images.githubusercontent.com/51083763/127141052-5bd17d5e-ff73-42b0-9ec6-6a15867c505a.png">
