### PR TITLE
[staging] Backport default dotted frame for focused buttons

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -84,6 +84,11 @@ h6 {
 }
 
 // Buttons
+
+button:focus {
+  outline: 1px dotted $white;
+}
+
 button.btn,
 a.btn,
 input.btn {


### PR DESCRIPTION
Follow up to
- https://github.com/sparkletown/sparkle/pull/2099

Resolves
- https://github.com/sparkletown/internal-sparkle-issues/issues/969