### PR TITLE
Pin firebase preview build to node 14

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -39,6 +39,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Build app
         run: |
           npm ci


### PR DESCRIPTION
Github updated all node builds to node 16. This is causing some package issues. Pinning back to 14 until we can investigate more completely.

As a side note, we're using a really old version of firebase tools. 8.6.0. Latest is 9.23.0