### PR TITLE
Follow up to "Move enteredVenueIds into UserLocation"

### DIFF
--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -32,7 +32,6 @@ import useConnectCurrentVenue from "hooks/useConnectCurrentVenue";
 import { useInterval } from "hooks/useInterval";
 import { useMixpanel } from "hooks/useMixpanel";
 import { usePreloadAssets } from "hooks/usePreloadAssets";
-import { useWorldUserLocation } from "hooks/users";
 import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 import { useVenueId } from "hooks/useVenueId";
@@ -71,8 +70,8 @@ export const VenuePage: React.FC = () => {
 
   // const [isAccessDenied, setIsAccessDenied] = useState(false);
 
-  const { user, profile } = useUser();
-  const { userLocation } = useWorldUserLocation(user?.uid);
+  const { user, profile, userLocation } = useUser();
+  console.log(userLocation);
   const { lastVenueIdSeenIn: userLastSeenIn, enteredVenueIds } =
     userLocation ?? {};
 
@@ -164,17 +163,12 @@ export const VenuePage: React.FC = () => {
 
   // @debt refactor how user location updates works here to encapsulate in a hook or similar?
   useEffect(() => {
-    if (
-      !venueId ||
-      !userId ||
-      !userLocation ||
-      enteredVenueIds?.includes(venueId)
-    ) {
+    if (!venueId || !userId || !profile || enteredVenueIds?.includes(venueId)) {
       return;
     }
 
     void updateProfileEnteredVenueIds(enteredVenueIds, userId, venueId);
-  }, [enteredVenueIds, userLocation, userId, venueId]);
+  }, [enteredVenueIds, userLocation, userId, venueId, profile]);
 
   // NOTE: User's timespent updates
 

--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -71,7 +71,6 @@ export const VenuePage: React.FC = () => {
   // const [isAccessDenied, setIsAccessDenied] = useState(false);
 
   const { user, profile, userLocation } = useUser();
-  console.log(userLocation);
   const { lastVenueIdSeenIn: userLastSeenIn, enteredVenueIds } =
     userLocation ?? {};
 

--- a/src/store/api/worldUsers.ts
+++ b/src/store/api/worldUsers.ts
@@ -9,6 +9,7 @@ import { WORLD_USERS_UPDATE_INTERVAL } from "settings";
 import { User, UserLocation, UserWithLocation } from "types/User";
 
 import { WithId, withId } from "utils/id";
+import { extractLocationFromUser, omitLocationFromUser } from "utils/user";
 
 export interface WorldUsersApiArgs {
   relatedLocationIds: string[];
@@ -145,32 +146,6 @@ export const {
   useQuerySubscription: useWorldUsersQuerySubscription,
 } = worldUsersApi.endpoints.worldUsers;
 
-// @debt Not sure if the validations are too 'heavyweight' for this, but object destructuring seemed to work
-//  here, whereas the validations seemed to hang my browser tab. There might also be something wrong with the
-//  validation rules leading to infinite recursion or similar?
-// @debt refactor userWithLocationToUser to optionally not require WithId, then use that in profileSelector
-const userWithLocationToUser = (
-  user: WithId<UserWithLocation>
-): WithId<User> => {
-  const { lastVenueIdSeenIn, lastSeenAt, ...userWithoutLocation } = user;
-
-  return userWithoutLocation;
-};
-
-const extractLocationFromUserWithLocation = (
-  user: WithId<UserWithLocation>
-): WithId<UserLocation> => {
-  const { lastVenueIdSeenIn, lastSeenAt, enteredVenueIds } = user;
-
-  const userLocation: UserLocation = {
-    lastVenueIdSeenIn,
-    lastSeenAt,
-    enteredVenueIds,
-  };
-
-  return withId(userLocation, user.id);
-};
-
 const notifyOnDocProcessingError = (
   modificationType: firebase.firestore.DocumentChangeType,
   userId: string,
@@ -199,12 +174,14 @@ const processUserDocChange = (draft: MaybeDrafted<WorldUsersData>) => (
   const userId: string = change.doc.id;
   const userWithLocation: WithId<UserWithLocation> = withId(user, userId);
 
-  const userWithoutLocation: WithId<User> = userWithLocationToUser(
-    userWithLocation
+  const userWithoutLocation: WithId<User> = withId(
+    omitLocationFromUser(userWithLocation),
+    userId
   );
 
-  const userLocation: WithId<UserLocation> = extractLocationFromUserWithLocation(
-    userWithLocation
+  const userLocation: WithId<UserLocation> = withId(
+    extractLocationFromUser(userWithLocation),
+    userId
   );
 
   const existingUserIndex = draft.worldUsers.findIndex(

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -57,6 +57,7 @@ export interface BaseUser {
 export interface User extends BaseUser {
   lastVenueIdSeenIn?: never;
   lastSeenAt?: never;
+  enteredVenueIds?: never;
 }
 
 export interface UserStatus {

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -12,7 +12,7 @@ import { Reaction, TextReaction, TextReactionType } from "types/reactions";
 import { ScreeningRoomVideo } from "types/screeningRoom";
 import { Settings } from "types/settings";
 import { SparkleSelector } from "types/SparkleSelector";
-import { User } from "types/User";
+import { User, UserWithLocation } from "types/User";
 import { AnyVenue, PosterPageVenue, VenueEvent } from "types/venues";
 
 import { WithId } from "utils/id";
@@ -37,17 +37,11 @@ export const authSelector: SparkleSelector<FirebaseReducer.AuthState> = (
  *
  * @param state the Redux store
  */
-export const profileSelector: SparkleSelector<FirebaseReducer.Profile<User>> = (
-  state
-) => {
+export const profileSelector: SparkleSelector<
+  FirebaseReducer.Profile<UserWithLocation>
+> = (state) => {
   // @debt refactor userWithLocationToUser to optionally not require WithId, then use that here
-  const {
-    lastVenueIdSeenIn,
-    lastSeenAt,
-    ...userProfileWithoutLocation
-  } = state.firebase.profile;
-
-  return userProfileWithoutLocation;
+  return state.firebase.profile;
 };
 
 /**

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,4 +1,6 @@
-import { Experience, User, UserLocation } from "types/User";
+import { omit, pick } from "lodash";
+
+import { Experience, User, UserLocation, UserWithLocation } from "types/User";
 
 import { WithId } from "./id";
 import { wrapIntoSlashes } from "./string";
@@ -32,3 +34,9 @@ export const getUserLocationData = ({
     ...userLocation,
   };
 };
+
+export const omitLocationFromUser = <T extends UserWithLocation>(user: T) =>
+  omit(user, "lastVenueIdSeenIn", "lastSeenAt", "enteredVenueIds");
+
+export const extractLocationFromUser = <T extends UserWithLocation>(user: T) =>
+  pick(user, "lastVenueIdSeenIn", "lastSeenAt", "enteredVenueIds");


### PR DESCRIPTION
Follows up https://github.com/sparkletown/sparkle/pull/2274

- Fixes a situation when `enteredVenueIds` is initially empty and then is never populated.
- Adds `enteredVenueIds?: never` to type `User`
- Updates `useUser` hook to return user location and removed `useWorldUserLocation` from `VenuePage`