### PR TITLE
Serve resized user avatars in Chat panel 

### DIFF
--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -16,7 +16,7 @@ import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
 import {
   getFirebaseStorageResizedImage,
   ImageResizeOptions,
-} from "../../../utils/image";
+} from "utils/image";
 
 import "./UserAvatar.scss";
 

--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -19,7 +19,7 @@ import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
 
 import "./UserAvatar.scss";
 
-export type UserAvatarSize = "small" | "medium" | "large" | "full";
+export type UserAvatarSize = "small" | "medium" | "large" | "xlarge" | "full";
 
 export interface UserAvatarProps extends ContainerClassName {
   user?: WithId<User>;
@@ -35,6 +35,7 @@ const AVATAR_SIZE_MAP: { [key in UserAvatarSize]: number | null } = {
   small: 25,
   medium: 40,
   large: 54,
+  xlarge: 100,
   full: null,
 };
 

--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -8,15 +8,14 @@ import { User, UsernameVisibility } from "types/User";
 import { ContainerClassName } from "types/utility";
 
 import { WithId } from "utils/id";
-
-import { useIsOnline } from "hooks/useIsOnline";
-import { useVenueId } from "hooks/useVenueId";
-import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
-
 import {
   getFirebaseStorageResizedImage,
   ImageResizeOptions,
 } from "utils/image";
+
+import { useIsOnline } from "hooks/useIsOnline";
+import { useVenueId } from "hooks/useVenueId";
+import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
 
 import "./UserAvatar.scss";
 

--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -13,7 +13,10 @@ import { useIsOnline } from "hooks/useIsOnline";
 import { useVenueId } from "hooks/useVenueId";
 import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
 
-import { getFirebaseStorageResizedImage, ImageResizeOptions } from "../../../utils/image";
+import {
+  getFirebaseStorageResizedImage,
+  ImageResizeOptions,
+} from "../../../utils/image";
 
 import "./UserAvatar.scss";
 
@@ -30,11 +33,11 @@ export interface UserAvatarProps extends ContainerClassName {
 
 // @debt The avatar sizes are a duplicate of $avatar-sizes-map inside UserAvatar.scss
 const AVATAR_SIZE_MAP: { [key in UserAvatarSize]: number | null } = {
-  "small": 25,
-  "medium": 40,
-  "large": 54,
-  "full": null
-}
+  small: 25,
+  medium: 40,
+  large: 54,
+  full: null,
+};
 
 // @debt the UserProfilePicture component serves a very similar purpose to this, we should unify them as much as possible
 export const _UserAvatar: React.FC<UserAvatarProps> = ({
@@ -68,7 +71,7 @@ export const _UserAvatar: React.FC<UserAvatarProps> = ({
     }
 
     return getFirebaseStorageResizedImage(url, resizeOptions);
-  }, [user, size])
+  }, [user, size]);
 
   const userDisplayName: string = user?.anonMode
     ? DEFAULT_PARTY_NAME

