### PR TITLE
Add min and max size to WorldCard's logo so it stays circle

### DIFF
--- a/src/components/molecules/WorldCard/WorldCard.scss
+++ b/src/components/molecules/WorldCard/WorldCard.scss
@@ -13,7 +13,11 @@ $world-card-logo-size: 70px;
   background-size: cover;
 
   &__logo {
-    @include square-size($world-card-logo-size);
+    @include square-size(
+      $world-card-logo-size,
+      $world-card-logo-size,
+      $world-card-logo-size
+    );
     border-radius: $border-radius--max;
     background-size: cover;
     background-color: var(--greyscale-darker-50pp);


### PR DESCRIPTION
Partially closes 
- https://github.com/sparkletown/internal-sparkle-issues/issues/1308

|Before | After
|--------|-----
|![sparkle-squishy-01](https://user-images.githubusercontent.com/79229621/138421108-929dcb49-ef39-4694-8f6a-3064d102e450.png) | ![sparkle-squishy-02](https://user-images.githubusercontent.com/79229621/138421056-1aaec621-1c77-41c6-8b9d-6abe5ad4f975.png)
