### PR TITLE
An attempt to streamline SCSS style of the ChatMessageBox

### DIFF
--- a/src/components/molecules/ChatMessageBox/ChatMessageBox.scss
+++ b/src/components/molecules/ChatMessageBox/ChatMessageBox.scss
@@ -10,37 +10,29 @@ $emoji-button-diameter: $submit-button-diameter - $spacing--md;
   &__form {
     padding: $spacing--md;
     display: flex;
-    align-items: center;
-
-    .InputField {
-      flex-grow: 1;
-    }
   }
 
   &__inputs {
     display: flex;
     align-items: center;
-    justify-content: center;
-    align-content: center;
+    place-content: center;
     flex-grow: 1;
     margin-right: $spacing--lg;
+  }
 
-    .InputField {
-      flex-grow: 1;
+  &__input-container {
+    flex-grow: 1;
+  }
 
-      input {
-        // NOTE: this removes screen artefacts of the embedded <input> inside InputField being as wide as the parent
-        margin: 1px;
-      }
-
-      &__input {
-        padding-right: $submit-button-diameter;
-      }
-    }
+  &__input {
+    padding-right: $submit-button-diameter;
+    // NOTE: this removes screen artefacts of the embedded <input> inside InputField being as wide as the parent
+    margin: 1px;
   }
 
   &__emoji-button {
     margin-left: -1 * $submit-button-diameter;
+    padding: $spacing--xs;
     @include square-size(
       $emoji-button-diameter,
       $emoji-button-diameter,
@@ -58,18 +50,13 @@ $emoji-button-diameter: $submit-button-diameter - $spacing--md;
     padding-left: $spacing--lg;
   }
 
-  &__buttons {
-    display: flex;
-    flex-grow: 0;
-  }
-
   &__submit-button {
     min-width: $submit-button-diameter;
     min-height: $submit-button-diameter;
-  }
 
-  &__submit-button-icon {
-    color: $white;
+    &-icon {
+      color: $white;
+    }
   }
 
   &__emoji-picker {

--- a/src/components/molecules/ChatMessageBox/ChatMessageBox.tsx
+++ b/src/components/molecules/ChatMessageBox/ChatMessageBox.tsx
@@ -114,6 +114,7 @@ export const ChatMessageBox: React.FC<ChatMessageBoxProps> = ({
       >
         <div className="Chatbox__inputs">
           <InputField
+            containerClassName="Chatbox__input-container"
             inputClassName="Chatbox__input"
             ref={register({ required: true })}
             name="message"


### PR DESCRIPTION
There was an inconsistency between locally run code and deployed on `burn-staging` environment probably due to merge artefacts in `ChatMessageBox.scss`. This PR tries to resolve that, with streamlined SCSS that will not be ambiguously interpreted
![sparkle-chat-smiley-01](https://user-images.githubusercontent.com/79229621/130728628-36efd768-7333-46f0-9fdb-0f89c47b464a.png)
