### PR TITLE
add unused imports plugin for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
       "jsx": true
     }
   },
-  "plugins": ["@typescript-eslint", "prefer-arrow", "simple-import-sort"],
+  "plugins": ["@typescript-eslint", "prefer-arrow", "simple-import-sort", "unused-imports"],
   "extends": [
     "react-app",
     "eslint:recommended",
@@ -115,7 +115,8 @@
           ["^.+\\.s?css$"]
         ]
       }
-    ]
+    ],
+    "unused-imports/no-unused-imports": "error",
   },
   "globals": {
     "React": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12170,6 +12170,21 @@
         }
       }
     },
+    "eslint-plugin-unused-imports": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.3.tgz",
+      "integrity": "sha512-KNAiVdwUz2s3bU5igt4ysgUGOWNEH5JLHOI1YtZK37krV+8ALy+3NNszIhD7c45JR9hbnFMDZ9P2vzZrJ72S8g==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "eslint-plugin-import": "^2.24.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-unused-imports": "^1.1.3",
     "firebase-admin": "^9.1.1",
     "firebase-tools": "^8.6.0",
     "gifwrap": "^0.9.2",


### PR DESCRIPTION
Adds `eslint-plugin-unused-imports` as dev dependency which will remove unused imports.