### PR TITLE
Fix BM Modal popup styles

### DIFF
--- a/src/components/templates/ExternalRoom/ExternalRoom.scss
+++ b/src/components/templates/ExternalRoom/ExternalRoom.scss
@@ -67,7 +67,6 @@ $spacing: 20px;
   }
 
   &__venue-description {
-    @include scrollbar;
     padding: $spacing--sm $spacing;
 
     background: $dark;

--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
@@ -48,21 +48,25 @@ $spacing: 20px;
     height: fit-content;
   }
 
+  &__content {
+    flex: auto;
+    margin-left: $spacing;
+  }
+
   &__btn-enter {
     width: 100%;
     margin-top: 10px;
   }
 
   &__userlist {
-    margin: $spacing 0;
+    margin-bottom: $spacing;
   }
 
   &__description {
     @include scrollbar;
 
-    margin-top: $spacing;
     margin-bottom: $spacing;
-    padding: 10px $spacing;
+    padding: 0 $spacing;
 
     background: $dark;
     border-radius: $border-radius;

--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
@@ -49,7 +49,7 @@ $spacing: 20px;
   }
 
   &__content {
-    flex: auto;
+    flex: 1;
     margin-left: $spacing;
   }
 
@@ -63,8 +63,6 @@ $spacing: 20px;
   }
 
   &__description {
-    @include scrollbar;
-
     margin-bottom: $spacing;
     padding: 0 $spacing;
 
@@ -80,7 +78,6 @@ $spacing: 20px;
   }
 
   &__events {
-    @include scrollbar;
     max-height: 35vh;
     overflow-y: auto;
 

--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
@@ -165,19 +165,24 @@ export const RoomModalContent: React.FC<RoomModalContentProps> = ({
           <button
             ref={enterButtonref}
             autoFocus
-            className="btn btn-primary room-modal__btn-enter"
+            className="btn btn-primary RoomModal__btn-enter"
             onMouseOver={triggerAttendance}
             onMouseOut={clearAttendance}
             onClick={enterRoomWithSound}
           >
-            Join Room
+            Enter
           </button>
         </div>
       </div>
 
       {room.about && (
         <div className="RoomModal__description">
-          <RenderMarkdown text={roomDescription} />
+          <RenderMarkdown
+            text={roomDescription}
+            components={{
+              p: "span",
+            }}
+          />
         </div>
       )}
 


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1167

Now it looks better for specific spaces
<img width="1440" alt="Screenshot 2021-09-06 at 16 20 52" src="https://user-images.githubusercontent.com/26366773/132224072-27bc2291-1380-4b77-a1ba-f19a10abb5b4.png">

<img width="1440" alt="Screenshot 2021-09-06 at 16 22 27" src="https://user-images.githubusercontent.com/26366773/132224079-1c6db464-3940-496c-8572-944d61a9579a.png">
