### PR TITLE
Popup bypass for clicking External Link

### DIFF
--- a/src/components/templates/PartyMap/PartyMap.tsx
+++ b/src/components/templates/PartyMap/PartyMap.tsx
@@ -9,6 +9,7 @@ import {
   eventsByStartUtcSecondsSorter,
   isEventLiveOrFuture,
 } from "utils/event";
+import { isExternalPortal, openUrl } from "utils/url";
 
 import { useVenueEvents } from "hooks/events";
 import { useRelatedVenues } from "hooks/useRelatedVenues";
@@ -60,7 +61,11 @@ export const PartyMap: React.FC<PartyMapProps> = ({ venue }) => {
   const selectRoom = useCallback((room: Room) => {
     if (room.type && COVERT_ROOM_TYPES.includes(room.type)) return;
 
-    setSelectedRoom(room);
+    if (isExternalPortal(room)) {
+      openUrl(room.url);
+    } else {
+      setSelectedRoom(room);
+    }
   }, []);
 
   const unselectRoom = useCallback(() => {

--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.tsx
@@ -13,7 +13,7 @@ import { Room, RoomType } from "types/rooms";
 import { AnyVenue, VenueEvent } from "types/venues";
 
 import { WithId, WithVenueId } from "utils/id";
-import { openUrl } from "utils/url";
+import { isExternalPortal, openUrl } from "utils/url";
 
 import { useCustomSound } from "hooks/sounds";
 import { useDispatch } from "hooks/useDispatch";
@@ -30,9 +30,6 @@ import { ScheduleItem } from "..";
 import "./RoomModal.scss";
 
 const emptyEvents: WithVenueId<WithId<VenueEvent>>[] = [];
-
-const isExternalPortal: (portal: Room) => boolean = (portal) =>
-  portal?.template === "external" || portal?.url.startsWith("http");
 
 export interface RoomModalProps {
   onHide: () => void;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,6 +15,8 @@ import {
   WORLD_ROOT_URL,
 } from "settings";
 
+import { Room } from "types/rooms";
+
 export const adminNGVenueUrl = (venueId?: string, selectedTab?: string) =>
   generatePath(ADMIN_V3_VENUE_PARAM_URL, { venueId, selectedTab });
 
@@ -63,12 +65,12 @@ export const isExternalUrl = (url: string) => {
   }
 };
 
-// @debt I feel like we could construct this url in a better way
-export const getRoomUrl = (roomUrl: string) =>
-  roomUrl.includes("http") ? roomUrl : "//" + roomUrl;
+export const isExternalPortal: (portal: Room) => boolean = (portal) =>
+  portal?.template === "external" || portal?.url.startsWith("http");
 
 export const openRoomUrl = (url: string, options?: OpenUrlOptions) => {
-  openUrl(getRoomUrl(url), options);
+  // @debt I feel like we could construct this url in a better way
+  openUrl(url.includes("http") ? url : "//" + url, options);
 };
 
 export const enterVenue = (venueId: string, options?: OpenUrlOptions) =>


### PR DESCRIPTION
Add popup modal bypass for clicking External Link portals in the party map.

Right now External Link opens the same Join modal popup before clicking a button again to go to the correct URL (like a zoom meeting). With this PR that popup will not open but the actual URL.