### PR TITLE
fixed admin space card edit link + cover image url as background

### DIFF
--- a/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
+++ b/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
@@ -30,9 +30,13 @@ export interface AdminSpaceCardProps {
   worldSlug?: string;
 }
 
-export const AdminSpaceCard: React.FC<AdminSpaceCardProps> = ({ venue }) => {
+export const AdminSpaceCard: React.FC<AdminSpaceCardProps> = ({
+  venue,
+  worldSlug,
+}) => {
   const [validBannerImageUrl] = useValidImage(
-    venue?.config?.landingPageConfig.bannerImageUrl,
+    venue?.config?.landingPageConfig.coverImageUrl ||
+      venue?.config?.landingPageConfig.bannerImageUrl,
     DEFAULT_VENUE_BANNER_COLOR
   );
 
@@ -106,7 +110,10 @@ export const AdminSpaceCard: React.FC<AdminSpaceCardProps> = ({ venue }) => {
               {spaceDescriptionText}
             </span>
           </div>
-          <ButtonNG linkTo={adminNGVenueUrl(venue.slug)} disabled={!venue.slug}>
+          <ButtonNG
+            linkTo={adminNGVenueUrl(worldSlug, venue.slug)}
+            disabled={!venue.slug}
+          >
             Edit
           </ButtonNG>
         </div>


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1468

Fixed admin space card 'Edit' link url
Set `coverImageUrl` as a background url option

Fixes issues found during QA: https://github.com/sparkletown/internal-sparkle-issues/issues/1468#issuecomment-982558516