### PR TITLE
add separate function for map background update

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -762,6 +762,26 @@ exports.updateVenue_v2 = functions.https.onCall(async (data, context) => {
   admin.firestore().collection("venues").doc(venueId).update(updated);
 });
 
+exports.updateMapBackground = functions.https.onCall(async (data, context) => {
+  const venueId = getVenueId(data.name);
+  checkAuth(context);
+
+  await checkUserIsOwner(venueId, context.auth.token.user_id);
+
+  if (!data.worldId) {
+    throw new HttpsError(
+      "not-found",
+      "World id is missing and the update can not be executed."
+    );
+  }
+
+  admin
+    .firestore()
+    .collection("venues")
+    .doc(venueId)
+    .update({ mapBackgroundImageUrl: data.mapBackgroundImageUrl });
+});
+
 exports.updateVenueNG = functions.https.onCall(async (data, context) => {
   checkAuth(context);
 

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -295,8 +295,10 @@ const createFirestoreVenueInput_v2 = async (
     if (!fileArr || fileArr.length === 0) continue;
     const file = fileArr[0];
 
+    const fileExtension = file.type.split("/").pop();
+
     const uploadFileRef = storageRef.child(
-      `users/${user.uid}/venues/${urlVenueName}/background.${file.type}`
+      `users/${user.uid}/venues/${urlVenueName}/background.${fileExtension}`
     );
 
     await uploadFileRef.put(file);
@@ -398,6 +400,30 @@ export const updateVenue_v2 = async (
       const msg = `[updateVenue_v2] updating venue ${input.name}`;
       const context = {
         location: "api/admin::updateVenue_v2",
+      };
+
+      Bugsnag.notify(msg, (event) => {
+        event.severity = "warning";
+        event.addMetadata("context", context);
+        event.addMetadata("firestoreVenueInput", firestoreVenueInput);
+      });
+      throw error;
+    });
+};
+
+export const updateMapBackground = async (
+  input: WithWorldId<VenueInput_v2>,
+  user: firebase.UserInfo
+) => {
+  const firestoreVenueInput = await createFirestoreVenueInput_v2(input, user);
+
+  return firebase
+    .functions()
+    .httpsCallable("venue-updateMapBackground")(firestoreVenueInput)
+    .catch((error) => {
+      const msg = `[updateMapBackground] updating venue ${input.name}`;
+      const context = {
+        location: "api/admin::updateMapBackground",
       };
 
       Bugsnag.notify(msg, (event) => {

--- a/src/pages/Admin/BackgroundSelect/BackgroundSelect.tsx
+++ b/src/pages/Admin/BackgroundSelect/BackgroundSelect.tsx
@@ -3,7 +3,7 @@ import { useAsyncFn } from "react-use";
 
 import { DEFAULT_BACKGROUNDS } from "settings";
 
-import { updateVenue_v2 } from "api/admin";
+import { updateMapBackground } from "api/admin";
 
 import { useUser } from "hooks/useUser";
 
@@ -30,7 +30,7 @@ export const BackgroundSelect: React.FC<BackgroundSelectProps> = ({
     async (url: string, file?: FileList) => {
       if (!user) return;
 
-      return await updateVenue_v2(
+      return await updateMapBackground(
         {
           worldId: worldId,
           name: venueName,


### PR DESCRIPTION
Adds separate function that updates only the map background of the venue and nothing else. The performance is improved for static and firebase images. The upload custom background still takes a while because it needs to upload it to storage and then in the collection.