### PR TITLE
Sort venues by creation date in Admin V1

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -221,6 +221,8 @@ const createVenueData = (data, context) => {
     showUserStatus:
       typeof data.showUserStatus === "boolean" ? data.showUserStatus : true,
     radioStations: data.radioStations ? [data.radioStations] : [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
   };
 
   if (data.mapBackgroundImageUrl) {
@@ -298,6 +300,8 @@ const createVenueData_v2 = (data, context) => {
     ...(data.showGrid && { columns: data.columns }),
     template: data.template || VenueTemplate.partymap,
     rooms: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
   };
 
   if (HAS_REACTIONS_TEMPLATES.includes(data.template)) {
@@ -409,6 +413,8 @@ const createBaseUpdateVenueData = (data, doc) => {
   if (data.showNametags) {
     updated.showNametags = data.showNametags;
   }
+
+  updated.updatedAt = Date.now();
 
   return updated;
 };

--- a/src/pages/Admin/Admin.scss
+++ b/src/pages/Admin/Admin.scss
@@ -2,6 +2,12 @@
 
 $page-max-width: 1240px;
 
+$sorting-dropdown--width: 60%;
+$sorting-dropdown--left: calc(100% - #{$sorting-dropdown--width});
+$sorting-dropdown--top: 40px;
+
+$sorting-option--font-size: 0.8rem;
+
 .admin-dashboard {
   overflow: hidden;
   height: 100%;
@@ -66,9 +72,44 @@ $page-max-width: 1240px;
 
       background-image: $admin-gradient;
 
+      &__sorting-dropdown {
+        position: absolute;
+        top: $sorting-dropdown--top;
+        left: $sorting-dropdown--left;
+        width: $sorting-dropdown--width;
+        background: $room-card-background;
+        border-radius: $border-radius--lg;
+        padding: $spacing--lg $spacing--sm;
+      }
+
+      &__sorting-list {
+        list-style-type: none;
+        font-size: $sorting-option--font-size;
+        margin-bottom: 0;
+      }
+
+      &__sorting-option {
+        &:hover {
+          color: var(--primary-color);
+          cursor: pointer;
+        }
+
+        &--active {
+          color: $primary--lightest;
+        }
+      }
+
       .page-container-adminsidebar-title {
         background: rgba($black, 0.15);
         padding: 14px;
+
+        &__ellipsis {
+          float: right;
+          &:hover {
+            cursor: pointer;
+            color: $light-grey--lightest;
+          }
+        }
       }
       .page-container-adminsidebar-top {
         padding: 14px;

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -14,6 +14,9 @@ import {
   useLocation,
   useRouteMatch,
 } from "react-router-dom";
+import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 
@@ -41,6 +44,8 @@ import {
   canHaveEvents,
   canHavePlacement,
   canHaveSubvenues,
+  sortVenues,
+  VenueSortingOptions,
 } from "utils/venue";
 
 import { useIsAdminUser } from "hooks/roles";
@@ -83,18 +88,58 @@ const VenueList: React.FC<VenueListProps> = ({
     currentVenueId: selectedVenueId,
   });
 
+  const {
+    isShown: showSortingDropdown,
+    toggle: toggleSortingDropdown,
+  } = useShowHide();
+
+  const [currentSortingOption, setCurrentSortingOption] = useState(
+    VenueSortingOptions.az
+  );
+
+  const sortedVenues = useMemo(() => {
+    return sortVenues(ownedVenues, currentSortingOption);
+  }, [currentSortingOption, ownedVenues]);
+
+  const sortingOptions = useMemo(
+    () =>
+      Object.values(VenueSortingOptions).map((sortingOption) => (
+        <li
+          key={sortingOption}
+          className={classNames("page-container-adminsidebar__sorting-option", {
+            "page-container-adminsidebar__sorting-option--active":
+              currentSortingOption === sortingOption,
+          })}
+          onClick={() => {
+            setCurrentSortingOption(sortingOption);
+            toggleSortingDropdown();
+          }}
+        >
+          {sortingOption}
+        </li>
+      )),
+    [currentSortingOption, toggleSortingDropdown]
+  );
+
   if (isLoading) return <Loading />;
 
   return (
     <>
-      <div className="page-container-adminsidebar-title title">My Venues</div>
+      <div className="page-container-adminsidebar-title title">
+        My Venues
+        <FontAwesomeIcon
+          className="page-container-adminsidebar-title__ellipsis"
+          icon={faEllipsisV}
+          onClick={toggleSortingDropdown}
+        />
+      </div>
       <div className="page-container-adminsidebar-top">
         <Link to="/admin/venue/creation" className="btn btn-primary">
           Create a venue
         </Link>
       </div>
       <ul className="page-container-adminsidebar-venueslist">
-        {ownedVenues.map((venue) => (
+        {sortedVenues.map((venue) => (
           <li
             key={venue.id}
             className={`${selectedVenueId === venue.id ? "selected" : ""} ${
@@ -119,6 +164,14 @@ const VenueList: React.FC<VenueListProps> = ({
           </li>
         ))}
       </ul>
+
+      {showSortingDropdown && (
+        <div className="page-container-adminsidebar__sorting-dropdown">
+          <ul className="page-container-adminsidebar__sorting-list">
+            {sortingOptions}
+          </ul>
+        </div>
+      )}
     </>
   );
 };

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -98,7 +98,7 @@ const VenueList: React.FC<VenueListProps> = ({
   );
 
   const sortedVenues = useMemo(() => {
-    return sortVenues(ownedVenues, currentSortingOption);
+    return sortVenues(ownedVenues, currentSortingOption) ?? [];
   }, [currentSortingOption, ownedVenues]);
 
   const sortingOptions = useMemo(

--- a/src/pages/Admin/AdminVenuePreview.tsx
+++ b/src/pages/Admin/AdminVenuePreview.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties, useMemo } from "react";
+import { format } from "date-fns";
 
 import { IFRAME_ALLOW } from "settings";
 
@@ -132,6 +133,15 @@ export const AdminVenuePreview: React.FC<AdminVenuePreviewProps> = ({
             <RenderMarkdown
               text={venue.config?.landingPageConfig.description}
             />
+          </div>
+
+          <div>
+            <span className="title">Created At:</span>
+            {venue.createdAt && format(venue.createdAt, "yyyy-MM-dd HH:mm:ss")}
+          </div>
+          <div>
+            <span className="title">Updated At:</span>
+            {venue.updatedAt && format(venue.updatedAt, "yyyy-MM-dd HH:mm:ss")}
           </div>
         </div>
         <div className="content-group" style={{ display: "flex" }}>

--- a/src/types/venues.ts
+++ b/src/types/venues.ts
@@ -191,6 +191,8 @@ export interface BaseVenue {
   showBadges?: boolean;
   showNametags?: UsernameVisibility;
   showUserStatus?: boolean;
+  createdAt?: number;
+  updatedAt?: number;
 }
 
 export interface GenericVenue extends BaseVenue {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,3 @@
+export const assertUnreachable = (): never => {
+  throw new Error("Didn't expect to get here");
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,3 +1,3 @@
-export const assertUnreachable = (): never => {
+export const assertUnreachable = (_: never) => {
   throw new Error("Didn't expect to get here");
 };

--- a/src/utils/venue.ts
+++ b/src/utils/venue.ts
@@ -169,6 +169,6 @@ export const sortVenues = (
           (b.createdAt ?? 0) - (a.createdAt ?? 0) || a.id.localeCompare(b.id)
       );
     default:
-      assertUnreachable();
+      assertUnreachable(sortingOption);
   }
 };

--- a/src/utils/venue.ts
+++ b/src/utils/venue.ts
@@ -140,3 +140,34 @@ export const withVenue = <T extends object>(
   ...obj,
   venue,
 });
+
+export enum VenueSortingOptions {
+  az = "A - Z",
+  za = "Z - A",
+  newestFirst = "Newest First",
+  oldestFirst = "Oldest First",
+}
+
+export const sortVenues = (
+  venueList: WithId<AnyVenue>[],
+  sortingOption: VenueSortingOptions
+) => {
+  switch (sortingOption) {
+    case VenueSortingOptions.az:
+      return [...venueList].sort((a, b) => a.id.localeCompare(b.id));
+    case VenueSortingOptions.za:
+      return [...venueList].sort((a, b) => -1 * a.id.localeCompare(b.id));
+    case VenueSortingOptions.oldestFirst:
+      return [...venueList].sort(
+        (a, b) =>
+          (a.createdAt ?? 0) - (b.createdAt ?? 0) || a.id.localeCompare(b.id)
+      );
+    case VenueSortingOptions.newestFirst:
+      return [...venueList].sort(
+        (a, b) =>
+          (b.createdAt ?? 0) - (a.createdAt ?? 0) || a.id.localeCompare(b.id)
+      );
+    default:
+      return venueList;
+  }
+};

--- a/src/utils/venue.ts
+++ b/src/utils/venue.ts
@@ -16,6 +16,7 @@ import {
 
 import { FormValues } from "pages/Admin/Venue/DetailsForm";
 
+import { assertUnreachable } from "./error";
 import { WithId } from "./id";
 
 export const canHaveEvents = (venue: AnyVenue): boolean =>
@@ -168,6 +169,6 @@ export const sortVenues = (
           (b.createdAt ?? 0) - (a.createdAt ?? 0) || a.id.localeCompare(b.id)
       );
     default:
-      return venueList;
+      assertUnreachable();
   }
 };


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1057

This PR:
* extends BaseVenue type by adding `createdAt: number` and `updatedAt: number` fields (data is stored in UTC ms)
* saves the information of the timing when a venue was created and updated
* adds sorting options to admin v1 venue list by `A-Z`, `Z-A`, `newly created first`, `oldest first`
* shows venue creation and venue update time in admin v1