### PR TITLE
Update caniuse library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9655,9 +9655,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001220",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001220.tgz",
-      "integrity": "sha512-pjC2T4DIDyGAKTL4dMvGUQaMUHRmhvPpAgNNTa14jaBWHu+bLQgvpFqElxh9L4829Fdx0PlKiMp3wnYldRtECA=="
+      "version": "1.0.30001274",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
+      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Makes this run message go away:

```
Browserslist: caniuse-lite is outdated. Please run: npx browserslist@latest --update-db

Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```