### PR TITLE
Switch SpacesDropdown to using ID

### DIFF
--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
@@ -5,7 +5,6 @@ import { omit } from "lodash";
 
 import { PORTAL_INFO_ICON_MAPPING } from "settings";
 
-import { Room } from "types/rooms";
 import { AnyVenue, PortalTemplate, VenueTemplate } from "types/venues";
 
 import { WithId } from "utils/id";
@@ -16,27 +15,22 @@ import "./SpacesDropdown.scss";
 
 const noneOptionName = "None";
 const spaceNoneOption = Object.freeze({
-  none: Object.freeze({ name: "", template: undefined }),
+  none: Object.freeze({ id: undefined, name: "", template: undefined }),
 });
 
 export type SpacesDropdownPortal = { template?: PortalTemplate; name: string };
-
-export interface DropdownRoom extends Room {
-  name: string;
-}
-
 export interface SpacesDropdownProps {
   parentSpace?: SpacesDropdownPortal;
   setValue: <T>(prop: string, value: T, validate: boolean) => void;
   register: ReturnType<typeof useForm>["register"];
   fieldName: string;
   error?: FieldError;
-  portals: Record<string, WithId<AnyVenue> | DropdownRoom>;
+  spaces: Record<string, WithId<AnyVenue>>;
 }
 
 export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
   parentSpace,
-  portals,
+  spaces,
   setValue,
   register,
   fieldName,
@@ -44,12 +38,13 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
 }) => {
   const [selected, setSelected] = useState(parentSpace);
 
-  // @debt: Probably need to omit returning playa from the useOwnedVenues as it's deprecated and doesn't exist on PORTAL_INFO_ICON_MAPPING
-  const filteredPortals = omit(portals, VenueTemplate.playa);
+  // @debt: Probably need to omit returning playa from the useOwnedVenues as it's deprecated and
+  // doesn't exist on SPACE_PORTALS_ICONS_MAPPING
+  const filteredSpaces = omit(spaces, VenueTemplate.playa);
 
-  const portalOptions = useMemo(
-    () => ({ ...spaceNoneOption, ...filteredPortals }),
-    [filteredPortals]
+  const spaceOptions = useMemo(
+    () => ({ ...spaceNoneOption, ...filteredSpaces }),
+    [filteredSpaces]
   );
 
   useEffect(() => {
@@ -60,15 +55,15 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
 
   const renderedOptions = useMemo(
     () =>
-      Object.values(portalOptions).map(({ name, template }) => {
+      Object.values(spaceOptions).map(({ id, name, template }) => {
         const spaceIcon = PORTAL_INFO_ICON_MAPPING[template ?? ""];
 
         return (
           <ReactBootstrapDropdown.Item
-            key={name}
+            key={id}
             onClick={() => {
               setSelected({ name, template });
-              setValue(fieldName, name, true);
+              setValue(fieldName, id, true);
             }}
             className="SpacesDropdown__item"
           >
@@ -83,7 +78,7 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
           </ReactBootstrapDropdown.Item>
         );
       }) ?? [],
-    [portalOptions, setValue, fieldName]
+    [spaceOptions, setValue, fieldName]
   );
 
   const renderedTitle = useMemo(() => {
@@ -91,7 +86,7 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
       return "Select a space";
     }
 
-    const space = portals?.[selected.name] ?? parentSpace;
+    const space = spaces?.[selected.name] ?? parentSpace;
 
     const spaceIcon = PORTAL_INFO_ICON_MAPPING[space?.template ?? ""];
 
@@ -107,7 +102,7 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
         {selected.name || noneOptionName}
       </span>
     );
-  }, [portals, selected, parentSpace]);
+  }, [spaces, selected, parentSpace]);
 
   return (
     // @debt align the style of the SpacesDropdown with the Dropdown component

--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -356,7 +356,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
               withLabel
             >
               <SpacesDropdown
-                portals={backButtonOptionList}
+                spaces={backButtonOptionList}
                 setValue={setValue}
                 register={register}
                 fieldName="venue.parentId"

--- a/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
+++ b/src/components/molecules/SpaceEditFormNG/SpaceEditFormNG.tsx
@@ -292,7 +292,7 @@ export const SpaceEditFormNG: React.FC<SpaceEditFormNGProps> = ({
               withLabel
             >
               <SpacesDropdown
-                portals={backButtonOptionList}
+                spaces={backButtonOptionList}
                 setValue={setValue}
                 register={register}
                 fieldName="parentId"

--- a/src/components/organisms/TimingEventModal/TimingEventModal.tsx
+++ b/src/components/organisms/TimingEventModal/TimingEventModal.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Modal } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import dayjs from "dayjs";
 
 import {
-  ALWAYS_EMPTY_ARRAY,
   DAYJS_INPUT_DATE_FORMAT,
   DAYJS_INPUT_TIME_FORMAT,
   HAS_ROOMS_TEMPLATES,
@@ -19,7 +18,6 @@ import { WithId } from "utils/id";
 import { eventEditSchema } from "forms/eventEditSchema";
 
 import { ButtonNG } from "components/atoms/ButtonNG";
-import { SpacesDropdown } from "components/atoms/SpacesDropdown";
 
 import "./TimingEventModal.scss";
 
@@ -51,7 +49,6 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
     errors,
     formState,
     reset,
-    setValue,
   } = useForm<EventInput>({
     mode: "onSubmit",
     reValidateMode: "onChange",
@@ -111,27 +108,6 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
     setShowDeleteEventModal();
   };
 
-  const dropdownVenueList = useMemo(
-    () =>
-      Object.fromEntries(
-        venue?.rooms?.map((room) => [
-          room.title,
-          { ...room, name: room.title },
-        ]) ?? ALWAYS_EMPTY_ARRAY
-      ),
-    [venue?.rooms]
-  );
-
-  const parentRoom = useMemo(
-    () => venue?.rooms?.find(({ title }) => title === event?.room),
-    [event?.room, venue?.rooms]
-  );
-
-  const parentSpace = {
-    name: parentRoom?.title ?? venue.name,
-    template: parentRoom?.template ?? venue.template,
-  };
-
   return (
     <>
       <Modal
@@ -144,17 +120,6 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
           <div className="form-container">
             <h2>Add experience</h2>
             <form className="form" onSubmit={handleSubmit(onUpdateEvent)}>
-              <div className="TimingEventModal__input-group dropdown-container">
-                <SpacesDropdown
-                  portals={dropdownVenueList}
-                  setValue={setValue}
-                  register={register}
-                  fieldName="room"
-                  parentSpace={parentSpace}
-                  error={errors.room}
-                />
-              </div>
-
               <div className="TimingEventModal__input-group">
                 <label htmlFor="name">Name your experience</label>
                 <input

--- a/src/pages/Admin/Details/Form/DetailsForm.tsx
+++ b/src/pages/Admin/Details/Form/DetailsForm.tsx
@@ -408,7 +408,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ venue, worldId }) => {
             withLabel
           >
             <SpacesDropdown
-              portals={backButtonOptionList}
+              spaces={backButtonOptionList}
               setValue={setValue}
               register={register}
               fieldName="parentId"


### PR DESCRIPTION
Follow up rework of parent list options: sparkletown/internal-sparkle-issues#1461
Specifically fixes this issue: sparkletown/internal-sparkle-issues#1461 (comment)

Replaced name with slug to be used in the option list, as it proved to be more sustainable source of identification.