### PR TITLE
Make NavBar show logo and profile components in admin context

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -17,6 +17,8 @@ import { UpcomingEvent } from "types/UpcomingEvent";
 import { radioStationsSelector } from "utils/selectors";
 import { enterVenue, venueInsideUrl } from "utils/url";
 
+import { useAdminContextCheck } from "hooks/useAdminContextCheck";
+import { useOwnedVenues } from "hooks/useConnectOwnedVenues";
 import { useProfileModalControls } from "hooks/useProfileModalControls";
 import { useRadio } from "hooks/useRadio";
 import { useRelatedVenues } from "hooks/useRelatedVenues";
@@ -67,10 +69,23 @@ export const NavBar: React.FC<NavBarPropsType> = ({
   const { user, userWithId } = useUser();
   const venueId = useVenueId();
   const radioStations = useSelector(radioStationsSelector);
+  const isAdminContext = useAdminContextCheck();
 
-  const { currentVenue, parentVenue, sovereignVenueId } = useRelatedVenues({
+  const {
+    currentVenue: relatedVenue,
+    parentVenue,
+    sovereignVenueId,
+  } = useRelatedVenues({
     currentVenueId: venueId,
   });
+
+  const { currentVenue: ownedVenue } = useOwnedVenues({
+    currentVenueId: venueId,
+  });
+
+  // when Admin is displayed, owned venues are used
+  const currentVenue = relatedVenue ?? ownedVenue;
+  const parentVenueId = parentVenue?.id ?? ownedVenue?.parentId;
 
   const {
     location: { pathname },
@@ -151,8 +166,6 @@ export const NavBar: React.FC<NavBarPropsType> = ({
     setEventScheduleVisible(false);
   }, []);
 
-  const parentVenueId = parentVenue?.id;
-
   const backToParentVenue = useCallback(() => {
     if (!parentVenueId) return;
 
@@ -178,10 +191,8 @@ export const NavBar: React.FC<NavBarPropsType> = ({
     openUrlUsingRouter(SPARKLE_PHOTOBOOTH_URL);
   };
 
-  if (!venueId || !currentVenue) return null;
-
   // TODO: ideally this would find the top most parent of parents and use those details
-  const navbarTitle = parentVenue?.name ?? currentVenue.name;
+  const navbarTitle = parentVenue?.name ?? currentVenue?.name;
 
   const radioStation = hasRadioStations(radioStations) && radioStations[0];
 
@@ -212,7 +223,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
                 />
               )}
 
-              {shouldShowSchedule ? (
+              {shouldShowSchedule && venueId ? (
                 <button
                   aria-label="Schedule"
                   className={`nav-party-logo ${
@@ -220,13 +231,14 @@ export const NavBar: React.FC<NavBarPropsType> = ({
                   }`}
                   onClick={toggleEventSchedule}
                 >
-                  {navbarTitle} <span className="schedule-text">Schedule</span>
+                  {venueId && !isAdminContext && navbarTitle} &nbsp;
+                  <span className="schedule-text">Schedule</span>
                 </button>
               ) : (
-                <div>{navbarTitle}</div>
+                venueId && !isAdminContext && <div>{navbarTitle}</div>
               )}
 
-              <VenuePartygoers />
+              {venueId && !isAdminContext && <VenuePartygoers />}
             </div>
 
             {withPhotobooth && (
@@ -242,7 +254,9 @@ export const NavBar: React.FC<NavBarPropsType> = ({
 
             {user && (
               <div className="navbar-links">
-                <NavSearchBar venueId={venueId} />
+                {venueId && !isAdminContext && (
+                  <NavSearchBar venueId={venueId} />
+                )}
 
                 {hasUpcomingEvents && (
                   <OverlayTrigger
@@ -319,7 +333,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
         </div>
       </header>
 
-      {shouldShowSchedule && (
+      {shouldShowSchedule && venueId && (
         <div
           aria-hidden={isEventScheduleVisible ? "false" : "true"}
           className={`schedule-dropdown-backdrop ${

--- a/src/components/organisms/WorldStartForm/WorldStartForm.tsx
+++ b/src/components/organisms/WorldStartForm/WorldStartForm.tsx
@@ -84,7 +84,7 @@ export const WorldStartForm: React.FC<WorldStartFormProps> = ({
   });
 
   const values = watch();
-  const slug = createUrlSafeName(values.name);
+  const slug = values.name ? createUrlSafeName(values.name) : "";
 
   const [{ error, loading: isSaving }, submit] = useAsyncFn(async () => {
     if (!values || !user) return;

--- a/src/hooks/useAdminContextCheck.tsx
+++ b/src/hooks/useAdminContextCheck.tsx
@@ -1,0 +1,12 @@
+import { useMemo } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+
+import { ADMIN_V1_ROOT_URL, ADMIN_V3_ROOT_URL } from "settings";
+
+export const useAdminContextCheck = () => {
+  const location = useLocation();
+  return useMemo(
+    () => matchPath(location.pathname, [ADMIN_V3_ROOT_URL, ADMIN_V1_ROOT_URL]),
+    [location]
+  );
+};


### PR DESCRIPTION
Makes `NavBar` usable in Admin context and in line with https://doesitsparkle.slack.com/archives/C01700P4QCT/p1631548197056100?thread_ts=1631516472.052000&cid=C01700P4QCT
> Yes to top bar with a horizontal line under, yes to schedule, no to name, no to search, yes to profile image and Sparkle logo. Left sidebar only when needed, depending on context

Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1195
- https://github.com/sparkletown/internal-sparkle-issues/issues/1376

Follow up PR to:
- https://github.com/sparkletown/sparkle/pull/2325
- https://github.com/sparkletown/sparkle/pull/2366
- https://github.com/sparkletown/sparkle/pull/2390
- https://github.com/sparkletown/sparkle/pull/2396

Now `NavBar` also visible in World Editor:

![sparkle-navbar-01](https://user-images.githubusercontent.com/79229621/136352051-48291933-599c-4d40-b8f8-fd6002d163f5.png)
