### PR TITLE
Serve resized venue images in the schedule and emergency view

### DIFF
--- a/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
+++ b/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
@@ -36,6 +36,8 @@ import { RenderMarkdown } from "components/organisms/RenderMarkdown";
 
 import { ButtonNG } from "components/atoms/ButtonNG";
 
+import { getFirebaseStorageResizedImage } from "../../../utils/image";
+
 import "./ScheduleItemNG.scss";
 
 export interface ScheduleItemNGProps {
@@ -99,6 +101,16 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({
     }
   }, [enterRoom, event, eventRoom, roomUrlParam]);
 
+  const eventImage = useMemo(
+    () =>
+      getFirebaseStorageResizedImage(eventRoom?.image_url ?? event.venueIcon, {
+        fit: "crop",
+        width: 40,
+        height: 40,
+      }),
+    [eventRoom, event]
+  );
+
   const infoContaier = classNames("ScheduleItemNG__info", {
     "ScheduleItemNG__info--active": isCurrentEventLive,
   });
@@ -150,7 +162,7 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({
       {isShowFullInfo && (
         <img
           className="ScheduleItemNG__icon"
-          src={eventRoom?.image_url ?? event.venueIcon}
+          src={eventImage}
           alt="event location"
         />
       )}

--- a/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
+++ b/src/components/molecules/ScheduleItemNG/ScheduleItemNG.tsx
@@ -17,6 +17,7 @@ import { Room } from "types/rooms";
 import { ScheduledVenueEvent } from "types/venues";
 
 import { eventEndTime, eventStartTime, isEventLive } from "utils/event";
+import { getFirebaseStorageResizedImage } from "utils/image";
 import { formatDateRelativeToNow, formatTimeLocalised } from "utils/time";
 import {
   enterVenue,
@@ -35,8 +36,6 @@ import { useUser } from "hooks/useUser";
 import { RenderMarkdown } from "components/organisms/RenderMarkdown";
 
 import { ButtonNG } from "components/atoms/ButtonNG";
-
-import { getFirebaseStorageResizedImage } from "../../../utils/image";
 
 import "./ScheduleItemNG.scss";
 
@@ -101,14 +100,13 @@ export const ScheduleItemNG: React.FC<ScheduleItemNGProps> = ({
     }
   }, [enterRoom, event, eventRoom, roomUrlParam]);
 
-  const eventImage = useMemo(
-    () =>
-      getFirebaseStorageResizedImage(eventRoom?.image_url ?? event.venueIcon, {
-        fit: "crop",
-        width: 40,
-        height: 40,
-      }),
-    [eventRoom, event]
+  const eventImage = getFirebaseStorageResizedImage(
+    eventRoom?.image_url ?? event.venueIcon,
+    {
+      fit: "crop",
+      width: 40,
+      height: 40,
+    }
   );
 
   const infoContaier = classNames("ScheduleItemNG__info", {

--- a/src/pages/EmergencyViewPage/EmergencyViewRoom.tsx
+++ b/src/pages/EmergencyViewPage/EmergencyViewRoom.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { faUserFriends } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { Room } from "types/rooms";
 
-import { useRoom } from "hooks/useRoom";
+import { getFirebaseStorageResizedImage } from "utils/image";
 
-import { getFirebaseStorageResizedImage } from "../../utils/image";
+import { useRoom } from "hooks/useRoom";
 
 type EmergencyViewRoomProps = {
   room: Room;
@@ -20,15 +20,11 @@ const EmergencyViewRoom: React.FC<EmergencyViewRoomProps> = ({
   isLive,
 }) => {
   const { enterRoom, recentRoomUsers } = useRoom({ room, venueName });
-  const roomImage = useMemo(
-    () =>
-      getFirebaseStorageResizedImage(room.image_url, {
-        fit: "crop",
-        width: 100,
-        height: 100,
-      }),
-    [room.image_url]
-  );
+  const roomImage = getFirebaseStorageResizedImage(room.image_url, {
+    fit: "crop",
+    width: 100,
+    height: 100,
+  });
 
   return (
     <div className="EmergencyView_content_room">

--- a/src/pages/EmergencyViewPage/EmergencyViewRoom.tsx
+++ b/src/pages/EmergencyViewPage/EmergencyViewRoom.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { faUserFriends } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { Room } from "types/rooms";
 
 import { useRoom } from "hooks/useRoom";
+
+import { getFirebaseStorageResizedImage } from "../../utils/image";
 
 type EmergencyViewRoomProps = {
   room: Room;
@@ -18,6 +20,15 @@ const EmergencyViewRoom: React.FC<EmergencyViewRoomProps> = ({
   isLive,
 }) => {
   const { enterRoom, recentRoomUsers } = useRoom({ room, venueName });
+  const roomImage = useMemo(
+    () =>
+      getFirebaseStorageResizedImage(room.image_url, {
+        fit: "crop",
+        width: 100,
+        height: 100,
+      }),
+    [room.image_url]
+  );
 
   return (
     <div className="EmergencyView_content_room">
@@ -33,7 +44,7 @@ const EmergencyViewRoom: React.FC<EmergencyViewRoomProps> = ({
       <div className="EmergencyView_content_room_body" onClick={enterRoom}>
         <img
           className="EmergencyView_content_room_body_image"
-          src={room.image_url}
+          src={roomImage}
           alt={room.title}
         />
         <span>{room.title}</span>


### PR DESCRIPTION
This significantly reduces time to load the page


https://burn.sparklever.se/m/playa 

(only images)

Before
![image](https://user-images.githubusercontent.com/88714064/131246382-207297fd-2913-4705-82d9-a67e48e86b8d.png)

After
![image](https://user-images.githubusercontent.com/88714064/131246368-14ba9078-e78d-46e8-8a8e-e7403121a869.png)

