### PR TITLE
Do not replace 'parent' param value with 'localhost' in twitch URLs

### DIFF
--- a/src/utils/embeddableUrl.ts
+++ b/src/utils/embeddableUrl.ts
@@ -79,7 +79,6 @@ const convertTwitchUrl: (options: ConvertTwitchUrlOptions) => string = ({
   }
 
   withParameters(twitchUrl, urlParameters);
-  twitchUrl.searchParams.set("parent", "localhost");
 
   return twitchUrl.href;
 };


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1472