### PR TITLE
[env/burn-staging] check for eventRoom in related venues

### DIFF
--- a/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
+++ b/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
@@ -40,12 +40,18 @@ export interface ScheduleItemNGProps {
 }
 
 export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({ event }) => {
-  const { currentVenue: eventVenue } = useRelatedVenues({
+  const { currentVenue: eventVenue, relatedVenues } = useRelatedVenues({
     currentVenueId: event.venueId,
   });
+
+  const relatedVenuesRooms = relatedVenues
+    ?.map((venue) => venue.rooms ?? [])
+    .flat()
+    .filter((room) => room !== undefined);
+
   const eventRoom = useMemo<Room | undefined>(
     () =>
-      eventVenue?.rooms?.find((room) => {
+      relatedVenuesRooms?.find((room) => {
         const { room: eventRoom = "" } = event;
         const noTrailSlashUrl = getUrlWithoutTrailingSlash(room.url);
 
@@ -55,7 +61,7 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({ event }) => {
 
         return roomUrlParam.endsWith(`${roomName}`) || selectedRoom;
       }),
-    [eventVenue, event]
+    [relatedVenuesRooms, event]
   );
   const { isShown: isEventExpanded, toggle: toggleEventExpand } = useShowHide();
   const { enterRoom } = useRoom({

--- a/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
+++ b/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
@@ -45,8 +45,7 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({ event }) => {
   });
 
   const relatedVenuesRooms = relatedVenues
-    ?.map((venue) => venue.rooms ?? [])
-    .flat()
+    ?.flatMap((venue) => venue.rooms ?? [])
     .filter((room) => room !== undefined);
 
   const eventRoom = useMemo<Room | undefined>(


### PR DESCRIPTION
eventRoom logic was ran only for the event's venue Id and it wasn't checking for related venues and their rooms. Now the logic will run through all of the related venue rooms and check if that room exists.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1086