### PR TITLE
add useWorldById in RegisterForm component

### DIFF
--- a/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
+++ b/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
@@ -16,7 +16,7 @@ import { isTruthy } from "utils/types";
 import { useAnalytics } from "hooks/useAnalytics";
 import { useSelector } from "hooks/useSelector";
 import { useSocialSignIn } from "hooks/useSocialSignIn";
-import { useWorldEdit } from "hooks/useWorldEdit";
+import { useWorldById } from "hooks/useWorldById";
 
 import { updateUserPrivate } from "pages/Account/helpers";
 
@@ -60,7 +60,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
 }) => {
   const history = useHistory();
   const venue = useSelector(venueSelector);
-  const { world, isLoaded: isWorldLoaded } = useWorldEdit(venue?.worldId);
+  const { world, isLoaded: isWorldLoaded } = useWorldById(venue?.worldId);
 
   const [showLoginModal, setShowLoginModal] = useState(false);
   const analytics = useAnalytics({ venue });


### PR DESCRIPTION
`useWorldEdit` no longer exists and it was accidentally merged. This PR unblocks staging and uses `useWorldById`