### PR TITLE
Craco blows up w/o the check

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -26,7 +26,9 @@ module.exports = {
       const instanceOfMiniCssExtractPlugin = webpackConfig.plugins.find(
         (plugin) => plugin instanceof MiniCssExtractPlugin
       );
-      instanceOfMiniCssExtractPlugin.options.ignoreOrder = true;
+      if (instanceOfMiniCssExtractPlugin?.options) {
+        instanceOfMiniCssExtractPlugin.options.ignoreOrder = true;
+      }
 
       return webpackConfig;
     },


### PR DESCRIPTION
Prevent error on `npm start`

```sh
> craco start

(node:68692) UnhandledPromiseRejectionWarning: TypeError: Cannot read p
roperty 'options' of undefined

```