### PR TITLE
fix auditorium logo upload in admin v3

### DIFF
--- a/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
+++ b/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
@@ -157,7 +157,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
     const portalData: RoomInput = {
       ...(room as RoomInput),
       ...(updatedRoom as RoomInput),
-      image_url: values.image_url,
+      ...values,
     };
 
     await upsertRoom(portalData, venueId, user, roomIndex);


### PR DESCRIPTION
The problem is that `values.image_file` is not passed down. However TS is crying because that doesn't exist in the `values` object, it's actually mutated by either the image component or useForm. That's why we can't simply pass it and we use spread operator to pass the whole thing and allow the function to get what it needs. It is a very hacky solution and now I understand why it was written this way in the other form.

Fixes: N/A