### PR TITLE
Update the Loading/NotFound conditions in VenuePage

### DIFF
--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -198,11 +198,11 @@ export const VenuePage: React.FC = () => {
 
   // useVenueAccess(venue, handleAccessDenied);
 
-  if (!isLoaded || !spaceId) {
+  if (!isLoaded) {
     return <LoadingPage />;
   }
 
-  if (!space || !spaceSlug) {
+  if (!spaceId || !spaceSlug || !space) {
     return (
       <WithNavigationBar hasBackButton withHiddenLoginButton>
         <NotFound />


### PR DESCRIPTION
A simple change to show `NotFound` instead of `Loading` on missing `spaceId`