### PR TITLE
BM: show parentId, hide user statuses

### DIFF
--- a/src/pages/Admin/Venue/DetailsForm.tsx
+++ b/src/pages/Admin/Venue/DetailsForm.tsx
@@ -817,7 +817,9 @@ const DetailsFormLeft: React.FC<DetailsFormLeftProps> = ({
 
         {renderBannerPhotoInput()}
         {renderLogoInput()}
-        {renderHelper("1:1 ratio recommended")}
+        {renderHelper(
+          "This is how you will appear on the map. Please upload a square image."
+        )}
 
         {templateID &&
           BANNER_MESSAGE_TEMPLATES.includes(templateID) &&


### PR DESCRIPTION
Admin adjustments:
* show parentId field with the default value === "playa"
* hide user statuses

closes https://github.com/sparkletown/internal-sparkle-issues/issues/1073
fixes https://github.com/sparkletown/internal-sparkle-issues/issues/1062