### PR TITLE
BM - fix parentId for newly created venues

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -671,4 +671,4 @@ export const ALLOWED_EMPTY_TABLES_NUMBER = 4;
 export const DEFAULT_JAZZBAR_TABLES_NUMBER = 12;
 export const DEFAULT_CONVERSATION_SPACE_TABLES_NUMBER = 10;
 
-export const BM_PARENT_ID = "/playa";
+export const BM_PARENT_ID = "playa";


### PR DESCRIPTION
The parent id had `/` in it and this will cause problems for newly created venues because the parent id should be the id of the venue with a slash.

closes https://github.com/sparkletown/internal-sparkle-issues/issues/994