### PR TITLE
show portal name when editing a space

### DIFF
--- a/src/components/organisms/AdminVenueView/components/MapPreview/MapPreview.tsx
+++ b/src/components/organisms/AdminVenueView/components/MapPreview/MapPreview.tsx
@@ -32,6 +32,7 @@ export const MapPreview: React.FC<MapPreviewProps> = ({
 }) => {
   const iconsMap: RoomIcon[] = useMemo(() => {
     return rooms.map((room, index: number) => ({
+      title: room.title ?? "",
       width: room.width_percent ?? 0,
       height: room.height_percent ?? 0,
       top: room.y_percent ?? 0,

--- a/src/components/organisms/AdminVenueView/components/VenueRoomsEditor/VenueRoomsEditor.tsx
+++ b/src/components/organisms/AdminVenueView/components/VenueRoomsEditor/VenueRoomsEditor.tsx
@@ -33,6 +33,7 @@ const styles: React.CSSProperties = {
 };
 
 export interface RoomIcon {
+  title: string;
   top: number;
   left: number;
   url: string;


### PR DESCRIPTION
Portal name was not being passed to the edit object and that's why the name was not showing when editing a space position/size.

Before:
![old-name](https://user-images.githubusercontent.com/18435853/135610499-51bc4ead-7c7f-4adc-9d0a-f92e12bf0547.jpg)

After:
![new-name](https://user-images.githubusercontent.com/18435853/135610521-f679b2d8-aed1-404c-9ec3-20a86a016ba6.jpg)


