### PR TITLE
Fix for using slug instead of ID when upserting a portal

### DIFF
--- a/src/components/molecules/PortalAddModal/PortalAddModal.tsx
+++ b/src/components/molecules/PortalAddModal/PortalAddModal.tsx
@@ -20,6 +20,7 @@ import { buildEmptyVenue } from "utils/venue";
 import { createPortalSchema } from "forms/createPortalSchema";
 import { createSpaceSchema } from "forms/createSpaceSchema";
 
+import { useSpaceBySlug } from "hooks/spaces/useSpaceBySlug";
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
 import { useCheckImage } from "hooks/useCheckImage";
 import { useUser } from "hooks/useUser";
@@ -48,6 +49,7 @@ export const PortalAddModal: React.FC<PortalAddModalProps> = ({
   const { user } = useUser();
   const { spaceSlug, worldSlug } = useSpaceParams();
   const { worldId } = useWorldBySlug(worldSlug);
+  const { spaceId } = useSpaceBySlug(spaceSlug);
 
   const { register, getValues, handleSubmit, errors } = useForm({
     validationSchema:
@@ -64,7 +66,7 @@ export const PortalAddModal: React.FC<PortalAddModalProps> = ({
     { loading: isLoading, error: submitError },
     addPortal,
   ] = useAsyncFn(async () => {
-    if (!user || !spaceSlug || !template || !worldId) return;
+    if (!user || !spaceSlug || !template || !worldId || !spaceId) return;
 
     const { roomUrl, venueName } = getValues();
 
@@ -96,10 +98,9 @@ export const PortalAddModal: React.FC<PortalAddModalProps> = ({
       );
     }
 
-    // @debt this is wrong, for all intents and purposes the venueId a.k.a spaceId is the identifier of the parent space
-    await createRoom(portalData, spaceSlug, user);
+    await createRoom(portalData, spaceId, user);
     await onHide();
-  }, [getValues, worldId, onHide, icon, template, user, spaceSlug]);
+  }, [getValues, worldId, onHide, icon, template, user, spaceSlug, spaceId]);
 
   const { isValid: isPosterValid } = useCheckImage(poster);
 


### PR DESCRIPTION
In some cases the ID of the venue is not the same as the slug and this prevents a portal from being successfully created.