### PR TITLE
(schedule v3) make schedule show up on left 

### DIFF
--- a/src/components/molecules/NavBar/NavBar.scss
+++ b/src/components/molecules/NavBar/NavBar.scss
@@ -218,7 +218,6 @@ $border-radius: 28px;
   z-index: z(navbar-schedule-backdrop);
   width: 100%;
   height: 100%;
-  background-color: rgba($black, 0.8);
   cursor: pointer;
   transition: opacity 600ms $transition-function,
     transform 600ms $transition-function;

--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.scss
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.scss
@@ -1,5 +1,6 @@
 @import "scss/constants.scss";
 
+$NavBarSchedule--width: 40%;
 $NavBarSchedule--padding: 20px;
 
 $weekday--padding: 8px 10px;
@@ -12,7 +13,7 @@ $weekday--margin-right: 10px;
   top: 0;
   left: 0;
   height: 100%;
-  width: 40%;
+  width: $NavBarSchedule--width;
 
   padding-top: $navbar-height;
   padding-left: $NavBarSchedule--padding;
@@ -23,6 +24,7 @@ $weekday--margin-right: 10px;
   pointer-events: none;
   opacity: 0;
   backdrop-filter: blur(5px);
+  transform: translateX(-$NavBarSchedule--width);
   box-shadow: 0 20px 50px 0 rgba(0, 0, 0, 0.33);
   transition: all 400ms $transition-function;
 

--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.scss
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.scss
@@ -1,6 +1,5 @@
 @import "scss/constants.scss";
 
-$NavBarSchedule--height: 620px;
 $NavBarSchedule--padding: 20px;
 
 $weekday--padding: 8px 10px;
@@ -12,18 +11,17 @@ $weekday--margin-right: 10px;
   z-index: z(navbar-schedule);
   top: 0;
   left: 0;
-  width: 100%;
-  height: $NavBarSchedule--height;
+  height: 100%;
+  width: 40%;
 
   padding-top: $navbar-height;
   padding-left: $NavBarSchedule--padding;
 
-  background-color: opaque-black(0.9);
+  background-color: opaque-black(0.8);
   overflow: auto;
 
   pointer-events: none;
   opacity: 0;
-  transform: translateY(-$NavBarSchedule--height);
   backdrop-filter: blur(5px);
   box-shadow: 0 20px 50px 0 rgba(0, 0, 0, 0.33);
   transition: all 400ms $transition-function;


### PR DESCRIPTION
also gets rid of dark background like in the designs

fixes https://github.com/sparkletown/internal-sparkle-issues/issues/986

before:
<img width="1440" alt="Screen Shot 2021-08-03 at 11 34 39 AM" src="https://user-images.githubusercontent.com/51083763/128001740-3fbca8bf-19e9-434d-a988-3a0257b45d40.png">

after:
<img width="1440" alt="Screen Shot 2021-08-03 at 11 34 24 AM" src="https://user-images.githubusercontent.com/51083763/128001774-38bedf7f-1c3c-4e8b-83e4-0e9dd976f51f.png">
