### PR TITLE
add room labels to run tab in admin v3

### DIFF
--- a/src/pages/Account/Venue/VenueMapEdition/Container.tsx
+++ b/src/pages/Account/Venue/VenueMapEdition/Container.tsx
@@ -25,6 +25,7 @@ const styles: React.CSSProperties = {
 };
 export interface SubVenueIconMap {
   [key: string]: {
+    title: string;
     top: number;
     left: number;
     url?: string;

--- a/src/pages/Account/Venue/VenueMapEdition/DraggableSubvenue.scss
+++ b/src/pages/Account/Venue/VenueMapEdition/DraggableSubvenue.scss
@@ -1,0 +1,18 @@
+@import "scss/constants";
+
+.DraggableSubvenue {
+  &__title {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    background-color: opaque-black(0.5);
+    border-radius: $border-radius--xl;
+    padding: $spacing--xs $spacing--sm;
+    font-size: $font-size--sm;
+    transition: all 400ms $transition-function;
+    white-space: nowrap;
+  }
+}

--- a/src/pages/Account/Venue/VenueMapEdition/DraggableSubvenue.tsx
+++ b/src/pages/Account/Venue/VenueMapEdition/DraggableSubvenue.tsx
@@ -8,6 +8,8 @@ import { Dimensions } from "types/utility";
 import { SubVenueIconMap } from "./Container";
 import { ItemTypes } from "./ItemTypes";
 
+import "./DraggableSubvenue.scss";
+
 const getStyles = (
   left: number,
   top: number,
@@ -40,6 +42,7 @@ export const DraggableSubvenue: React.FC<PropsType> = (props) => {
     top,
     width,
     height,
+    title,
     onChangeSize,
     isResizable,
     rounded,
@@ -118,6 +121,7 @@ export const DraggableSubvenue: React.FC<PropsType> = (props) => {
             <img src={url} alt="subvenue-icon" style={styles.resizeableImage} />
           </div>
         </div>
+        <div className="DraggableSubvenue__title">{title}</div>
       </Resizable>
     );
   }

--- a/src/pages/Admin/MapPreview/MapPreview.tsx
+++ b/src/pages/Admin/MapPreview/MapPreview.tsx
@@ -63,6 +63,7 @@ const MapPreview: React.FC<MapPreviewProps> = ({
   const iconsMap = useMemo(() => {
     const iconsRooms = isEditing || mapRooms.length ? mapRooms : rooms;
     return iconsRooms.map((room, index: number) => ({
+      title: room.title,
       width: room.width_percent,
       height: room.height_percent,
       top: room.y_percent,


### PR DESCRIPTION
Run tab's bulk room edit wasn't showing the room labels and it was hard to figure out which room is which especially if they have the same logo. This now fixes the issue and displays the room title underneath the avatar.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1032

![blablabla](https://user-images.githubusercontent.com/18435853/132326078-374e1470-44a2-467e-a7bd-0143d0d60834.jpg)
