### PR TITLE
[env/burn-staging] fix bulk room save button

### DIFF
--- a/src/pages/Admin/MapPreview/MapPreview.tsx
+++ b/src/pages/Admin/MapPreview/MapPreview.tsx
@@ -93,7 +93,7 @@ const MapPreview: React.FC<MapPreviewProps> = ({
   );
 
   const [{ loading: isSaving }, saveRoomPositions] = useAsyncFn(async () => {
-    if (isSaving || !user) return;
+    if (!user) return;
 
     // Why is this using the ref and not mapRooms state?
     const updatedRooms = Object.values(roomRef.current);


### PR DESCRIPTION
Save button was working only once because of a false check inside the function and it's memoization.

This check already exists in the component and it's disabled prop.
`useAsyncFn` also handles this automatically.