--- a/src/components/molecules/NavSearchBar/NavSearchResult.tsx
+++ b/src/components/molecules/NavSearchBar/NavSearchResult.tsx
@@ -37,6 +37,7 @@ export const NavSearchResult: React.FC<NavSearchResultProps> = ({
           user={user}
           showStatus
           containerClassName="NavSearchResult__avatar"
+          size="small"
         />
       ) : (
         <div className="NavSearchResult__image" style={imageStyles} />

--- a/src/components/molecules/UserProfilePicture/UserProfilePicture.tsx
+++ b/src/components/molecules/UserProfilePicture/UserProfilePicture.tsx
@@ -12,6 +12,8 @@ import { UserReactions } from "components/molecules/UserReactions";
 
 import { UserAvatar } from "components/atoms/UserAvatar";
 
+import { UserAvatarSize } from "../../atoms/UserAvatar/UserAvatar";
+
 import "./UserProfilePicture.scss";
 
 // @debt This miniAvatars/'random avatar url' feature is currently disabled, it might be legacy code to be deleted?
@@ -55,6 +57,7 @@ export interface UserProfilePictureProp extends ContainerClassName {
    * @deprecated Note: This feature is currently disabled.
    */
   miniAvatars?: boolean;
+  size?: UserAvatarSize;
 }
 
 export const UserProfilePicture: React.FC<UserProfilePictureProp> = ({
@@ -64,6 +67,7 @@ export const UserProfilePicture: React.FC<UserProfilePictureProp> = ({
   reactionPosition = "right",
   showNametags,
   showStatus = false,
+  size,
   // @debt This feature is currently disabled and might be part of legacy code to be removed, see comment on generateRandomAvatarUrl above
   // miniAvatars = false,
 }) => {
@@ -117,6 +121,7 @@ export const UserProfilePicture: React.FC<UserProfilePictureProp> = ({
         containerClassName="UserProfilePicture__avatar"
         showNametag={showNametags}
         showStatus={showStatus}
+        size={size}
       />
 
       {userId && (

--- a/src/components/organisms/ChatSidebar/components/OnlineUser/OnlineUser.tsx
+++ b/src/components/organisms/ChatSidebar/components/OnlineUser/OnlineUser.tsx
@@ -16,7 +16,7 @@ export interface OnlineUserProps {
 export const OnlineUser: React.FC<OnlineUserProps> = ({ user, onClick }) => {
   return (
     <div className="online-user" onClick={onClick}>
-      <UserAvatar user={user} showStatus />
+      <UserAvatar user={user} showStatus size="small" />
       <div className="online-user__name">{user.partyName}</div>
     </div>
   );

--- a/src/components/organisms/ChatSidebar/components/PrivateChatPreview/PrivateChatPreview.tsx
+++ b/src/components/organisms/ChatSidebar/components/PrivateChatPreview/PrivateChatPreview.tsx
@@ -27,7 +27,7 @@ export const PrivateChatPreview: React.FC<PrivateChatPreviewProps> = ({
 
   return (
     <div className={containerClasses} onClick={onClick}>
-      <UserAvatar user={counterPartyUser} showStatus />
+      <UserAvatar user={counterPartyUser} showStatus size="small" />
       <div className="chat-preview__content">
         <div className="chat-preview__username">
           {counterPartyUser.partyName}

--- a/src/components/organisms/ChatSidebar/components/RecipientChat/RecipientChat.tsx
+++ b/src/components/organisms/ChatSidebar/components/RecipientChat/RecipientChat.tsx
@@ -48,7 +48,7 @@ export const RecipientChat: React.FC<RecipientChatProps> = ({
           className="recipient-chat__back-icon"
           size="sm"
         />
-        <UserAvatar user={recipient} showStatus />
+        <UserAvatar user={recipient} showStatus size="small" />
         <div className="recipient-chat__nickname">{recipient.partyName}</div>
       </div>
       <div className="recipient-chat__chatbox">

--- a/src/components/templates/Audience/Audience.tsx
+++ b/src/components/templates/Audience/Audience.tsx
@@ -426,6 +426,7 @@ export const Audience: React.FC<AudienceProps> = ({ venue }) => {
                                 miniAvatars={venue.miniAvatars}
                                 isAudioEffectDisabled={isUserAudioMuted}
                                 showNametags={venue.showNametags}
+                                size="xlarge"
                               />
                             )}
                             {seat && !seatedPartygoer && <>+</>}

--- a/src/hooks/useUploadProfilePictureHandler.ts
+++ b/src/hooks/useUploadProfilePictureHandler.ts
@@ -1,6 +1,7 @@
 import { ChangeEvent, useCallback } from "react";
 import { useFirebase } from "react-redux-firebase";
 import firebase from "firebase/app";
+import { v4 as uuid } from "uuid";
 
 import {
   ACCEPTED_IMAGE_TYPES,
@@ -35,10 +36,9 @@ export const useUploadProfilePictureHandler = (
         file = new File([resizedImage], fileName);
       }
       const storageRef = firebase.storage().ref();
-      // TODO: add rule to forbid other users to edit a user's image
       if (user?.uid) {
         const profilePictureRef = storageRef.child(
-          `/users/${user.uid}/${file.name}`
+          `/users/${user.uid}/${uuid()}_${file.name}`
         );
         const uploadedProfilePicture = await profilePictureRef.put(file);
         return await uploadedProfilePicture.ref.getDownloadURL();

--- a/src/hooks/useUploadProfilePictureHandler.ts
+++ b/src/hooks/useUploadProfilePictureHandler.ts
@@ -37,6 +37,8 @@ export const useUploadProfilePictureHandler = (
       }
       const storageRef = firebase.storage().ref();
       if (user?.uid) {
+        // We append a uuid to the filename to ensure every file created has a unique name.
+        // This helps avoiding cache invalidation.
         const profilePictureRef = storageRef.child(
           `/users/${user.uid}/${uuid()}_${file.name}`
         );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -751,5 +751,7 @@ export const EVENTS_PREVIEW_LIST_LENGTH = 5;
 
 // Set these to have images uploaded to Firebase Storage served off of Imgix
 // @debt load this from an env variable. This is good enough for Burning Man but we want to have env-specific conf
-export const FIREBASE_STORAGE_IMAGES_ORIGIN = "https://firebasestorage.googleapis.com/v0/b/sparkle-burn.appspot.com/o/";
-export const FIREBASE_STORAGE_IMAGES_IMGIX_URL = "https://sparkle-burn-users.imgix.net/";
+export const FIREBASE_STORAGE_IMAGES_ORIGIN =
+  "https://firebasestorage.googleapis.com/v0/b/sparkle-burn.appspot.com/o/";
+export const FIREBASE_STORAGE_IMAGES_IMGIX_URL =
+  "https://sparkle-burn-users.imgix.net/";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -748,3 +748,8 @@ export const PROFILE_MODAL_EDIT_MODE_TURNING_OFF_DELAY = 130;
 export const EVENT_STARTING_SOON_TIMEFRAME = 120; // in minutes
 
 export const EVENTS_PREVIEW_LIST_LENGTH = 5;
+
+// Set these to have images uploaded to Firebase Storage served off of Imgix
+// @debt load this from an env variable. This is good enough for Burning Man but we want to have env-specific conf
+export const FIREBASE_STORAGE_IMAGES_ORIGIN = "https://firebasestorage.googleapis.com/v0/b/sparkle-burn.appspot.com/o/";
+export const FIREBASE_STORAGE_IMAGES_IMGIX_URL = "https://sparkle-burn-users.imgix.net/";

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,6 +1,9 @@
 import Resizer from "react-image-file-resizer";
 
-import { FIREBASE_STORAGE_IMAGES_IMGIX_URL, FIREBASE_STORAGE_IMAGES_ORIGIN } from "settings";
+import {
+  FIREBASE_STORAGE_IMAGES_IMGIX_URL,
+  FIREBASE_STORAGE_IMAGES_ORIGIN,
+} from "settings";
 
 // See https://docs.imgix.com/apis/rendering/size
 export interface ImageResizeOptions {
@@ -29,13 +32,20 @@ export const resizeFile = (file: File): Promise<Blob> => {
 /**
  * Returns an optimized, resized image url using a Imgix
  */
-export const getResizedImage = (originBasePath: string, imgixBasePath: string, url: string, options: ImageResizeOptions): string => {
+export const getResizedImage = (
+  originBasePath: string,
+  imgixBasePath: string,
+  url: string,
+  options: ImageResizeOptions
+): string => {
   if (originBasePath && imgixBasePath && url.startsWith(originBasePath)) {
     const newUrl = url.replace(originBasePath, imgixBasePath);
 
     const urlObject = new URL(newUrl);
-    if (options.width) urlObject.searchParams.set("w", options.width.toString());
-    if (options.height) urlObject.searchParams.set("h", options.height.toString());
+    if (options.width)
+      urlObject.searchParams.set("w", options.width.toString());
+    if (options.height)
+      urlObject.searchParams.set("h", options.height.toString());
     if (options.fit) urlObject.searchParams.set("fit", options.fit);
     return urlObject.toString();
   }
@@ -46,5 +56,13 @@ export const getResizedImage = (originBasePath: string, imgixBasePath: string, u
 /**
  * Like getResizedImage, but specific to any upload to the default Firebase storage bucket
  */
-export const getFirebaseStorageResizedImage = (url: string, options: ImageResizeOptions): string =>
-  getResizedImage(FIREBASE_STORAGE_IMAGES_ORIGIN, FIREBASE_STORAGE_IMAGES_IMGIX_URL, url, options);
+export const getFirebaseStorageResizedImage = (
+  url: string,
+  options: ImageResizeOptions
+): string =>
+  getResizedImage(
+    FIREBASE_STORAGE_IMAGES_ORIGIN,
+    FIREBASE_STORAGE_IMAGES_IMGIX_URL,
+    url,
+    options
+  );

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -30,7 +30,8 @@ export const resizeFile = (file: File): Promise<Blob> => {
 };
 
 /**
- * Returns an optimized, resized image url using a Imgix
+ * Generates a resized image URL.
+ * This function does not guarantee a resized image. In some cases the original URL may be returned.
  */
 export const getResizedImage = (
   originBasePath: string,

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,5 +1,14 @@
 import Resizer from "react-image-file-resizer";
 
+import { FIREBASE_STORAGE_IMAGES_IMGIX_URL, FIREBASE_STORAGE_IMAGES_ORIGIN } from "settings";
+
+// See https://docs.imgix.com/apis/rendering/size
+export interface ImageResizeOptions {
+  width?: number;
+  height?: number;
+  fit?: "crop";
+}
+
 export const resizeFile = (file: File): Promise<Blob> => {
   return new Promise((resolve) => {
     Resizer.imageFileResizer(
@@ -16,3 +25,26 @@ export const resizeFile = (file: File): Promise<Blob> => {
     );
   });
 };
+
+/**
+ * Returns an optimized, resized image url using a Imgix
+ */
+export const getResizedImage = (originBasePath: string, imgixBasePath: string, url: string, options: ImageResizeOptions): string => {
+  if (originBasePath && imgixBasePath && url.startsWith(originBasePath)) {
+    const newUrl = url.replace(originBasePath, imgixBasePath);
+
+    const urlObject = new URL(newUrl);
+    if (options.width) urlObject.searchParams.set("w", options.width.toString());
+    if (options.height) urlObject.searchParams.set("h", options.height.toString());
+    if (options.fit) urlObject.searchParams.set("fit", options.fit);
+    return urlObject.toString();
+  }
+
+  return url;
+};
+
+/**
+ * Like getResizedImage, but specific to any upload to the default Firebase storage bucket
+ */
+export const getFirebaseStorageResizedImage = (url: string, options: ImageResizeOptions): string =>
+  getResizedImage(FIREBASE_STORAGE_IMAGES_ORIGIN, FIREBASE_STORAGE_IMAGES_IMGIX_URL, url, options);

--- a/storage.rules
+++ b/storage.rules
@@ -2,11 +2,13 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /assets/{allPaths=**} {
-        allow read
+        allow read;
     }
     match /users/{uid}/{allPaths=**} {
-        allow read
-        allow write, update: if request.auth.uid == uid
+        allow read;
+        // Allow users to create new files under their unique path.
+        // Don't allow updating files so we can cache files long-term
+        allow write: if request.auth.uid == uid && resource == null;
     }
   }
 }


### PR DESCRIPTION
We now use Imgix to resize user avatars in the chat panel.
This reduces network payload for avatars by ~4-5x, improves CPU performance and UX.

This is the first iteration to serve optimized images. We'll need to follow up by serving optimized images in the AnimateMap and other places.

This introduces two debts points:
1. A duplication of avatar image sizes between SCSS and the TSX files - ideally we should have one source of truth
2. Hardocded configuration value inside settings.ts - this should come from the env

If someone has a quick win for the above, great. If not, let me know and let's follow-up separately
