### PR TITLE
Add flip-switch vaiant to AdminCheckbox and fix labeless click bug

### DIFF
--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.scss
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.scss
@@ -47,6 +47,10 @@ $checkbox-shadow-preset: inset 0 0 0 1px;
   &__label {
     display: flex;
     align-items: center;
+
+    &--before {
+      margin-right: $spacing--md;
+    }
   }
 
   &__box {
@@ -88,7 +92,8 @@ $checkbox-shadow-preset: inset 0 0 0 1px;
     }
   }
 
-  &--toggler &__box {
+  &--toggler &__box,
+  &--flip-switch &__box {
     height: $size;
     min-height: $size;
     width: 2 * $size;
@@ -111,7 +116,12 @@ $checkbox-shadow-preset: inset 0 0 0 1px;
     }
   }
 
-  &--toggler &__input:checked ~ &__box {
+  &--flip-switch &__box {
+    margin-left: font-size--parent(1);
+  }
+
+  &--toggler &__input:checked ~ &__box,
+  &--flip-switch &__input:checked ~ &__box {
     background-color: var(--accent--under-50a);
 
     &::after {
@@ -120,7 +130,13 @@ $checkbox-shadow-preset: inset 0 0 0 1px;
     }
   }
 
-  &--toggler &__tick {
+  &--toggler &__tick,
+  &--flip-switch &__tick {
     display: none;
+  }
+
+  &__flip-wrapper {
+    display: flex;
+    align-items: center;
   }
 }

--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.scss
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.scss
@@ -44,12 +44,25 @@ $checkbox-shadow-preset: inset 0 0 0 1px;
     height: 0 !important;
   }
 
+  label {
+    // NOTE: this undoes another global.scss damage, remove after that one is removed
+    margin-bottom: unset;
+  }
+
   &__label {
     display: flex;
     align-items: center;
 
     &--before {
       margin-right: $spacing--md;
+    }
+  }
+
+  &--label-above &__label {
+    flex-direction: column;
+
+    > * + * {
+      margin-top: font-size--parent(0.5);
     }
   }
 

--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
@@ -10,15 +10,17 @@ import { CheckboxProps } from "components/atoms/Checkbox";
 import "./AdminCheckbox.scss";
 
 export interface AdminCheckboxProps
-  extends Omit<CheckboxProps, "label" | "toggler"> {
+  extends Omit<CheckboxProps, "label" | "toggler" | "flip-switch"> {
   className?: string;
   errors?: FieldErrors<FieldValues>;
   label?: ReactNode | string;
   labelPosition?: "before" | "after";
   name: string;
+  displayOn?: ReactNode | string;
+  displayOff?: ReactNode | string;
   register: (Ref: unknown, RegisterOptions?: unknown) => void;
   subtext?: ReactNode | string;
-  variant?: "toggler" | "checkbox";
+  variant?: "toggler" | "checkbox" | "flip-switch";
 }
 
 export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
@@ -28,6 +30,8 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
   label,
   labelPosition = "after",
   name,
+  displayOn,
+  displayOff,
   register,
   subtext,
   variant = "checkbox",
@@ -43,24 +47,46 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
     [className]: className,
   });
 
+  const ev = (tag: string) => console.log.bind(console, tag);
+  // console.log(AdminCheckbox.name, { disabled });
+
   const input = (
-    <>
-      <input
-        {...inputProps}
-        className="AdminCheckbox__input"
-        type="checkbox"
-        hidden
-        name={name}
-        ref={register}
-      />
-      <span className="AdminCheckbox__box">
-        <FontAwesomeIcon
-          className="AdminCheckbox__tick"
-          icon={faCheck}
-          size="sm"
+    <span className="AdminCheckbox__flip-wrapper">
+      {variant === "flip-switch" && (
+        <span className="AdminCheckbox__off" onClick={ev("off.onClick")}>
+          {displayOff}
+        </span>
+      )}
+      {/* NOTE: must always have label around input and the following span for the click to be shared */}
+      {/* NOTE: multiple labels per input are OK, so keep this one empty of any text, use surrounding label for it */}
+      <label className="AdminCheckbox__input-wrapper">
+        <input
+          {...inputProps}
+          className="AdminCheckbox__input"
+          type="checkbox"
+          hidden
+          disabled={disabled}
+          name={name}
+          ref={register}
+          onClick={ev("input.onClick")}
         />
-      </span>
-    </>
+        <span
+          className="AdminCheckbox__box"
+          // onClick={ev("box.onClick")}
+        >
+          <FontAwesomeIcon
+            className="AdminCheckbox__tick"
+            icon={faCheck}
+            size="sm"
+          />
+        </span>
+      </label>
+      {variant === "flip-switch" && (
+        <span className="AdminCheckbox__on" onClick={ev("on.onClick")}>
+          {displayOn}
+        </span>
+      )}
+    </span>
   );
 
   return (

--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
@@ -64,10 +64,7 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
           name={name}
           ref={register}
         />
-        <span
-          className="AdminCheckbox__box"
-          // onClick={ev("box.onClick")}
-        >
+        <span className="AdminCheckbox__box">
           <FontAwesomeIcon
             className="AdminCheckbox__tick"
             icon={faCheck}

--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
@@ -47,15 +47,10 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
     [className]: className,
   });
 
