### PR TITLE
replaced venue id with spaceslug param

### DIFF
--- a/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
+++ b/src/components/organisms/AuthenticationModal/RegisterForm/RegisterForm.tsx
@@ -164,7 +164,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
       postRegisterCheck(auth, data);
 
       const accountProfileUrl = `/account/profile${
-        spaceId ? `?venueId=${spaceId}` : ""
+        spaceId ? `?spaceSlug=${spaceId}` : ""
       }`;
 
       history.push(accountProfileUrl);


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1286

Fixed an issue with hardcoded redirect to `bootstrap` venue since `spaceSlug` was missing from the url params for new registration url

Fixed by replacing here:
![image](https://user-images.githubusercontent.com/56254806/143895118-e3cd0c9f-d717-43e8-8c43-1cab332b19bb.png)

`venueId` replaced by `spaceSlug` in the url params: 

Code of conduct questions:
![image](https://user-images.githubusercontent.com/56254806/143894730-3505f360-aa3c-431f-9c8e-f09fd51004df.png)

`venueId` replaced by `spaceSlug` in the url params: 
![image](https://user-images.githubusercontent.com/56254806/143894815-a4e2ac13-423d-45a8-89bb-ecd8fea4d0af.png)
