### PR TITLE
Make both createFirestoreVenueInput functions set safe URL slug as venue name

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -199,7 +199,7 @@ const createFirestoreVenueInput = async (
 ) => {
   const storageRef = firebase.storage().ref();
 
-  const urlVenueName = createUrlSafeName(input.name);
+  const slug = createUrlSafeName(input.name);
   type ImageNaming = {
     fileKey: VenueImageFileKeys;
     urlKey: VenueImageUrlKeys;
@@ -231,7 +231,7 @@ const createFirestoreVenueInput = async (
     const randomPrefix = Math.random().toString();
 
     const uploadFileRef = storageRef.child(
-      `users/${user.uid}/venues/${urlVenueName}/${randomPrefix}-${file.name}`
+      `users/${user.uid}/venues/${slug}/${randomPrefix}-${file.name}`
     );
 
     await uploadFileRef.put(file);
@@ -256,6 +256,8 @@ const createFirestoreVenueInput = async (
     owners,
     ...imageInputData,
     rooms: [], // eventually we will be getting the rooms from the form
+    // While name is used as URL slug and there is possibility cloud functions might miss this step, canonicalize before saving
+    name: slug,
   };
 
   return firestoreVenueInput;
@@ -266,8 +268,7 @@ const createFirestoreVenueInput_v2 = async (
   user: firebase.UserInfo
 ) => {
   const storageRef = firebase.storage().ref();
-
-  const urlVenueName = createUrlSafeName(input.name);
+  const slug = createUrlSafeName(input.name);
   type ImageNaming = {
     fileKey: ImageFileKeys;
     urlKey: ImageUrlKeys;
@@ -296,7 +297,7 @@ const createFirestoreVenueInput_v2 = async (
     const file = fileArr[0];
 
     const uploadFileRef = storageRef.child(
-      `users/${user.uid}/venues/${urlVenueName}/background.${file.type}`
+      `users/${user.uid}/venues/${slug}/background.${file.type}`
     );
 
     await uploadFileRef.put(file);
@@ -316,6 +317,8 @@ const createFirestoreVenueInput_v2 = async (
     ...imageInputData,
     template: input.template ?? VenueTemplate.partymap,
     parentId: input.parentId ?? "",
+    // While name is used as URL slug and there is possibility cloud functions might miss this step, canonicalize before saving
+    name: slug,
   };
 
   return firestoreVenueInput;

--- a/src/components/organisms/WorldStartForm/WorldStartForm.tsx
+++ b/src/components/organisms/WorldStartForm/WorldStartForm.tsx
@@ -6,7 +6,7 @@ import * as Yup from "yup";
 
 import { WORLD_ROOT_URL } from "settings";
 
-import { createWorld, updateWorld, World } from "api/admin";
+import { createUrlSafeName, createWorld, updateWorld, World } from "api/admin";
 
 import { WithId } from "utils/id";
 
@@ -84,6 +84,7 @@ export const WorldStartForm: React.FC<WorldStartFormProps> = ({
   });
 
   const values = watch();
+  const slug = createUrlSafeName(values.name);
 
   const [{ error, loading: isSaving }, submit] = useAsyncFn(async () => {
     if (!values || !user) return;
@@ -120,7 +121,7 @@ export const WorldStartForm: React.FC<WorldStartFormProps> = ({
               {window.location.host}
             </span>
             <span className="WorldStartForm__path-end WorldStartForm__name">
-              {WORLD_ROOT_URL}/{values.name}
+              {WORLD_ROOT_URL}/{slug}
             </span>
           </p>
         </AdminSection>


### PR DESCRIPTION
Tries to resolve
- https://github.com/sparkletown/internal-sparkle-issues/issues/1252

Update on the front end that forces venue name conform to slug since currently is used just as a part of a URL.
This PR tries to make a middle-of-the-road solution between
>fix this or
> disallow user to type any spaces in venuename field and label it "URL" instead

In the way that it will allow other characters in the field, but update (strip the unwanted) before sending to back end.