### PR TITLE
fix BackButton visibility and linkability issues (take 2)

### DIFF
--- a/functions/venue.js
+++ b/functions/venue.js
@@ -991,11 +991,13 @@ exports.updateVenueNG = functions.https.onCall(async (data, context) => {
     updated.radioStations = [data.radioStations];
   }
 
+  // @debt perhaps await is more appropriate in front of admin so the function will return the error
   admin
     .firestore()
     .collection("venues")
     .doc(data.id)
-    .set(updated, { merge: true });
+    .set(updated, { merge: true })
+    .catch((e) => console.error(exports.updateVenueNG.name, e));
 });
 
 exports.updateTables = functions.https.onCall((data, context) => {

--- a/src/components/atoms/BackButton/BackButton.tsx
+++ b/src/components/atoms/BackButton/BackButton.tsx
@@ -1,22 +1,58 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { useHistory } from "react-router-dom";
 import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { AnyVenue } from "types/venues";
+
+import { WithId } from "utils/id";
+import { enterVenue } from "utils/url";
+
+import { useAdminContextCheck } from "hooks/useAdminContextCheck";
 
 import "./BackButton.scss";
 
 export interface BackButtonProps {
   locationName?: string;
-  onClick: () => void;
+  space?: WithId<AnyVenue>;
+  variant: "simple" | "relative" | "external";
 }
 
 export const BackButton: React.FC<BackButtonProps> = ({
   locationName,
-  onClick,
+  space,
+  variant,
 }) => {
-  const backButtonText = locationName ? `Back to ${locationName}` : "Back";
+  const spaceSlug = space?.slug;
+  const displayName = locationName ?? space?.name;
+  const backButtonText = locationName ? `Back to ${displayName}` : "Back";
+
+  const {
+    push: customOpenRelativeUrl,
+    replace: customOpenExternalUrl,
+  } = useHistory();
+
+  const handleClick = useCallback(() => {
+    if (!spaceSlug) return;
+
+    if (variant === "relative") {
+      return enterVenue(spaceSlug, { customOpenRelativeUrl });
+    }
+
+    if (variant === "external") {
+      return enterVenue(spaceSlug, { customOpenExternalUrl });
+    }
+
+    return enterVenue(spaceSlug);
+  }, [spaceSlug, variant, customOpenExternalUrl, customOpenRelativeUrl]);
+
+  const isAdminContext = useAdminContextCheck();
+  if (isAdminContext) {
+    return null;
+  }
 
   return (
-    <div className="BackButton" onClick={onClick}>
+    <div className="BackButton" onClick={handleClick}>
       <FontAwesomeIcon
         className="BackButton__icon"
         icon={faChevronLeft}

--- a/src/components/atoms/BackButton/index.ts
+++ b/src/components/atoms/BackButton/index.ts
@@ -1,1 +1,2 @@
 export { BackButton } from "./BackButton";
+export type { BackButtonProps } from "./BackButton";

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -89,7 +89,6 @@ export const NavBar: React.FC<NavBarPropsType> = ({
 
   // when Admin is displayed, owned venues are used
   const currentVenue = relatedVenue ?? ownedVenue;
-  const parentVenueId = parentVenue?.id ?? ownedVenue?.parentId;
 
   const {
     location: { pathname },
@@ -161,12 +160,6 @@ export const NavBar: React.FC<NavBarPropsType> = ({
 
     setEventScheduleVisible(false);
   }, []);
-
-  const backToParentVenue = useCallback(() => {
-    if (!parentVenueId) return;
-
-    enterVenue(parentVenueId, { customOpenRelativeUrl: openUrlUsingRouter });
-  }, [parentVenueId, openUrlUsingRouter]);
 
   const navigateToHomepage = useCallback(() => {
     if (!sovereignVenueId) return;
@@ -303,10 +296,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
 
       {/* @debt Remove back button from Navbar */}
       {hasBackButton && currentVenue?.parentId && parentVenue?.name && (
-        <BackButton
-          onClick={backToParentVenue}
-          locationName={parentVenue.name}
-        />
+        <BackButton variant="relative" space={parentVenue} />
       )}
     </>
   );

--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -91,17 +91,18 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
   const spaceSlug = useSpaceParams();
   const { spaceId } = useSpaceBySlug(spaceSlug);
 
-  const roomVenueId = room?.url?.split("/").pop();
+  const spaceSlugFromPortal = room?.url?.split("/").pop();
+  const { spaceId: spaceIdFromPortal } = useSpaceBySlug(spaceSlugFromPortal);
 
   const {
     loading: isLoadingRoomVenue,
     error: fetchError,
     value: roomVenue,
   } = useAsync(async () => {
-    if (!roomVenueId) return;
+    if (!spaceIdFromPortal) return;
 
-    return await fetchVenue(roomVenueId);
-  }, [roomVenueId]);
+    return await fetchVenue(spaceIdFromPortal);
+  }, [spaceIdFromPortal]);
 
   const defaultValues = useMemo(
     () => ({
@@ -190,7 +191,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
   );
 
   const updateVenueRoom = useCallback(async () => {
-    if (!user || !roomVenueId) return;
+    if (!user || !spaceIdFromPortal) return;
 
     const embedUrl = convertToEmbeddableUrl({
       url: venueValues.iframeUrl,
@@ -199,14 +200,20 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
 
     await updateVenueNG(
       {
-        id: roomVenueId,
+        id: spaceIdFromPortal,
         worldId: roomVenue?.worldId,
         ...venueValues,
         iframeUrl: embedUrl || DEFAULT_EMBED_URL,
       },
       user
     );
-  }, [roomVenueId, user, venueValues, roomVenue?.autoPlay, roomVenue?.worldId]);
+  }, [
+    spaceIdFromPortal,
+    user,
+    venueValues,
+    roomVenue?.autoPlay,
+    roomVenue?.worldId,
+  ]);
 
   const [
     { loading: isUpdating, error: updateError },
@@ -265,11 +272,11 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
         ownedVenues
           .filter(
             ({ id, worldId }) =>
-              !(roomVenue?.worldId !== worldId || id === roomVenueId)
+              !(roomVenue?.worldId !== worldId || id === spaceIdFromPortal)
           )
           .map((venue) => [venue.id, venue])
       ),
-    [ownedVenues, roomVenue?.worldId, roomVenueId]
+    [ownedVenues, roomVenue?.worldId, spaceIdFromPortal]
   );
 
   const parentSpace = useMemo(

--- a/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
+++ b/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
@@ -82,13 +82,14 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
   const spaceSlug = useSpaceParams();
   const { spaceId } = useSpaceBySlug(spaceSlug);
 
-  const portalId = room?.url?.split("/").pop();
+  const spaceSlugFromPortal = room?.url?.split("/").pop();
+  const { spaceId: spaceIdFromPortal } = useSpaceBySlug(spaceSlugFromPortal);
 
   const { loading: isLoadingPortal, value: portal } = useAsync(async () => {
-    if (!portalId) return;
+    if (!spaceIdFromPortal) return;
 
-    return await fetchVenue(portalId);
-  }, [portalId]);
+    return await fetchVenue(spaceIdFromPortal);
+  }, [spaceIdFromPortal]);
 
   const defaultValues = useMemo(
     () => ({
@@ -141,7 +142,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
   );
 
   const updateVenueRoom = useCallback(async () => {
-    if (!user || !portalId) return;
+    if (!user || !spaceIdFromPortal) return;
 
     const embedUrl = convertToEmbeddableUrl({
       url: values.iframeUrl,
@@ -150,7 +151,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
 
     await updateVenueNG(
       {
-        id: portalId,
+        id: spaceIdFromPortal,
         iframeUrl: embedUrl || DEFAULT_EMBED_URL,
         autoPlay: values.autoPlay,
         bannerImageUrl: values.bannerImageUrl,
@@ -169,7 +170,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
     );
   }, [
     user,
-    portalId,
+    spaceIdFromPortal,
     values.iframeUrl,
     values.autoPlay,
     values.bannerImageUrl,
@@ -235,11 +236,11 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
         ownedVenues
           .filter(
             ({ id, worldId }) =>
-              !(portal?.worldId !== worldId || id === portalId)
+              !(portal?.worldId !== worldId || id === spaceIdFromPortal)
           )
           .map((venue) => [venue.id, venue])
       ),
-    [ownedVenues, portal?.worldId, portalId]
+    [ownedVenues, portal?.worldId, spaceIdFromPortal]
   );
 
   const parentSpace = useMemo(

--- a/src/components/templates/Auditorium/components/AllSectionPreviews/AllSectionPreviews.tsx
+++ b/src/components/templates/Auditorium/components/AllSectionPreviews/AllSectionPreviews.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { useRouteMatch } from "react-router";
-import { Redirect, useHistory } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import classNames from "classnames";
 import { sample } from "lodash";
 
@@ -13,7 +13,6 @@ import { AuditoriumVenue } from "types/venues";
 import { chooseAuditoriumSize } from "utils/auditorium";
 import { convertToEmbeddableUrl } from "utils/embeddableUrl";
 import { WithId } from "utils/id";
-import { enterVenue } from "utils/url";
 
 import { useAllAuditoriumSections } from "hooks/auditorium";
 import { useRelatedVenues } from "hooks/useRelatedVenues";
@@ -38,12 +37,10 @@ export const AllSectionPreviews: React.FC<SectionPreviewsProps> = ({
   venue,
 }) => {
   const match = useRouteMatch();
-  const { push: openUrlUsingRouter } = useHistory();
 
   const { parentVenue } = useRelatedVenues({
     currentVenueId: venue.id,
   });
-  const parentVenueId = parentVenue?.id;
 
   const {
     auditoriumSections,
@@ -84,12 +81,6 @@ export const AllSectionPreviews: React.FC<SectionPreviewsProps> = ({
     enterSection(randomSectionId);
   }, [enterSection, availableSectionIds]);
 
-  const backToParentVenue = useCallback(() => {
-    if (!parentVenueId) return;
-
-    enterVenue(parentVenueId, { customOpenRelativeUrl: openUrlUsingRouter });
-  }, [parentVenueId, openUrlUsingRouter]);
-
   const containerClasses = classNames(
     "AllSectionPreviews",
     `AllSectionPreviews--${auditoriumSize}`
@@ -101,12 +92,7 @@ export const AllSectionPreviews: React.FC<SectionPreviewsProps> = ({
 
   return (
     <>
-      {parentVenue && (
-        <BackButton
-          onClick={backToParentVenue}
-          locationName={parentVenue.name}
-        />
-      )}
+      {parentVenue && <BackButton variant="relative" space={parentVenue} />}
       <VenueWithOverlay venue={venue} containerClassNames="">
         <InfiniteScroll
           dataLength={auditoriumSections.length}

--- a/src/components/templates/Auditorium/components/Section/Section.tsx
+++ b/src/components/templates/Auditorium/components/Section/Section.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useParams } from "react-router";
-import { useHistory } from "react-router-dom";
 import { useCss } from "react-use";
 import classNames from "classnames";
 
@@ -9,7 +8,6 @@ import { DEFAULT_REACTIONS_AUDIBLE, DEFAULT_SECTIONS_AMOUNT } from "settings";
 import { AuditoriumVenue } from "types/venues";
 
 import { WithId } from "utils/id";
-import { enterVenue } from "utils/url";
 
 import { useAuditoriumGrid, useAuditoriumSection } from "hooks/auditorium";
 import { useAnalytics } from "hooks/useAnalytics";
@@ -51,17 +49,10 @@ export const Section: React.FC<SectionProps> = ({ venue }) => {
   const { parentVenue } = useRelatedVenues({
     currentVenueId: venue.id,
   });
-  const parentVenueId = parentVenue?.id;
 
   const isUserAudioMuted = !isUserAudioOn;
-
   const { iframeUrl, id: venueId } = venue;
-
   const { sectionId } = useParams<{ sectionId: string }>();
-  const {
-    push: openUrlUsingRouter,
-    replace: replaceUrlUsingRouter,
-  } = useHistory();
 
   const {
     auditoriumSection,
@@ -141,24 +132,7 @@ export const Section: React.FC<SectionProps> = ({ venue }) => {
     );
   };
 
-  const backToMain = useCallback(() => {
-    if (!venueId) return;
-
-    if (hasOnlyOneSection && parentVenueId) {
-      return enterVenue(parentVenueId, {
-        // NOTE: Replace URL here to get rid of /section/sectionId in the URL
-        customOpenExternalUrl: replaceUrlUsingRouter,
-      });
-    }
-
-    enterVenue(venueId, { customOpenRelativeUrl: openUrlUsingRouter });
-  }, [
-    venueId,
-    openUrlUsingRouter,
-    replaceUrlUsingRouter,
-    hasOnlyOneSection,
-    parentVenueId,
-  ]);
+  const isSimpleBackButton = hasOnlyOneSection && parentVenue;
 
   if (!isAuditoriumSectionLoaded) {
     return <Loading label="Loading section data" />;
@@ -168,12 +142,16 @@ export const Section: React.FC<SectionProps> = ({ venue }) => {
 
   return (
     <VenueWithOverlay venue={venue} containerClassNames="Section">
-      <BackButton
-        onClick={backToMain}
-        locationName={
-          hasOnlyOneSection && parentVenue ? parentVenue.name : "overview"
-        }
-      />
+      {isSimpleBackButton ? (
+        <BackButton
+          variant="external"
+          space={parentVenue}
+          locationName={parentVenue?.name}
+        />
+      ) : (
+        <BackButton variant="relative" space={venue} locationName="overview" />
+      )}
+
       <div className="Section__seats">
         <div className="Section__central-screen-overlay">
           <div className={centralScreenClasses}>

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { ALWAYS_EMPTY_ARRAY } from "settings";
 
 import { GenericVenue, VenueTemplate } from "types/venues";
 
 import { WithId } from "utils/id";
-import { openUrl, venueInsideUrl } from "utils/url";
 
 import { useAnalytics } from "hooks/useAnalytics";
 import { useExperiences } from "hooks/useExperiences";
@@ -62,13 +61,6 @@ export const ConversationSpace: React.FC<ConversationSpaceProps> = ({
 
   useExperiences(venue?.name);
 
-  // @debt This logic is a copy paste from NavBar. Move that into a separate Back button component
-  const backToParentVenue = useCallback(() => {
-    if (!parentVenueId) return;
-
-    openUrl(venueInsideUrl(parentVenueId));
-  }, [parentVenueId]);
-
   const tables = venue?.config?.tables ?? TABLES;
 
   return (
@@ -88,10 +80,7 @@ export const ConversationSpace: React.FC<ConversationSpaceProps> = ({
       </InformationLeftColumn>
       <VenueWithOverlay venue={venue} containerClassNames="conversation-space">
         {!seatedAtTable && parentVenueId && parentVenue && (
-          <BackButton
-            onClick={backToParentVenue}
-            locationName={parentVenue.name}
-          />
+          <BackButton variant="simple" space={parentVenue} />
         )}
         <div className={`scrollable-area ${seatedAtTable && "at-table"}`}>
           {venue.description?.text && (

--- a/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
+++ b/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 
 import {
@@ -13,7 +13,6 @@ import { JazzbarVenue, VenueTemplate } from "types/venues";
 
 import { convertToEmbeddableUrl } from "utils/embeddableUrl";
 import { WithId } from "utils/id";
-import { openUrl, venueInsideUrl } from "utils/url";
 
 import { useAnalytics } from "hooks/useAnalytics";
 import { useExperiences } from "hooks/useExperiences";
@@ -52,20 +51,12 @@ export const JazzBar: React.FC<JazzProps> = ({ venue }) => {
   } = useShowHide();
   const { parentVenue } = useRelatedVenues({ currentVenueId: venue.id });
   const { isLoaded: areSettingsLoaded, settings } = useSettings();
-  const parentVenueId = parentVenue?.id;
   const embedIframeUrl = convertToEmbeddableUrl({
     url: venue.iframeUrl,
     autoPlay: venue.autoPlay,
   });
   const [iframeUrl, setIframeUrl] = useState(embedIframeUrl);
   const analytics = useAnalytics({ venue });
-
-  // @debt This logic is a copy paste from NavBar. Move that into a separate Back button component
-  const backToParentVenue = useCallback(() => {
-    if (!parentVenueId) return;
-
-    openUrl(venueInsideUrl(parentVenueId));
-  }, [parentVenueId]);
 
   useExperiences(venue.name);
 
@@ -136,10 +127,7 @@ export const JazzBar: React.FC<JazzProps> = ({ venue }) => {
         containerClassNames={`music-bar ${containerClasses}`}
       >
         {!seatedAtTable && parentVenue && (
-          <BackButton
-            onClick={backToParentVenue}
-            locationName={parentVenue.name}
-          />
+          <BackButton variant="simple" space={parentVenue} />
         )}
 
         {!seatedAtTable && (


### PR DESCRIPTION
Resolves 
- https://github.com/sparkletown/internal-sparkle-issues/issues/1487

by refactor of `<BackButton>` so it
- doesn't show up in admin context
- uses the proper slug to go back
- compiles 3 different modes of going back from parent components via its new `variant` prop

Bonus:
- fix for space slug -> space id read from portal URLs in order to test Auditorium back button

![sparkle-back-button-02](https://user-images.githubusercontent.com/79229621/143260530-45124c70-c5aa-464d-a3d6-b39c2e382776.png)
![sparkle-back-button-01](https://user-images.githubusercontent.com/79229621/143260533-1b7504ef-2f46-4ca0-b218-09ba88bb6b4a.png)
