### PR TITLE
Admin login default venue redirect fix

### DIFF
--- a/src/components/atoms/AdminRestricted/AdminRestricted.tsx
+++ b/src/components/atoms/AdminRestricted/AdminRestricted.tsx
@@ -3,7 +3,9 @@ import { useFirebase } from "react-redux-firebase";
 import { useHistory } from "react-router-dom";
 import { useAsyncFn } from "react-use";
 
-import { venueLandingUrl } from "utils/url";
+import { DEFAULT_VENUE } from "settings";
+
+import { venueInsideUrl, venueLandingUrl } from "utils/url";
 
 import { useIsAdminUser } from "hooks/roles";
 import { useUser } from "hooks/useUser";
@@ -28,6 +30,11 @@ export const AdminRestricted: React.FC = ({ children }) => {
     await firebase.auth().signOut();
     history.push(venueId ? venueLandingUrl(venueId) : "/");
   }, [firebase, history, venueId]);
+
+  const redirectToDefaultRoute = () =>
+    history.push(venueInsideUrl(DEFAULT_VENUE));
+
+  const authHandler = userId ? logout : redirectToDefaultRoute;
 
   if (isAdminUser) return <>{children}</>;
 
@@ -59,9 +66,9 @@ export const AdminRestricted: React.FC = ({ children }) => {
           variant="primary"
           loading={isLoggingOut}
           disabled={isLoggingOut}
-          onClick={logout}
+          onClick={authHandler}
         >
-          Log Out
+          {userId ? "Log Out" : "Log In"}
         </ButtonNG>
       </div>
     </div>

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -542,7 +542,7 @@ export const FIREBASE_CONFIG = {
   storageBucket: BUCKET_URL,
 };
 
-export const DEFAULT_VENUE = "zilloween";
+export const DEFAULT_VENUE = "bootstrap";
 
 export const RANDOM_AVATARS = [
   "avatar-01.png",


### PR DESCRIPTION
Fixes https://github.com/sparkletown/internal-sparkle-issues/issues/1333

Replaced `zilloween` redirect with `bootstrap` at admin route if user is not logged in