### PR TITLE
Return firebarrel in the Add Portal but hidden

### DIFF
--- a/src/settings/spacesSettings.ts
+++ b/src/settings/spacesSettings.ts
@@ -2,6 +2,7 @@ import { PortalTemplate, VenueTemplate } from "types/venues";
 
 import IconArtPiece from "assets/icons/icon-room-artpiece.svg";
 import IconAuditorium from "assets/icons/icon-room-auditorium.svg";
+import IconBurnBarrel from "assets/icons/icon-room-burnbarrel.svg";
 import IconConversation from "assets/icons/icon-room-conversation.svg";
 import IconEmbeddable from "assets/icons/icon-room-embeddable.svg";
 import IconExperience from "assets/icons/icon-room-experience.svg";
@@ -50,6 +51,14 @@ export const SPACE_PORTALS_LIST: SpacePortalsListItem[] = [
     description:
       "Host any number of small groups from 2-10 in video chats with each other around central content.",
     template: VenueTemplate.jazzbar,
+  },
+  {
+    text: "Burn Firebarrel",
+    icon: IconBurnBarrel,
+    template: VenueTemplate.firebarrel,
+    poster: "",
+    description: "",
+    hidden: true,
   },
   {
     text: "Art Piece",


### PR DESCRIPTION
Partially resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1298

Based on comment (https://github.com/sparkletown/internal-sparkle-issues/issues/1298#issuecomment-955594955):
> Final thing: need to enable - but hidden - firebarrel, until we account for this in the unified table template (it will act as a one-table conversation space // no central content).

![sparkle-add-portal-04](https://user-images.githubusercontent.com/79229621/139655373-337d4c55-3a40-41cc-a23b-ebfb9d572606.png)
