### PR TITLE
Remove SCSS warning by quoting ButtonNG variants' names

### DIFF
--- a/src/components/atoms/ButtonNG/ButtonNG.scss
+++ b/src/components/atoms/ButtonNG/ButtonNG.scss
@@ -9,10 +9,10 @@ $normal-button-width: 100%;
 // $normal-bg - the normal background color
 // $hover-bg  - the background color when button is :hover-ed
 $variants-enum: (
-  (primary, $white, $primary--live, $primary--live-hover),
-  (secondary, $white, opaque-white(0.2), opaque-white(0.25)),
-  (white, $primary--live, $white, $white),
-  (dark, $white, opaque-black(0.4), opaque-black(0.6))
+  ("primary", $white, $primary--live, $primary--live-hover),
+  ("secondary", $white, opaque-white(0.2), opaque-white(0.25)),
+  ("white", $primary--live, $white, $white),
+  ("dark", $white, opaque-black(0.4), opaque-black(0.6))
 );
 
 @function calc-size-by-factor($factor) {


### PR DESCRIPTION
Avoids the warning by using quoted strings like
```scss
"white"
```
instead of unqoted values like
```scss
white
```

```powershell
WARNING: You probably don't mean to use the color value white in interpolation here.
It may end up represented as white, which will likely produce invalid CSS.
Always quote color names when using them as strings or map keys (for example, "white").
If you really want to use the color value here, use '"" + $modifier'.

   â•·
98 â”‚     &--#{$modifier} {
   â”‚          ^^^^^^^^^
   â•µ
    src\components\atoms\ButtonNG\ButtonNG.scss 98:10  root stylesheet
```