### PR TITLE
Make mini-css-extract-plugin plugin ignore style order

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,4 +1,6 @@
 const path = require("path");
+// noinspection NpmUsedModulesInstalled
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
   reactScriptsVersion: "react-scripts",
@@ -14,14 +16,25 @@ module.exports = {
       lodash: path.resolve(__dirname, "node_modules/lodash"),
       "lodash-es": path.resolve(__dirname, "node_modules/lodash"),
     },
-    configure: webpackConfig => {
+    configure: (webpackConfig) => {
       webpackConfig.module.rules
-        .find(i => i.oneOf !== undefined)
-        .oneOf
-        .unshift({
+        .find((i) => i.oneOf !== undefined)
+        .oneOf.unshift({
           test: /\.(glsl)$/,
-          loader: "ts-shader-loader"
+          loader: "ts-shader-loader",
         });
+
+      const instanceOfMiniCssExtractPlugin = webpackConfig.plugins.find(
+        (plugin) => plugin instanceof MiniCssExtractPlugin
+      );
+
+      if (
+        instanceOfMiniCssExtractPlugin &&
+        instanceOfMiniCssExtractPlugin.options
+      ) {
+        instanceOfMiniCssExtractPlugin.options.ignoreOrder = true;
+      }
+
       return webpackConfig;
     },
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,94 @@
   "name": "co-reality-map",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "start": "craco start",
+    "init": "node scripts/init.js",
+    "build": "craco build",
+    "build:bundle-stats": "craco build --stats",
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
+    "analyze:bundle-stats": "npx webpack-bundle-analyzer build/bundle-stats.json -m static -r build/bundle-stats.html",
+    "analyze:bundle-stats:statoscope": "npx @statoscope/cli serve ./build/bundle-stats.json",
+    "analyze:bundle-stats:duplicates-1": "npx inspectpack --action duplicates --stats build/bundle-stats.json",
+    "analyze:bundle-stats:duplicates-2": "npx webpack-stats-duplicates ./build/bundle-stats.json",
+    "lint": "npm run prettier:check && npm run eslint:check",
+    "eslint": "eslint --fix",
+    "eslint:check": "eslint src scripts functions --ext .js,.jsx,.ts,.tsx",
+    "eslint:fix": "eslint src scripts functions --fix --ext .js,.jsx,.ts,.tsx",
+    "prettier": "prettier --write \"{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "prettier:check": "prettier --check \"{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "test": "npm run jest",
+    "jest": "jest --passWithNoTests",
+    "eject": "react-scripts eject",
+    "deploy": "npm run build && firebase deploy",
+    "cy:install": "cypress install",
+    "cy:run": "cypress run",
+    "firebase": "npx --no-install -- firebase",
+    "firebase:emulate-functions": "npm run firebase -- emulators:start --only functions",
+    "firebase:emulate-functions-hosting": "npm run firebase -- emulators:start --only functions,hosting",
+    "firebase:emulate-functions-hosting:debug": "npm run firebase -- emulators:start --only functions,hosting --inspect-functions",
+    "browserslist:update-db": "npx browserslist@latest --update-db"
+  },
+  "proxy": "http://localhost:3001",
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "lint-staged": {
+    "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --write"
+    ],
+    "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx}": [
+      "eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "devDependencies": {
+    "@craco/craco": "^6.2.0",
+    "@types/classnames": "^2.2.11",
+    "@types/emoji-mart": "^3.0.4",
+    "@types/faker": "^5.5.7",
+    "@types/howler": "^2.2.1",
+    "@types/jest": "^25.2.3",
+    "@types/lodash": "^4.14.155",
+    "@types/node": "^14.6.1",
+    "@types/react": "^17.0.18",
+    "@types/react-color": "^3.0.4",
+    "@types/react-dom": "^17.0.9",
+    "@types/react-mic": "^12.4.2",
+    "@types/react-router-dom": "^5.1.5",
+    "@types/scheduler": "^0.16.1",
+    "@types/styled-components": "^5.1.4",
+    "@types/twilio-video": "^2.7.2",
+    "@types/yup": "^0.29.3",
+    "babel-plugin-lodash": "^3.3.4",
+    "cypress": "^4.11.0",
+    "cypress-file-upload": "^4.0.7",
+    "eslint-plugin-import": "^2.24.0",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "firebase-admin": "^9.1.1",
+    "firebase-tools": "^8.6.0",
+    "gifwrap": "^0.9.2",
+    "phin": "^3.5.0",
+    "source-map-explorer": "^2.5.2",
+    "ts-node": "^9.1.1",
+    "ts-shader-loader": "^1.0.6",
+    "typescript": "^4.2.4",
+    "uuidv4": "^6.2.3"
+  },
   "dependencies": {
     "@ash.ts/ash": "^1.3.0",
     "@bugsnag/js": "^7.5.1",
@@ -95,93 +183,5 @@
     "ws": "^7.4.2",
     "xhr2": "^0.2.0",
     "yup": "^0.29.2"
-  },
-  "scripts": {
-    "start": "craco start",
-    "init": "node scripts/init.js",
-    "build": "craco build",
-    "build:bundle-stats": "craco build --stats",
-    "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "analyze:bundle-stats": "npx webpack-bundle-analyzer build/bundle-stats.json -m static -r build/bundle-stats.html",
-    "analyze:bundle-stats:statoscope": "npx @statoscope/cli serve ./build/bundle-stats.json",
-    "analyze:bundle-stats:duplicates-1": "npx inspectpack --action duplicates --stats build/bundle-stats.json",
-    "analyze:bundle-stats:duplicates-2": "npx webpack-stats-duplicates ./build/bundle-stats.json",
-    "lint": "npm run prettier:check && npm run eslint:check",
-    "eslint": "eslint --fix",
-    "eslint:check": "eslint src scripts functions --ext .js,.jsx,.ts,.tsx",
-    "eslint:fix": "eslint src scripts functions --fix --ext .js,.jsx,.ts,.tsx",
-    "prettier": "prettier --write \"{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
-    "prettier:check": "prettier --check \"{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
-    "test": "npm run jest",
-    "jest": "jest --passWithNoTests",
-    "eject": "react-scripts eject",
-    "deploy": "npm run build && firebase deploy",
-    "cy:install": "cypress install",
-    "cy:run": "cypress run",
-    "firebase": "npx --no-install -- firebase",
-    "firebase:emulate-functions": "npm run firebase -- emulators:start --only functions",
-    "firebase:emulate-functions-hosting": "npm run firebase -- emulators:start --only functions,hosting",
-    "firebase:emulate-functions-hosting:debug": "npm run firebase -- emulators:start --only functions,hosting --inspect-functions",
-    "browserslist:update-db": "npx browserslist@latest --update-db"
-  },
-  "proxy": "http://localhost:3001",
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "lint-staged": {
-    "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write"
-    ],
-    "{src,scripts,functions,configs,reporting}/**/*.{js,jsx,ts,tsx}": [
-      "eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "devDependencies": {
-    "@craco/craco": "^6.2.0",
-    "@types/classnames": "^2.2.11",
-    "@types/emoji-mart": "^3.0.4",
-    "@types/faker": "^5.5.7",
-    "@types/howler": "^2.2.1",
-    "@types/jest": "^25.2.3",
-    "@types/lodash": "^4.14.155",
-    "@types/node": "^14.6.1",
-    "@types/react": "^17.0.18",
-    "@types/react-color": "^3.0.4",
-    "@types/react-dom": "^17.0.9",
-    "@types/react-mic": "^12.4.2",
-    "@types/react-router-dom": "^5.1.5",
-    "@types/scheduler": "^0.16.1",
-    "@types/styled-components": "^5.1.4",
-    "@types/twilio-video": "^2.7.2",
-    "@types/yup": "^0.29.3",
-    "babel-plugin-lodash": "^3.3.4",
-    "cypress": "^4.11.0",
-    "cypress-file-upload": "^4.0.7",
-    "eslint-plugin-import": "^2.24.0",
-    "eslint-plugin-prefer-arrow": "^1.2.3",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
-    "firebase-admin": "^9.1.1",
-    "firebase-tools": "^8.6.0",
-    "gifwrap": "^0.9.2",
-    "phin": "^3.5.0",
-    "source-map-explorer": "^2.5.2",
-    "ts-node": "^9.1.1",
-    "ts-shader-loader": "^1.0.6",
-    "typescript": "^4.2.4",
-    "uuidv4": "^6.2.3"
   }
 }


### PR DESCRIPTION
Makes plugin not display style order warning thus halting CI build and deployment process. Example of warnings displayed:
```
chunk 1 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-7-1!./node_modules/postcss-loader/src??postcss!./node_modules/resolve-url-loader??ref--5-oneOf-7-3!./node_modules/sass-loader/dist/cjs.js??ref--5-oneOf-7-4!./src/components/atoms/PortalVisibility/PortalVisibility.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-7-1!./node_modules/postcss-loader/src??postcss!./node_modules/resolve-url-loader??ref--5-oneOf-7-3!./node_modules/sass-loader/dist/cjs.js??ref--5-oneOf-7-4!./src/components/molecules/UserStatusManager/components/UserStatusPanel/UserStatusPanel.scss
   - couldn't fulfill desired order of chunk group(s)
```


Using the opportunity to also move `dependencies` block of `package.json` to the end of the file, not before `scripts` and similar.