### PR TITLE
Stop showing the horizontal scrollbar on the room modal

### DIFF
--- a/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
+++ b/src/components/templates/PartyMap/components/RoomModal/RoomModal.scss
@@ -79,6 +79,7 @@ $spacing: 20px;
 
   &__events {
     max-height: 35vh;
+    overflow-x: hidden;
     overflow-y: auto;
     // @debt these overrides are here because ScheduleItem sets incompatible margins/etc.
     //   We should just clean it up there instead.


### PR DESCRIPTION
**AV1 only**

Resolves #1505

No horizontal scrollbar anymore:
![image](https://user-images.githubusercontent.com/88904/143458983-be478833-5c49-4c93-9c31-8fb0dd4de09c.png)
