### PR TITLE
disable photobooth feature

### DIFF
--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -5,7 +5,11 @@ import { faTicketAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import firebase from "firebase/app";
 
-import { PLAYA_VENUE_ID, SPARKLE_PHOTOBOOTH_URL } from "settings";
+import {
+  DISABLED_DUE_TO_1142,
+  PLAYA_VENUE_ID,
+  SPARKLE_PHOTOBOOTH_URL,
+} from "settings";
 
 import { UpcomingEvent } from "types/UpcomingEvent";
 
@@ -211,7 +215,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
               )}
             </div>
 
-            {withPhotobooth && (
+            {!DISABLED_DUE_TO_1142 && withPhotobooth && (
               <div
                 className="NavBar__photobooth-button nav-schedule"
                 onClick={handlePhotoboothRedirect}

--- a/src/settings/disableSettings.ts
+++ b/src/settings/disableSettings.ts
@@ -14,3 +14,9 @@ export const DISABLED_DUE_TO_1253 = true;
  * @see https://github.com/sparkletown/internal-sparkle-issues/issues/1324
  */
 export const DISABLED_DUE_TO_1324 = true;
+
+/**
+ * Disables Photobooth feature
+ * @see https://github.com/sparkletown/internal-sparkle-issues/issues/1142
+ */
+export const DISABLED_DUE_TO_1142 = true;


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1142

Disables `photobooth` feature at staging using `DISABLED_DUE_TO_1142` constant

Created as a follow up for https://github.com/sparkletown/sparkle/pull/2392

