### PR TITLE
Use shouldScheduleBeShown() everywhere to have same check

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -5,14 +5,11 @@ import { faHome, faTicketAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import firebase from "firebase/app";
 
-import {
-  DEFAULT_SHOW_SCHEDULE,
-  PLAYA_VENUE_ID,
-  SPARKLE_PHOTOBOOTH_URL,
-} from "settings";
+import { PLAYA_VENUE_ID, SPARKLE_PHOTOBOOTH_URL } from "settings";
 
 import { UpcomingEvent } from "types/UpcomingEvent";
 
+import { shouldScheduleBeShown } from "utils/schedule";
 import { enterVenue, venueInsideUrl } from "utils/url";
 
 import { useSpaceBySlug } from "hooks/spaces/useSpaceBySlug";
@@ -108,9 +105,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
   }, [openUserProfileModal, userWithId]);
 
   const shouldShowSchedule =
-    !isAdminContext &&
-    withSchedule &&
-    (world?.showSchedule ?? DEFAULT_SHOW_SCHEDULE);
+    !isAdminContext && withSchedule && shouldScheduleBeShown(world);
 
   const isOnPlaya = pathname.toLowerCase() === venueInsideUrl(PLAYA_VENUE_ID);
 

--- a/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
+++ b/src/components/organisms/WorldAdvancedForm/WorldAdvancedForm.tsx
@@ -4,14 +4,13 @@ import { useForm } from "react-hook-form";
 import { useAsyncFn } from "react-use";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 
-import { DEFAULT_SHOW_SCHEDULE } from "settings";
-
 import { updateWorldAdvancedSettings, World } from "api/world";
 
 import { UserStatus } from "types/User";
 import { WorldAdvancedFormInput } from "types/world";
 
 import { WithId, withId } from "utils/id";
+import { shouldScheduleBeShown } from "utils/schedule";
 
 import { emptyObjectSchema } from "forms/emptyObjectSchema";
 
@@ -62,7 +61,7 @@ export const WorldAdvancedForm: React.FC<WorldAdvancedFormProps> = ({
       radioStation: world.radioStations?.[0],
       showBadges: world.showBadges,
       showRadio: world.showRadio,
-      showSchedule: world.showSchedule ?? DEFAULT_SHOW_SCHEDULE,
+      showSchedule: shouldScheduleBeShown(world),
       showUserStatus: world.showUserStatus,
       userStatuses: userStatuses,
     }),

--- a/src/components/templates/PartyMap/components/PortalModal/PortalModal.tsx
+++ b/src/components/templates/PartyMap/components/PortalModal/PortalModal.tsx
@@ -10,6 +10,7 @@ import { Room, RoomType } from "types/rooms";
 import { AnyVenue, VenueEvent } from "types/venues";
 
 import { WithId, WithVenueId } from "utils/id";
+import { shouldScheduleBeShown } from "utils/schedule";
 import { isExternalPortal, openUrl } from "utils/url";
 
 import { useCustomSound } from "hooks/sounds";
@@ -134,7 +135,8 @@ export const PortalModalContent: React.FC<PortalModalContentProps> = ({
     void (isExternalPortal(portal) ? openUrl(portal.url) : enterWithSound());
   }, [analytics, enterWithSound, portal]);
 
-  const showPortalEvents = world?.showSchedule && venueEvents.length > 0;
+  const showPortalEvents =
+    shouldScheduleBeShown(world) && venueEvents.length > 0;
 
   const iconStyles = {
     backgroundImage: portal.image_url ? `url(${portal.image_url})` : undefined,

--- a/src/components/templates/PartyMap/components/index.ts
+++ b/src/components/templates/PartyMap/components/index.ts
@@ -1,3 +1,4 @@
+// @debt these components should be exported by index.ts inside their respective directories
 export { Map } from "./Map/Map";
 export { PartyTitle } from "./PartyTitle/PartyTitle";
 export { RoomAttendance } from "./RoomAttendance";

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,3 +1,7 @@
+import { DEFAULT_SHOW_SCHEDULE } from "settings";
+
+import { World } from "api/world";
+
 import { LocationEvents } from "types/venues";
 
 export const sortScheduleRoomsAlphabetically = (rooms: LocationEvents[]) => {
@@ -10,3 +14,6 @@ export const sortScheduleRoomsAlphabetically = (rooms: LocationEvents[]) => {
     return nameA.localeCompare(nameB);
   });
 };
+
+export const shouldScheduleBeShown = (world?: World) =>
+  world?.showSchedule ?? DEFAULT_SHOW_SCHEDULE;


### PR DESCRIPTION
Resolves
- https://github.com/sparkletown/internal-sparkle-issues/issues/1475

by making a single check `shouldScheduleBeShown()` everywhere that factors in `DEFAULT_SHOW_SCHEDULE` if the world or the value for `showSchedule` is missing.