### PR TITLE
Increase circleCI instance size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,7 @@ jobs:
       - *notify-on-fail
   deploy-hosting:
     executor: node/default
+    resource_class: "large"
     steps:
       - checkout
       - node/install-packages


### PR DESCRIPTION
Temporarily increase instance size for build/deploy phase to get around
memory/slowness issues that are causing builds to fail.