### PR TITLE
Space setting parent selector list exclude outside spaces

### DIFF
--- a/src/pages/Admin/Details/Form/DetailsForm.tsx
+++ b/src/pages/Admin/Details/Form/DetailsForm.tsx
@@ -282,7 +282,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ venue }) => {
 
   const backButtonOptionList = ownedVenues.filter(
     ({ id, name, template, worldId: venueWorldId }) => {
-      if (venueId === id || worldId !== venueWorldId) {
+      if (venueId === id || venue?.worldId !== venueWorldId) {
         return null;
       }
 


### PR DESCRIPTION
Closes a minor bug in:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1282

Fixed an error with `worldId` being undefined resulting in an empty parent list