### PR TITLE
Hide the Manage users button

### DIFF
--- a/src/components/organisms/AdminVenueView/components/RunTabUsers/RunTabUsers.tsx
+++ b/src/components/organisms/AdminVenueView/components/RunTabUsers/RunTabUsers.tsx
@@ -71,9 +71,9 @@ export const RunTabUsers: React.FC<RunTabSidebarProps> = ({ venueId }) => {
     <div className="RunTabUsers">
       <div className="RunTabUsers__row RunTabUsers__manage">
         <span className="RunTabUsers__info">
-          {sovereignVenue?.recentUserCount} people live
+          {sovereignVenue?.recentUserCount ?? 0} people online
         </span>
-        <ButtonNG>Manage users</ButtonNG>
+        <ButtonNG className="mod--hidden">Manage users</ButtonNG>
       </div>
       <div>
         {foundUsers.map((user) => (


### PR DESCRIPTION
Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1331

Also-- added "0" if no users online

**Before**:
![sparkle-hide-manage-users-02](https://user-images.githubusercontent.com/79229621/138731552-04e1301b-0f93-4217-8ecd-00dc9699f21a.png)


**After**:
![sparkle-hide-manage-users-01](https://user-images.githubusercontent.com/79229621/138731580-b7a0e5f8-cf08-4898-ae03-bc8d336b075a.png)
