### PR TITLE
make title in subvenuemap optional

### DIFF
--- a/src/pages/Account/Venue/VenueMapEdition/Container.tsx
+++ b/src/pages/Account/Venue/VenueMapEdition/Container.tsx
@@ -25,7 +25,7 @@ const styles: React.CSSProperties = {
 };
 export interface SubVenueIconMap {
   [key: string]: {
-    title: string;
+    title?: string;
     top: number;
     left: number;
     url?: string;


### PR DESCRIPTION
The field is handled properly everywhere and it's being used only in 1 single place. This change will just make it optional.