### PR TITLE
Fix Admin scrollbar issues

### DIFF
--- a/src/components/organisms/AdminVenueView/AdminVenueView.tsx
+++ b/src/components/organisms/AdminVenueView/AdminVenueView.tsx
@@ -117,7 +117,7 @@ export const AdminVenueView: React.FC = () => {
   }
 
   return (
-    <WithNavigationBar withSchedule>
+    <WithNavigationBar withSchedule variant="internal-scroll">
       <AdminRestricted>
         <div className="AdminVenueView">
           <AdminTitleBar>

--- a/src/components/organisms/AdminVenueView/components/AdminPanel/AdminPanel.scss
+++ b/src/components/organisms/AdminVenueView/components/AdminPanel/AdminPanel.scss
@@ -1,8 +1,14 @@
 @import "scss/constants";
 
 .AdminPanel {
-  height: $admin-ng-panel-height;
-  overflow: hidden;
+  &--bound {
+    height: $admin-ng-panel-height;
+    overflow: hidden;
+  }
+
+  &--unbound {
+    display: flex;
+  }
 
   @media (max-width: $media-breakpoint--lg) {
     align-items: center;

--- a/src/components/organisms/AdminVenueView/components/AdminPanel/AdminPanel.tsx
+++ b/src/components/organisms/AdminVenueView/components/AdminPanel/AdminPanel.tsx
@@ -5,12 +5,18 @@ import "./AdminPanel.scss";
 
 export interface AdminPanelProps {
   className?: string;
+  variant: "bound" | "unbound";
 }
 
 export const AdminPanel: React.FC<AdminPanelProps> = ({
   className,
   children,
+  variant,
 }) => {
-  const containerClasses = classNames("AdminPanel", className);
+  const containerClasses = classNames(
+    "AdminPanel",
+    className,
+    `AdminPanel--${variant ?? "bound"}`
+  );
   return <div className={containerClasses}>{children}</div>;
 };

--- a/src/components/organisms/AdminVenueView/components/AdminShowcase/AdminShowcase.scss
+++ b/src/components/organisms/AdminVenueView/components/AdminShowcase/AdminShowcase.scss
@@ -1,7 +1,10 @@
 @import "scss/constants";
 
 .AdminShowcase {
-  height: $admin-ng-panel-height;
   width: $admin-ng-showcase-width--normal;
-  overflow: auto;
+
+  &--internal-scroll {
+    height: $admin-ng-panel-height;
+    overflow: auto;
+  }
 }

--- a/src/components/organisms/AdminVenueView/components/AdminShowcase/AdminShowcase.tsx
+++ b/src/components/organisms/AdminVenueView/components/AdminShowcase/AdminShowcase.tsx
@@ -3,14 +3,20 @@ import classNames from "classnames";
 
 import "./AdminShowcase.scss";
 
-export interface AdminPanelProps {
+export interface AdminShowcaseProps {
   className?: string;
+  variant?: "internal-scroll" | "no-scroll";
 }
 
-export const AdminShowcase: React.FC<AdminPanelProps> = ({
+export const AdminShowcase: React.FC<AdminShowcaseProps> = ({
   className,
+  variant = "internal-scroll",
   children,
 }) => {
-  const containerClasses = classNames("AdminShowcase", className);
+  const containerClasses = classNames(
+    "AdminShowcase",
+    className,
+    `AdminShowcase--${variant}`
+  );
   return <div className={containerClasses}>{children}</div>;
 };

--- a/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
+++ b/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
@@ -36,7 +36,7 @@ export const RunTabView: React.FC<RunTabViewProps> = ({ venue }) => {
   const venueId = venue.id;
 
   return (
-    <AdminPanel className="RunTabView">
+    <AdminPanel variant="unbound" className="RunTabView">
       <AdminSidebar>
         <AdminSidebarTitle>Run your {SPACE_TAXON.lower}</AdminSidebarTitle>
         <div className="RunTabView__content">
@@ -51,7 +51,7 @@ export const RunTabView: React.FC<RunTabViewProps> = ({ venue }) => {
           <RunTabUsers venueId={venueId} />
         </div>
       </AdminSidebar>
-      <AdminShowcase className="RunTabView__main">
+      <AdminShowcase className="RunTabView__main" variant="no-scroll">
         <div className="RunTabView__toolbar RunTabView--spacing">
           <RunTabToolbar
             venueId={venueId}

--- a/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.tsx
+++ b/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.tsx
@@ -21,7 +21,7 @@ export interface SpaceTimingPanelProps {
 export const SpaceTimingPanel: React.FC<SpaceTimingPanelProps> = ({
   venue,
 }) => (
-  <AdminPanel className="SpaceTimingPanel">
+  <AdminPanel variant="bound" className="SpaceTimingPanel">
     <AdminSidebar>
       <AdminSidebarTitle>Plan your event</AdminSidebarTitle>
       <SpaceTimingForm venue={venue} />

--- a/src/components/organisms/AdminVenueView/components/Spaces/Spaces.tsx
+++ b/src/components/organisms/AdminVenueView/components/Spaces/Spaces.tsx
@@ -123,7 +123,7 @@ export const Spaces: React.FC<SpacesProps> = ({ venue }) => {
   ]);
 
   return (
-    <AdminPanel className="Spaces">
+    <AdminPanel variant="bound" className="Spaces">
       <AdminSidebar>
         {renderSpaceEditForm()}
         {!selectedRoom && (

--- a/src/components/organisms/WithNavigationBar/WithNavigationBar.scss
+++ b/src/components/organisms/WithNavigationBar/WithNavigationBar.scss
@@ -1,8 +1,26 @@
 @import "scss/constants.scss";
 
-.navbar-margin {
-  height: 100%;
+.WithNavigationBar {
+  &__wrapper {
+    height: 100%;
 
-  padding-top: $navbar-height;
-  padding-bottom: $footer-height;
+    padding-top: $navbar-height;
+    padding-bottom: $footer-height;
+  }
+
+  &__wrapper--internal-scroll,
+  &__slider--internal-scroll {
+    margin: 0;
+    padding: 0;
+  }
+
+  &__wrapper--internal-scroll {
+    height: calc(100% - #{$reserved-page-height});
+
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    margin-top: $navbar-height;
+    margin-bottom: $footer-height;
+  }
 }

--- a/src/components/organisms/WithNavigationBar/WithNavigationBar.tsx
+++ b/src/components/organisms/WithNavigationBar/WithNavigationBar.tsx
@@ -28,6 +28,7 @@ export interface WithNavigationBarProps {
   withPhotobooth?: boolean;
   withHiddenLoginButton?: boolean;
   title?: string;
+  variant?: "internal-scroll";
 }
 
 export const WithNavigationBar: React.FC<WithNavigationBarProps> = ({
@@ -37,6 +38,7 @@ export const WithNavigationBar: React.FC<WithNavigationBarProps> = ({
   withHiddenLoginButton,
   withRadio,
   title,
+  variant,
   children,
 }) => {
   const { spaceSlug } = useSpaceParams();
@@ -63,7 +65,15 @@ export const WithNavigationBar: React.FC<WithNavigationBarProps> = ({
         </Suspense>
       </RelatedVenuesProvider>
 
-      <div className="navbar-margin">{children}</div>
+      {variant === "internal-scroll" ? (
+        <div className="WithNavigationBar__wrapper WithNavigationBar__wrapper--internal-scroll">
+          <div className="WithNavigationBar__slider WithNavigationBar__slider--internal-scroll">
+            {children}
+          </div>
+        </div>
+      ) : (
+        <div className="WithNavigationBar__wrapper">{children}</div>
+      )}
 
       <Footer />
       <NewProfileModal venue={space} />

--- a/src/pages/Admin/Details/SpaceEditorStartPanel.tsx
+++ b/src/pages/Admin/Details/SpaceEditorStartPanel.tsx
@@ -15,7 +15,7 @@ export const SpaceEditorStartPanel: React.FC<DetailsProps> = ({
   worldId,
 }) => {
   return (
-    <AdminPanel className="SpaceEditorStartPanel">
+    <AdminPanel variant="bound" className="SpaceEditorStartPanel">
       <AdminSidebar>
         <DetailsForm venue={venue} worldId={worldId} />
       </AdminSidebar>

--- a/src/pages/SpacesDashboard/SpacesDashboard.scss
+++ b/src/pages/SpacesDashboard/SpacesDashboard.scss
@@ -3,7 +3,7 @@
 .SpacesDashboard {
   width: 100%;
   height: 100vh;
-  padding: $spacing--lg;
+  padding: 0;
 
   position: relative;
   overflow-y: scroll;
@@ -16,7 +16,7 @@
   &__aside {
     display: flex;
     flex-direction: column;
-    align-items: end;
+    align-items: flex-end;
     padding-right: $button-width--max-margin;
   }
 

--- a/src/pages/SpacesDashboard/SpacesDashboard.tsx
+++ b/src/pages/SpacesDashboard/SpacesDashboard.tsx
@@ -77,7 +77,7 @@ export const SpacesDashboard: React.FC = () => {
 
   return (
     <div className="SpacesDashboard">
-      <WithNavigationBar>
+      <WithNavigationBar variant="internal-scroll">
         <AdminRestricted>
           <AdminTitleBar>
             <ButtonNG

--- a/src/pages/WorldEditor/WorldEditorAdvancedPanel.tsx
+++ b/src/pages/WorldEditor/WorldEditorAdvancedPanel.tsx
@@ -22,7 +22,7 @@ export const WorldEditorAdvancedPanel: React.FC<WorldEditorAdvancedPanelProps> =
 }) => {
   const { isLoaded, world } = useWorldBySlug(worldSlug);
   return (
-    <AdminPanel>
+    <AdminPanel variant="bound">
       <AdminSidebar>
         <AdminSidebarTitle>Advanced Settings: {world?.name}</AdminSidebarTitle>
         <AdminSidebarFooter onClickHome={onClickHome} />

--- a/src/pages/WorldEditor/WorldEditorEntrancePanel.tsx
+++ b/src/pages/WorldEditor/WorldEditorEntrancePanel.tsx
@@ -23,7 +23,7 @@ export const WorldEditorEntrancePanel: React.FC<WorldEditorEntrancePanelProps> =
   const { isLoaded, world } = useWorldBySlug(worldSlug);
 
   return (
-    <AdminPanel>
+    <AdminPanel variant="bound">
       <AdminSidebar>
         <AdminSidebarTitle>Entrance Experience</AdminSidebarTitle>
         <AdminSidebarFooter onClickHome={onClickHome} />

--- a/src/pages/WorldEditor/WorldEditorStartPanel.tsx
+++ b/src/pages/WorldEditor/WorldEditorStartPanel.tsx
@@ -29,7 +29,7 @@ export const WorldEditorStartPanel: React.FC<WorldEditorStartPanelProps> = ({
   const isCreatingWorld = isLoaded && !world && !worldSlug;
 
   return (
-    <AdminPanel>
+    <AdminPanel variant="bound">
       <AdminSidebar>
         <AdminSidebarTitle>
           {worldSlug ? "Configure your world" : "Create a new world"}

--- a/src/pages/WorldsDashboard/WorldsDashboard.tsx
+++ b/src/pages/WorldsDashboard/WorldsDashboard.tsx
@@ -58,7 +58,7 @@ export const WorldsDashboard: React.FC = () => {
         <AdminRestricted>
           {hasWorlds ? (
             <>
-              <AdminPanel>
+              <AdminPanel variant="bound">
                 <AdminSidebar>
                   <AdminSidebarTitle>
                     Select or create a world to get started


### PR DESCRIPTION
Some views in Admin have scrollbar issues.

1 Cutting off to certain elements when scrolled all the way down (now no more of that):

![sparkle-admin-scrolls-01](https://user-images.githubusercontent.com/79229621/144277967-39a4f690-ab09-43a5-b4f9-e078cf55430d.png)

2. Double scrollbars (now only a single one displayed):

![sparkle-admin-scrolls-02](https://user-images.githubusercontent.com/79229621/144278128-1a9373a9-46ba-4fb0-964f-a65f39b1b518.png)
