### PR TITLE
Measure `processQueuedChanges` execution time

### DIFF
--- a/src/store/api/worldUsers.ts
+++ b/src/store/api/worldUsers.ts
@@ -74,7 +74,7 @@ export const worldUsersApi = createApi({
         const processQueuedChanges = () => {
           if (queuedChanges.length === 0) return;
           console.log(
-            "[worldUsersApi::processQueuedChanges] queuedChanges.length = ",
+            "worldUsersApi::processQueuedChanges queuedChanges.length = ",
             queuedChanges.length
           );
 


### PR DESCRIPTION
`processQueuedChanges` can hog the CPU when there are many users online. This PR uses the `performance` object to time the execution of the method. It will allow us to monitor its performance in production.

`window.performance` is integrated into Chrome DevTools and monitoring tools. [Here is an example from DataDog](https://www.datadoghq.com/blog/modern-frontend-monitoring/#listen-to-route-changes).

This is how the measurement looks in DevTools:
![image](https://user-images.githubusercontent.com/88714064/131140306-fc5e4a9d-851d-4c86-a9b2-41f9cbd46cff.png)

If we end up adopting this method we should build a simple abstraction layer around the measurement code.

See https://web.dev/custom-metrics/#user-timing-api for more information about timing methods using the built-in `performance` object.