### PR TITLE
Make Schedule button not show up in Admin side of NavBar

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -107,7 +107,9 @@ export const NavBar: React.FC<NavBarPropsType> = ({
   }, [openUserProfileModal, userWithId]);
 
   const shouldShowSchedule =
-    withSchedule && (world?.showSchedule ?? DEFAULT_SHOW_SCHEDULE);
+    !isAdminContext &&
+    withSchedule &&
+    (world?.showSchedule ?? DEFAULT_SHOW_SCHEDULE);
 
   const isOnPlaya = pathname.toLowerCase() === venueInsideUrl(PLAYA_VENUE_ID);
 


### PR DESCRIPTION
Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1460

This button should no longer show up.

![sparkle-schedule-button-01](https://user-images.githubusercontent.com/79229621/142226420-e651fd90-a893-450c-8250-1c3c97796574.png)
