### PR TITLE
Hide portal URL if portal isn't external

### DIFF
--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -24,6 +24,7 @@ import { Room } from "types/rooms";
 import { RoomVisibility, VenueTemplate } from "types/venues";
 
 import { convertToEmbeddableUrl } from "utils/embeddableUrl";
+import { isExternalPortal } from "utils/url";
 
 import { useUser } from "hooks/useUser";
 import { useVenueId } from "hooks/useVenueId";
@@ -262,14 +263,19 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
             errors={errors}
           />
 
-          <AdminInput
-            name="room.url"
-            autoComplete="off"
-            label={`${ROOM_TAXON.capital} url`}
-            placeholder={`${ROOM_TAXON.capital} url`}
-            register={register}
-            errors={errors}
-          />
+          {isExternalPortal(room) ? (
+            <AdminInput
+              name="room.url"
+              autoComplete="off"
+              label={`${ROOM_TAXON.capital} url`}
+              placeholder={`${ROOM_TAXON.capital} url`}
+              register={register}
+              errors={errors}
+            />
+          ) : (
+            // NOTE: Save button doesn't work if the value is missing
+            <input name="room.url" type="hidden" ref={register} />
+          )}
 
           <div>
             <Form.Label>{ROOM_TAXON.capital} image</Form.Label>


### PR DESCRIPTION
Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1390

In short, portal URL is hidden in all cases except the template is `external` or the URL starts with `http` based on `isExternalPortal()` logic.

**External**:
![sparkle-portal-edit-03](https://user-images.githubusercontent.com/79229621/140097778-56819d6f-0ff9-4a50-b9fe-93e717d5c40c.png) 

**Embedded**:
![sparkle-portal-edit-04](https://user-images.githubusercontent.com/79229621/140097759-2c34216a-85c0-4a4f-ab48-566d0c2ab676.png)
