### PR TITLE
Add .catch() to permission check in DeviceVideo

### DIFF
--- a/src/components/atoms/DeviceVideo/DeviceVideo.tsx
+++ b/src/components/atoms/DeviceVideo/DeviceVideo.tsx
@@ -49,7 +49,10 @@ export const DeviceVideo: React.FC<DeviceVideoProps> = ({
         permissionStatus.onchange = function permissionStatusOnChange() {
           setCameraPermission(this.state);
         };
-      });
+      })
+      .catch((e) =>
+        console.error(DeviceVideo.name, "Problem detecting permission", e)
+      );
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes bugs / inconsistencies on
- https://github.com/sparkletown/internal-sparkle-issues/issues/1015

Like:
- Minor issue reporting an error in Firefox on deployed code, but an annoyance when developing locally

Prior PR setting up the groundwork:
- https://github.com/sparkletown/sparkle/pull/2018

**Before**:

![sparkle-firefox-camera-error-01](https://user-images.githubusercontent.com/79229621/130748882-edef64ea-ff8d-42a5-b406-8cee8812599d.png)

**After**:

![sparkle-firefox-camera-error-02](https://user-images.githubusercontent.com/79229621/130748897-b4fb740d-f44e-4a7d-9a3a-43efcd1e2a2e.png)
