### PR TITLE
[env/burn-staging] Refactor ArtPiece layout to follow screen size

### DIFF
--- a/src/components/templates/ArtPiece/ArtPiece.scss
+++ b/src/components/templates/ArtPiece/ArtPiece.scss
@@ -1,57 +1,131 @@
-.full-page-container.art-piece-container {
-  padding: 0;
+@import "scss/constants";
 
-  .content {
-    display: flex;
-    padding-left: 70px;
-    flex-grow: 1;
-    flex-direction: column;
-    overflow: auto;
+$info-bar-width: 96px;
+$chat-bar-width: 96px;
+$chat-wrapper-height: 260px;
+
+.ArtPiece {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+
+  &__title-sidebar {
+    font-size: $font-size--xl;
+    font-weight: $font-weight--700;
   }
 
-  .aspect-container {
+  &__short-description-sidebar {
+    font-size: $font-size--lg;
+    font-weight: $font-weight--700;
+  }
+
+  &__rendered-markdown {
+    font-size: $font-size--md;
+  }
+
+  &__sparkle-fairies {
+    position: fixed;
+    top: 250px;
+    left: 0;
+  }
+
+  &__content {
+    height: 100%;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 1;
+    margin: 0;
+    padding: 0 $chat-bar-width 0 $info-bar-width;
     overflow: hidden;
-    position: relative;
+    align-content: center;
+    justify-content: space-between;
+    align-items: center;
+  }
 
-    // Default aspect ratio 2.39:1
-    padding-top: (1/2.39) * 100%;
+  &__aspect-container {
+    display: grid;
+    place-items: center;
+    height: 100%;
+    padding: $spacing--xl;
+    overflow: auto;
+    @include gray-scrollbar();
+  }
 
-    &.aspect-16-9 {
-      padding-top: (9/16) * 100%;
+  &__youtube-video {
+    height: 100%;
+    width: 100%;
+  }
+
+  &__video-chat-wrapper {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: $spacing--xs;
+    margin: 0;
+    padding: 0;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    width: 100%;
+    height: $chat-wrapper-height;
+    @include gray-scrollbar();
+
+    .participant-container {
+      width: unset;
+      flex-grow: 0;
+      flex-shrink: 0;
+
+      .participant {
+        max-width: 200px;
+        max-height: 200px;
+        height: 100%;
+        padding: 0;
+        margin: 0;
+
+        display: flex;
+        border-radius: $border-radius--xl;
+
+        .mirrored {
+          transform: scale(-1, 1);
+        }
+
+        .profile-icon {
+          cursor: pointer;
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          border-radius: 188%;
+          z-index: z(global-profile-icon);
+        }
+
+        .mute-container,
+        .mute-other-container {
+          cursor: pointer;
+          position: absolute;
+          text-align: center;
+          display: flex;
+          justify-content: center;
+        }
+
+        .mute-container {
+          bottom: $spacing--md;
+          left: 0;
+          right: 0;
+        }
+
+        .mute-other-container {
+          top: $spacing--md;
+          right: $spacing--md;
+        }
+
+        video {
+          border-radius: $border-radius--xl;
+          width: 100%;
+          display: block;
+          margin: 0 auto;
+        }
+      }
     }
   }
-
-  .youtube-video {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .video-chat-wrapper {
-    display: grid;
-    margin: 1rem 0;
-    grid-template-columns: repeat(15, 1fr);
-    grid-gap: 1rem;
-  }
-  .title-sidebar {
-    font-size: 22px;
-    font-weight: bold;
-  }
-  .short-description-sidebar {
-    font-size: 15px;
-    font-weight: bold;
-  }
-}
-.sparkle-fairies {
-  position: fixed;
-  top: 250px;
-  left: 0px;
-}
-.donate-popup {
-  position: fixed;
-  top: 370px;
-  left: 0px;
 }

--- a/src/components/templates/ArtPiece/ArtPiece.tsx
+++ b/src/components/templates/ArtPiece/ArtPiece.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 
 import { IFRAME_ALLOW } from "settings";
 
@@ -25,55 +26,55 @@ export interface ArtPieceProps {
 export const ArtPiece: React.FC<ArtPieceProps> = ({ venue }) => {
   if (!venue) return <Loading label="Loading..." />;
 
-  const iframeUrl = ConvertToEmbeddableUrl(venue.iframeUrl);
+  const { name, host, config, showRangers, iframeUrl, videoAspect } = venue;
+  const landingPageConfig = config?.landingPageConfig;
+  const embeddableUrl = ConvertToEmbeddableUrl(iframeUrl);
 
-  const aspectContainerClasses = `aspect-container ${
-    venue.videoAspect === VideoAspectRatio.SixteenNine ? "aspect-16-9" : ""
-  }`;
+  const aspectContainerClasses = classNames({
+    "ArtPiece__aspect-container": true,
+    "mod--sixteen-nine": videoAspect === VideoAspectRatio.SixteenNine,
+    "mod--anamorphic": videoAspect !== VideoAspectRatio.SixteenNine,
+  });
 
   return (
-    <>
-      <div className="full-page-container art-piece-container">
-        <InformationLeftColumn iconNameOrPath={venue?.host?.icon}>
-          <InformationCard title="About the venue">
-            <p className="title-sidebar">{venue.name}</p>
-            <p className="short-description-sidebar" style={{ fontSize: 18 }}>
-              {venue.config?.landingPageConfig.subtitle}
-            </p>
-            <div style={{ fontSize: 13 }}>
-              <RenderMarkdown
-                text={venue.config?.landingPageConfig.description}
-              />
-            </div>
-          </InformationCard>
-        </InformationLeftColumn>
-        <div className="content">
-          <div className={aspectContainerClasses}>
-            <iframe
-              className="youtube-video"
-              title="art-piece-video"
-              src={iframeUrl}
-              frameBorder="0"
-              allow={IFRAME_ALLOW}
-              allowFullScreen
-            />
+    <div className="ArtPiece">
+      <InformationLeftColumn iconNameOrPath={host?.icon}>
+        <InformationCard title="About the venue">
+          <p className="ArtPiece__title-sidebar">{name}</p>
+          <p className="ArtPiece__short-description-sidebar">
+            {landingPageConfig?.subtitle}
+          </p>
+          <div className="ArtPiece__rendered-markdown">
+            <RenderMarkdown text={landingPageConfig?.description} />
           </div>
-          <div className="video-chat-wrapper">
-            <Room
-              venueName={venue.name}
-              roomName={venue.name}
-              setUserList={() => null}
-              hasChairs={false}
-              defaultMute={true}
-            />
-          </div>
+        </InformationCard>
+      </InformationLeftColumn>
+      <div className="ArtPiece__content">
+        <div className={aspectContainerClasses}>
+          <iframe
+            className="ArtPiece__youtube-video"
+            title="art-piece-video"
+            src={embeddableUrl}
+            frameBorder="0"
+            allow={IFRAME_ALLOW}
+            allowFullScreen
+          />
+        </div>
+        <div className="ArtPiece__video-chat-wrapper">
+          <Room
+            venueName={name}
+            roomName={name}
+            setUserList={() => null}
+            hasChairs={false}
+            defaultMute={true}
+          />
         </div>
       </div>
-      {venue?.showRangers && (
-        <div className="sparkle-fairies">
+      {showRangers && (
+        <div className="ArtPiece__sparkle-fairies">
           <SparkleFairiesPopUp />
         </div>
       )}
-    </>
+    </div>
   );
 };

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -251,28 +251,6 @@ $z-layers: (
   @return 0 10px 30px 0 rgba($black, $transparency);
 }
 
-@mixin scrollbar {
-  &::-webkit-scrollbar-track {
-    border-radius: 3px;
-    background-color: rgba(0, 0, 0, 0);
-  }
-
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    background-color: rgba($black, 0);
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba($white, 0.3);
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: rgba($white, 0.5);
-  }
-}
-
 // @debt replace this with `line-clamp` property once it's supported in autoprefixer; see https://github.com/postcss/autoprefixer/issues/1322
 @mixin line-clamp($line-count: 1) {
   display: -webkit-box;
@@ -303,5 +281,49 @@ $z-layers: (
   &:hover {
     color: $hover-color;
     text-decoration: underline $hover-color;
+  }
+}
+
+// @debt use only one scrollbar mixin (if two different styles are needed, add variables)
+@mixin scrollbar {
+  &::-webkit-scrollbar-track {
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0);
+  }
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    background-color: rgba($black, 0);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba($white, 0.3);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: rgba($white, 0.5);
+  }
+}
+
+@mixin gray-scrollbar {
+  &::-webkit-scrollbar-track {
+    border-radius: $border-radius--xs;
+    background-color: $black;
+  }
+
+  &::-webkit-scrollbar {
+    @include square-size($spacing--sm);
+    background-color: opaque-black(0);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: $border-radius--xs;
+    background-color: opaque-white(0.3);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: opaque-white(0.5);
   }
 }

--- a/src/scss/modifiers.scss
+++ b/src/scss/modifiers.scss
@@ -24,6 +24,14 @@ $spacing-map: (
     visibility: hidden;
   }
 
+  &--anamorphic {
+    aspect-ratio: 2.39;
+  }
+
+  &--sixteen-nine {
+    aspect-ratio: 16 / 9;
+  }
+
   &--text {
     @each $where in $text-align-enum {
       &-#{$where} {


### PR DESCRIPTION
Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1065

Updated `ArtPiece` structure and mostly SCSS to take the screen height into account and display appropriate scrollbars when needed i.e. a vertical one for the art part and a horizontal one for the video chat part.