### PR TITLE
Fix BM External Link page 2.0 text wrapping

### DIFF
--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -4,13 +4,21 @@ $border-radius: 22px;
 $spacing: 20px;
 
 .ExternalRoom {
-  height: 100%;
+  min-height: 100%;
+  padding-bottom: $spacing--xxl;
   display: flex;
   background-position: center;
   background-size: cover;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+
+  &__link {
+    max-width: 50rem;
+
+    text-align: center;
+    overflow-wrap: break-word;
+  }
 
   &__message {
     display: flex;
@@ -74,12 +82,14 @@ $spacing: 20px;
     background: $dark;
     border-radius: $border-radius;
 
-    max-height: 10vh;
+    max-height: 25vh;
+    max-width: 50rem;
     overflow-y: auto;
 
     font-size: $font-size--md;
     font-weight: $font-weight--400;
     color: opaque-white(0.6);
+    overflow-wrap: break-word;
   }
 
   &__userlist {

--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -27,6 +27,7 @@ $spacing: 20px;
     display: flex;
     flex-direction: column;
     max-height: 80vh;
+    max-width: 80%;
     border-radius: $border-radius;
     background: $dark;
   }
@@ -73,7 +74,7 @@ $spacing: 20px;
     background: $dark;
     border-radius: $border-radius;
 
-    max-height: 25vh;
+    max-height: 10vh;
     overflow-y: auto;
 
     font-size: $font-size--md;

--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -2,6 +2,7 @@
 
 $border-radius: 22px;
 $spacing: 20px;
+$text-width: 50rem;
 
 .ExternalRoom {
   min-height: 100%;
@@ -14,7 +15,7 @@ $spacing: 20px;
   flex-direction: column;
 
   &__link {
-    max-width: 50rem;
+    max-width: $text-width;
 
     text-align: center;
     overflow-wrap: break-word;
@@ -35,7 +36,6 @@ $spacing: 20px;
     display: flex;
     flex-direction: column;
     max-height: 80vh;
-    max-width: 80%;
     border-radius: $border-radius;
     background: $dark;
   }
@@ -83,7 +83,7 @@ $spacing: 20px;
     border-radius: $border-radius;
 
     max-height: 25vh;
-    max-width: 50rem;
+    max-width: $text-width;
     overflow-y: auto;
 
     font-size: $font-size--md;

--- a/src/components/templates/ExternalRoom/ExternalRoom.tsx
+++ b/src/components/templates/ExternalRoom/ExternalRoom.tsx
@@ -67,7 +67,12 @@ export const ExternalRoom: React.FC<ExternalRoomProps> = ({ venue }) => {
         <>
           <div className="ExternalRoom__message">
             <div>This page should automatically open</div>
-            <a rel="noreferrer" href={redirectUrl} target="_blank">
+            <a
+              rel="noreferrer"
+              href={redirectUrl}
+              target="_blank"
+              className="ExternalRoom__link"
+            >
               {redirectUrl}
             </a>
 

--- a/src/components/templates/ExternalRoom/ExternalRoom.tsx
+++ b/src/components/templates/ExternalRoom/ExternalRoom.tsx
@@ -11,7 +11,7 @@ import {
 import { AnyVenue } from "types/venues";
 
 import { WithId } from "utils/id";
-import { openUrl } from "utils/url";
+import { getExtraLinkProps, openUrl } from "utils/url";
 
 import { useRecentVenueUsers } from "hooks/users";
 
@@ -68,10 +68,9 @@ export const ExternalRoom: React.FC<ExternalRoomProps> = ({ venue }) => {
           <div className="ExternalRoom__message">
             <div>This page should automatically open</div>
             <a
-              rel="noreferrer"
               href={redirectUrl}
-              target="_blank"
               className="ExternalRoom__link"
+              {...getExtraLinkProps(true)}
             >
               {redirectUrl}
             </a>


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1168

fixed text wrapping. see example below

<img width="1440" alt="Screenshot 2021-09-06 at 11 43 42" src="https://user-images.githubusercontent.com/26366773/132188289-66beea58-a867-4edf-a05a-eea57f23fec6.png">
