### PR TITLE
Close profile modal after logout

### DIFF
--- a/src/components/organisms/NewProfileModal/NewProfileModalBody/NewProfileModalBody.tsx
+++ b/src/components/organisms/NewProfileModal/NewProfileModalBody/NewProfileModalBody.tsx
@@ -39,9 +39,10 @@ export const NewProfileModalBody: React.FC<NewProfileModalBodyProps> = ({
 
   const logout = useCallback(async () => {
     await firebase.auth().signOut();
+    closeUserProfileModal();
 
     history.push(venue.id ? venueLandingUrl(venue.id) : "/");
-  }, [firebase, history, venue.id]);
+  }, [closeUserProfileModal, firebase, history, venue.id]);
 
   const { selectRecipientChat } = useChatSidebarControls();
 


### PR DESCRIPTION
Fixes a bug when the user profile modal is left open after a user logs out.