### PR TITLE
Revert "remove add events from right panel"

### DIFF
--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -196,7 +196,11 @@ const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
             <>Appearance Component</>
           </Route>
           <Route path={matchUrl}>
-            <VenueInfoComponent venue={currentVenue} roomIndex={roomIndex} />
+            <VenueInfoComponent
+              setShowCreateEventModal={setShowCreateEventModal}
+              venue={currentVenue}
+              roomIndex={roomIndex}
+            />
           </Route>
         </Switch>
       </div>
@@ -222,13 +226,13 @@ const VenueDetails: React.FC<VenueDetailsProps> = ({ venueId, roomIndex }) => {
 export type VenueInfoComponentProps = {
   venue: WithId<AnyVenue>;
   roomIndex?: number;
-  editedEvent?: WithId<VenueEvent>;
-  setEditedEvent?: Function;
+  setShowCreateEventModal: Function;
 };
 
 const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
   venue,
   roomIndex,
+  setShowCreateEventModal,
 }) => {
   const queryParams = useQuery();
   const manageUsers = !!queryParams.get("manageUsers");
@@ -236,6 +240,8 @@ const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
   const onManageUsersModalHide = useCallback(() => push({ search: "" }), [
     push,
   ]);
+  const history = useHistory();
+  const match = useRouteMatch();
   const placementDivRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -351,7 +357,16 @@ const VenueInfoComponent: React.FC<VenueInfoComponentProps> = ({
                 Edit Room
               </Link>
             )}
-
+            <button
+              className="btn btn-primary"
+              onClick={() => {
+                history.push(`${match.url}/events`);
+                setShowCreateEventModal(true);
+              }}
+              style={{ marginBottom: 10, width: "100%" }}
+            >
+              Create an Event
+            </button>
             <Link
               to={{ search: "manageUsers=true" }}
               className="btn btn-block btn-primary"

--- a/src/pages/Admin/EventsComponent.tsx
+++ b/src/pages/Admin/EventsComponent.tsx
@@ -109,6 +109,14 @@ const EventsComponent: React.FC<EventsComponentProps> = ({
           )}
         </div>
       </div>
+      <div className="page-container-adminpanel-actions">
+        <button
+          className="btn btn-primary"
+          onClick={() => setShowCreateEventModal(true)}
+        >
+          Create an Event
+        </button>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
This reverts some commits from https://github.com/sparkletown/sparkle/pull/1382
Just a minimum effort to bring the functionality back for BM. Discussion here: https://github.com/sparkletown/internal-sparkle-issues/issues/712#issuecomment-902315202