### PR TITLE
[env/burn-staging] Fix art piece aspect ratio and going over 100% width/height

### DIFF
--- a/src/components/templates/ArtPiece/ArtPiece.scss
+++ b/src/components/templates/ArtPiece/ArtPiece.scss
@@ -52,6 +52,8 @@ $chat-wrapper-height: 260px;
     padding: $spacing--xl;
     overflow: auto;
     @include gray-scrollbar();
+    max-width: 100%;
+    max-height: 100%;
   }
 
   &__youtube-video {

--- a/src/components/templates/ArtPiece/ArtPiece.tsx
+++ b/src/components/templates/ArtPiece/ArtPiece.tsx
@@ -30,10 +30,13 @@ export const ArtPiece: React.FC<ArtPieceProps> = ({ venue }) => {
   const landingPageConfig = config?.landingPageConfig;
   const embeddableUrl = ConvertToEmbeddableUrl(iframeUrl);
 
+  // NOTE: useful if some UI element with multiple options or free input is added for aspect ratio
   const aspectContainerClasses = classNames({
     "ArtPiece__aspect-container": true,
-    "mod--sixteen-nine": videoAspect === VideoAspectRatio.SixteenNine,
-    "mod--anamorphic": videoAspect !== VideoAspectRatio.SixteenNine,
+    "mod--sixteen-nine": videoAspect === VideoAspectRatio.sixteenNine,
+    "mod--anamorphic": videoAspect === VideoAspectRatio.anamorphic,
+    // @debt add useCss to set the aspect-ratio CSS property to the custom value instead of this purely informative class
+    [`ArtPiece__video-aspect--${videoAspect}`]: videoAspect,
   });
 
   return (

--- a/src/types/VideoAspectRatio.ts
+++ b/src/types/VideoAspectRatio.ts
@@ -1,3 +1,4 @@
 export enum VideoAspectRatio {
-  SixteenNine = "16:9",
+  sixteenNine = "16:9",
+  anamorphic = "anamorphic",
 }


### PR DESCRIPTION
Resolves 
- https://github.com/sparkletown/internal-sparkle-issues/issues/1132

Removed default anamorphic aspect ratio and added `max-width` and `max-height` of 100% to `ArtPiece__aspect-container`.

From comment https://github.com/sparkletown/internal-sparkle-issues/issues/1132#issuecomment-908940158:
>  -  going with @Sparkle-T insight and setting max width and max height to be 100% on the aspect ratio container;
>  - Height remains 100% to keep the layout with the video strip at the bottom in place;
>  - Removed the default aspect setting class i.e. no default aspect set;
>  - Now the value `anamorphic`, just like `16:9` previously, can be set through DB field `videoAspect` at the venue itself.