### PR TITLE
Disable reactions audio button according to flag

### DIFF
--- a/src/components/molecules/ReactionsBar/ReactionsBar.scss
+++ b/src/components/molecules/ReactionsBar/ReactionsBar.scss
@@ -13,6 +13,12 @@
     align-items: center;
     font-size: $font-size--xl;
     cursor: pointer;
+
+    &--disabled {
+      cursor: default;
+      pointer-events: none;
+      color: $lighter-intermediate-grey;
+    }
   }
 
   &__leave-seat-button {

--- a/src/components/molecules/ReactionsBar/ReactionsBar.tsx
+++ b/src/components/molecules/ReactionsBar/ReactionsBar.tsx
@@ -3,6 +3,8 @@ import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 
+import { ALWAYS_NOOP_FUNCTION } from "settings";
+
 import { addReaction } from "store/actions/Reactions";
 
 import {
@@ -44,6 +46,8 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     "ReactionsBar__mute-button--disabled": isAudioDisabled,
   });
 
+  const handleToggleMute = isAudioDisabled ? ALWAYS_NOOP_FUNCTION : toggleMute;
+
   const sendReaction = useCallback(
     (emojiReaction: EmojiReactionType) => {
       if (!venueId || !userWithId) return;
@@ -74,7 +78,7 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     <div className="ReactionsBar">
       {renderedReactions}
 
-      <div className={muteClasses} onClick={toggleMute}>
+      <div className={muteClasses} onClick={handleToggleMute}>
         <FontAwesomeIcon icon={isReactionsMuted ? faVolumeMute : faVolumeUp} />
       </div>
 

--- a/src/components/molecules/ReactionsBar/ReactionsBar.tsx
+++ b/src/components/molecules/ReactionsBar/ReactionsBar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { faVolumeMute, faVolumeUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
 
 import { addReaction } from "store/actions/Reactions";
 
@@ -23,6 +24,7 @@ export interface ReactionsBarProps {
   venueId: string;
   reactions?: ReactionData<EmojiReactionType>[];
   isReactionsMuted: boolean;
+  isAudioDisabled: boolean;
   toggleMute: () => void;
   leaveSeat?: () => void;
 }
@@ -30,12 +32,17 @@ export interface ReactionsBarProps {
 export const ReactionsBar: React.FC<ReactionsBarProps> = ({
   venueId,
   isReactionsMuted,
+  isAudioDisabled,
   reactions = EMOJI_REACTIONS,
   toggleMute,
   leaveSeat,
 }) => {
   const dispatch = useDispatch();
   const { userWithId } = useUser();
+
+  const muteClasses = classNames("ReactionsBar__mute-button", {
+    "ReactionsBar__mute-button--disabled": isAudioDisabled,
+  });
 
   const sendReaction = useCallback(
     (emojiReaction: EmojiReactionType) => {
@@ -67,7 +74,7 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     <div className="ReactionsBar">
       {renderedReactions}
 
-      <div className="ReactionsBar__mute-button" onClick={toggleMute}>
+      <div className={muteClasses} onClick={toggleMute}>
         <FontAwesomeIcon icon={isReactionsMuted ? faVolumeMute : faVolumeUp} />
       </div>
 

--- a/src/components/templates/Auditorium/components/Section/Section.tsx
+++ b/src/components/templates/Auditorium/components/Section/Section.tsx
@@ -31,6 +31,8 @@ export interface SectionProps {
 }
 
 export const Section: React.FC<SectionProps> = ({ venue }) => {
+  const isReactionsAudioDisabled = !venue.isReactionsMuted;
+
   const { isShown: isUserAudioOn, toggle: toggleUserAudio } = useShowHide(
     venue.isReactionsMuted ?? false
   );
@@ -120,6 +122,7 @@ export const Section: React.FC<SectionProps> = ({ venue }) => {
             venueId={venueId}
             leaveSeat={leaveSeat}
             isReactionsMuted={isUserAudioMuted}
+            isAudioDisabled={isReactionsAudioDisabled}
             toggleMute={toggleUserAudio}
           />
         </div>

--- a/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
+++ b/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
@@ -77,6 +77,8 @@ export const JazzBar: React.FC<JazzProps> = ({ venue }) => {
     seatedAtTable && venue?.id
   );
 
+  const isReactionsAudioDisabled = !venue.isReactionsMuted;
+
   const { isShown: isUserAudioOn, toggle: toggleUserAudio } = useShowHide(
     venue.isReactionsMuted
   );
@@ -182,6 +184,7 @@ export const JazzBar: React.FC<JazzProps> = ({ venue }) => {
                       venueId={venue.id}
                       isReactionsMuted={isUserAudioMuted}
                       toggleMute={toggleUserAudio}
+                      isAudioDisabled={isReactionsAudioDisabled}
                     />
                   </div>
                 )}


### PR DESCRIPTION
Closes:

- https://github.com/sparkletown/internal-sparkle-issues/issues/1214

Added noop + disabled styles if the `isReactionsMuted` is set to `true` in the admin
![image](https://user-images.githubusercontent.com/56254806/141803097-742544bd-49c2-47a7-bdfd-31270f8c1b84.png)
