### PR TITLE
Fixed portal & image styles

### DIFF
--- a/src/components/atoms/ImageInput/ImageInput.scss
+++ b/src/components/atoms/ImageInput/ImageInput.scss
@@ -43,6 +43,7 @@ $upload-button-height: 150px;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    text-align: center;
     background-color: opaque-white(0.12);
     border-radius: $border-radius--xl;
   }

--- a/src/components/atoms/PortalVisibility/PortalVisibility.scss
+++ b/src/components/atoms/PortalVisibility/PortalVisibility.scss
@@ -8,6 +8,7 @@ $portal-image-width: 75px;
 .PortalVisibility {
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
   width: 100%;
   align-items: center;
 


### PR DESCRIPTION
Throwback to Friday's (12.11.21) play in the product. Adding `wrap` to portal appearance container
![image](https://user-images.githubusercontent.com/56254806/141741487-a1ac4783-090a-43a9-a2e6-7b4880762c00.png)