-  const ev = (tag: string) => console.log.bind(console, tag);
-  // console.log(AdminCheckbox.name, { disabled });
-
   const input = (
     <span className="AdminCheckbox__flip-wrapper">
       {variant === "flip-switch" && (
-        <span className="AdminCheckbox__off" onClick={ev("off.onClick")}>
-          {displayOff}
-        </span>
+        <span className="AdminCheckbox__off">{displayOff}</span>
       )}
       {/* NOTE: must always have label around input and the following span for the click to be shared */}
       {/* NOTE: multiple labels per input are OK, so keep this one empty of any text, use surrounding label for it */}
@@ -68,7 +63,6 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
           disabled={disabled}
           name={name}
           ref={register}
-          onClick={ev("input.onClick")}
         />
         <span
           className="AdminCheckbox__box"
@@ -82,9 +76,7 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
         </span>
       </label>
       {variant === "flip-switch" && (
-        <span className="AdminCheckbox__on" onClick={ev("on.onClick")}>
-          {displayOn}
-        </span>
+        <span className="AdminCheckbox__on">{displayOn}</span>
       )}
     </span>
   );

--- a/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
+++ b/src/components/molecules/AdminCheckbox/AdminCheckbox.tsx
@@ -14,7 +14,7 @@ export interface AdminCheckboxProps
   className?: string;
   errors?: FieldErrors<FieldValues>;
   label?: ReactNode | string;
-  labelPosition?: "before" | "after";
+  labelPosition?: "before" | "after" | "above";
   name: string;
   displayOn?: ReactNode | string;
   displayOff?: ReactNode | string;
@@ -93,9 +93,15 @@ export const AdminCheckbox: React.FC<AdminCheckboxProps> = ({
     <p className={parentClasses}>
       {label ? (
         <label className="AdminCheckbox__label">
-          {labelPosition === "before" && label}
+          {(labelPosition === "before" || labelPosition === "above") && (
+            <span className="AdminCheckbox__label-wrapper">{label}</span>
+          )}
+
           {input}
-          {labelPosition === "after" && label}
+
+          {labelPosition === "after" && (
+            <span className="AdminCheckbox__label-wrapper">{label}</span>
+          )}
         </label>
       ) : (
         input

--- a/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
+++ b/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
@@ -209,11 +209,8 @@ export const WorldAdvancedForm: React.FC<WorldAdvancedFormProps> = ({
         <AdminSection>
           <AdminCheckbox
             name="showBadges"
-            // label="Air conditioning"
-            labelPosition="above"
-            displayOff={"❄️"}
-            displayOn={"🔥"}
-            variant="flip-switch"
+            label="Show badges"
+            variant="toggler"
             register={register}
           />
         </AdminSection>

--- a/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
+++ b/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
@@ -209,8 +209,11 @@ export const WorldAdvancedForm: React.FC<WorldAdvancedFormProps> = ({
         <AdminSection>
           <AdminCheckbox
             name="showBadges"
-            label="Show badges"
-            variant="toggler"
+            // label="Air conditioning"
+            labelPosition="above"
+            displayOff={"❄️"}
+            displayOn={"🔥"}
+            variant="flip-switch"
             register={register}
           />
         </AdminSection>


### PR DESCRIPTION
Previously `AdminCheckbox` would not toggle its state if label wasn't present ( `label={<></>}` was a workaround ). Now...

ON / OFF displays, no label:
![sparkle-flip-switch-02](https://user-images.githubusercontent.com/79229621/141091739-398d02af-1df0-4287-a775-9ad4ebe0cf58.png)

ON / OFF displays, with label above:
![sparkle-flip-switch-01](https://user-images.githubusercontent.com/79229621/141091741-735bd701-a509-4d09-9b63-b88787458270.png)
