### PR TITLE
Default displayWhile to true in <Loading> to unbreak older uses

### DIFF
--- a/src/components/molecules/Loading/Loading.tsx
+++ b/src/components/molecules/Loading/Loading.tsx
@@ -15,7 +15,7 @@ export interface LoadingProps extends ContainerClassName {
 export const Loading: React.FC<LoadingProps> = ({
   containerClassName,
   label,
-  displayWhile,
+  displayWhile = true,
 }) => {
   const containerClasses = classNames("Loading", containerClassName);
   return displayWhile ? (

--- a/src/components/organisms/ChatSidebar/ChatSidebar.scss
+++ b/src/components/organisms/ChatSidebar/ChatSidebar.scss
@@ -20,7 +20,7 @@ $help-center-background-color: #232225;
   background-color: $saturated-black;
   z-index: z(sidebar);
 
-  .ButtonNG__button {
+  &__tab {
     border-radius: 0;
     border: none;
   }


### PR DESCRIPTION
Fix for regression in:
- https://github.com/sparkletown/sparkle/pull/2117

Comment (https://github.com/sparkletown/sparkle/commit/c6b6346682d4f81d4e9e95591c7b6791ee03da1c#r55837037):

> this change is not backward compatible and causes <Loading /> to not render anything where it was being used before this PR. e.g ScheduleNg, EmojiPicker.

BONUS regression fix: round off square buttons in chat

**Before**:

 
![sparkle-chat-squares-02](https://user-images.githubusercontent.com/79229621/132002633-bb5a1924-e2a4-4ef1-ab69-e05a6e058b27.png)

**After**:
**![sparkle-chat-squares-01](https://user-images.githubusercontent.com/79229621/132002625-d9b86d1c-c18b-4155-8541-17283c1b982d.png)**:
