### PR TITLE
Make AdminSpaceCard border visible compared to the background

### DIFF
--- a/src/components/molecules/AdminSpaceCard/AdminSpaceCard.scss
+++ b/src/components/molecules/AdminSpaceCard/AdminSpaceCard.scss
@@ -14,11 +14,11 @@ $admin-space-card-description-height: 100px;
   display: flex;
   justify-content: flex-end;
   flex-direction: column;
-  border: none;
   border-radius: $border-radius--xl;
   gap: font-size--root(0.5);
   max-height: 3 * $admin-space-card-bg-height;
-  box-shadow: $admin-ng-space-card-box-shadow;
+  border: none;
+  box-shadow: box-shadow--card(var(--content--over-20a));
 
   &__bg {
     width: 100%;

--- a/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
+++ b/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
@@ -111,7 +111,11 @@ export const AdminSpaceCard: React.FC<AdminSpaceCardProps> = ({
             </span>
           </div>
           <ButtonNG
-            linkTo={adminNGVenueUrl(worldSlug, venue.slug)}
+            linkTo={
+              worldSlug && venue.slug
+                ? adminNGVenueUrl(worldSlug, venue.slug)
+                : "#"
+            }
             disabled={!venue.slug}
           >
             Edit

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -188,7 +188,6 @@ $admin-ng-tab-bar-height: calc(2rem + #{$spacing--sm});
 $admin-ng-panel-height: calc(
   100vh - #{$admin-ng-tab-bar-height} - #{$reserved-page-height}
 );
-$admin-ng-space-card-box-shadow: 0px 2px 4px rgba(58, 92, 144, 0.14);
 
 $admin-ia-dash-template-columns: 5fr minmax(#{$button-width--max-wrap}, 1fr);
 $admin-ia-manage-space-template-columns: 5fr
@@ -312,6 +311,10 @@ $z-layers: (
 
 @function box-shadow--input($color) {
   @return 0 0 0 2px $color;
+}
+
+@function box-shadow--card($color) {
+  @return 0 2px 4px $color;
 }
 
 @function box-shadow--small($color) {


### PR DESCRIPTION
Not actually the border, but a tweak to the `box-shadow` color to be `--content--over-20a` so it contrasts the background which has `--content--under`.

Also, a fix for the time before `worldSlug` is loaded, the edit links are just `#`.

**Before**:

![sparkle-before-01](https://user-images.githubusercontent.com/79229621/144449243-40dd1f1f-f991-4daa-9944-5a0b84b86bdc.png)

**After**:

![sparkle-after-01](https://user-images.githubusercontent.com/79229621/144449517-6da7850c-2293-4fce-b635-d282938461a8.png)
