### PR TITLE
fixed parent space icon + update properties

### DIFF
--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
@@ -16,11 +16,10 @@ import "./SpacesDropdown.scss";
 
 const noneOptionName = "None";
 const spaceNoneOption = Object.freeze({
-  none: Object.freeze({ name: "", template: undefined }),
+  none: Object.freeze({ slug: "", template: undefined }),
 });
 
-export type SpacesDropdownPortal = { template?: PortalTemplate; name: string };
-
+export type SpacesDropdownPortal = { template?: PortalTemplate; slug: string };
 export interface DropdownRoom extends Room {
   name: string;
 }
@@ -60,26 +59,26 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
 
   const renderedOptions = useMemo(
     () =>
-      Object.values(portalOptions).map(({ name, template }) => {
+      Object.values(portalOptions).map(({ slug, template }) => {
         const spaceIcon = PORTAL_INFO_ICON_MAPPING[template ?? ""];
 
         return (
           <ReactBootstrapDropdown.Item
-            key={name}
+            key={slug}
             onClick={() => {
-              setSelected({ name, template });
-              setValue(fieldName, name, true);
+              setSelected({ slug, template });
+              setValue(fieldName, slug, true);
             }}
             className="SpacesDropdown__item"
           >
-            {name !== spaceNoneOption.none.name ? (
+            {slug !== spaceNoneOption.none.slug ? (
               <img
                 alt={`space-icon-${spaceIcon}`}
                 src={spaceIcon}
                 className="SpacesDropdown__item-icon"
               />
             ) : null}
-            {name || noneOptionName}
+            {slug || noneOptionName}
           </ReactBootstrapDropdown.Item>
         );
       }) ?? [],
@@ -91,20 +90,20 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
       return "Select a space";
     }
 
-    const space = portals?.[selected.name] ?? parentSpace;
+    const space = portals?.[selected.slug] ?? parentSpace;
 
     const spaceIcon = PORTAL_INFO_ICON_MAPPING[space?.template ?? ""];
 
     return (
       <span className="SpacesDropdown__value">
-        {selected.name !== spaceNoneOption.none.name ? (
+        {selected.slug !== spaceNoneOption.none.slug ? (
           <img
             alt={`space-icon-${spaceIcon}`}
             src={spaceIcon}
             className="SpacesDropdown__item-icon"
           />
         ) : null}
-        {selected.name || noneOptionName}
+        {selected.slug || noneOptionName}
       </span>
     );
   }, [portals, selected, parentSpace]);

--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -285,7 +285,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
             ({ id, worldId }) =>
               !(roomVenue?.worldId !== worldId || id === spaceIdFromPortal)
           )
-          .map((venue) => [venue.id, venue])
+          .map((venue) => [venue.slug, venue])
       ),
     [ownedVenues, roomVenue?.worldId, spaceIdFromPortal]
   );
@@ -293,8 +293,8 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
   const parentSpace = useMemo(
     () =>
       roomVenue?.parentId
-        ? ownedVenues.find(({ id }) => id === roomVenue?.parentId)
-        : { name: "" },
+        ? ownedVenues.find(({ slug }) => slug === roomVenue?.parentId)
+        : { slug: "" },
     [ownedVenues, roomVenue?.parentId]
   );
 

--- a/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
+++ b/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
@@ -238,7 +238,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
             ({ id, worldId }) =>
               !(portal?.worldId !== worldId || id === spaceIdFromPortal)
           )
-          .map((venue) => [venue.id, venue])
+          .map((venue) => [venue.slug, venue])
       ),
     [ownedVenues, portal?.worldId, spaceIdFromPortal]
   );
@@ -246,8 +246,8 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
   const parentSpace = useMemo(
     () =>
       portal?.parentId
-        ? ownedVenues.find(({ id }) => id === portal?.parentId)
-        : { name: "" },
+        ? ownedVenues.find(({ slug }) => slug === portal?.parentId)
+        : { slug: "" },
     [portal?.parentId, ownedVenues]
   );
 

--- a/src/components/organisms/TimingEventModal/TimingEventModal.tsx
+++ b/src/components/organisms/TimingEventModal/TimingEventModal.tsx
@@ -116,7 +116,7 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
       Object.fromEntries(
         venue?.rooms?.map((room) => [
           room.title,
-          { ...room, name: room.title },
+          { ...room, name: room.title, slug: room.title },
         ]) ?? ALWAYS_EMPTY_ARRAY
       ),
     [venue?.rooms]
@@ -128,7 +128,7 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
   );
 
   const parentSpace = {
-    name: parentRoom?.title ?? venue.name,
+    slug: parentRoom?.title ?? venue.slug,
     template: parentRoom?.template ?? venue.template,
   };
 

--- a/src/pages/Admin/Details/Form/DetailsForm.tsx
+++ b/src/pages/Admin/Details/Form/DetailsForm.tsx
@@ -295,7 +295,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ venue, worldId }) => {
       Object.fromEntries(
         filteredWorlds
           .filter(({ id }) => !(venueId === id))
-          .map((world) => [world.id, world])
+          .map((world) => [world.slug, world])
       ),
     [venueId, filteredWorlds]
   );
@@ -303,8 +303,8 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ venue, worldId }) => {
   const parentSpace = useMemo(
     () =>
       venue?.parentId
-        ? filteredWorlds.find(({ id }) => id === venue?.parentId)
-        : { name: "" },
+        ? filteredWorlds.find(({ slug }) => slug === venue?.parentId)
+        : { slug: "" },
     [filteredWorlds, venue?.parentId]
   );
 


### PR DESCRIPTION
Follow up rework of parent list options: https://github.com/sparkletown/internal-sparkle-issues/issues/1461
Specifically fixes this issue: https://github.com/sparkletown/internal-sparkle-issues/issues/1461#issuecomment-984932616

Replaced `name` with `slug` to be used in the option list, as it proved to be more sustainable source of identification

