### PR TITLE
[env/burn-staging] fix incorrect event room comparison

### DIFF
--- a/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
+++ b/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
@@ -59,7 +59,7 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({ event }) => {
 
         const [roomName] = getLastUrlParam(noTrailSlashUrl);
         const roomUrlParam = getUrlParamFromString(eventRoom);
-        const selectedRoom = getUrlParamFromString(room.title) === eventRoom;
+        const selectedRoom = getUrlParamFromString(room.title) === roomUrlParam;
 
         return roomUrlParam.endsWith(`${roomName}`) || selectedRoom;
       }),


### PR DESCRIPTION
The check was incorrect and it was comparing lower case value with another one that wasn't lower case. One silly check a couple of hours wasted.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1114