### PR TITLE
custom redirects for clients added

### DIFF
--- a/src/components/organisms/AppRouter/AppRouter.tsx
+++ b/src/components/organisms/AppRouter/AppRouter.tsx
@@ -1,5 +1,10 @@
 import React, { lazy, Suspense } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+} from "react-router-dom";
 
 import {
   ACCOUNT_ROOT_URL,
@@ -12,6 +17,10 @@ import {
   ENTRANCE_STEP_VENUE_PARAM_URL,
   EXTERNAL_SPARKLE_HOMEPAGE_URL,
   EXTERNAL_SPARKLEVERSE_HOMEPAGE_URL,
+  googleCloudWestName,
+  googleCloudWestRootUrl,
+  iterableName,
+  iterableRootUrl,
   LOGIN_CUSTOM_TOKEN_PARAM_URL,
   ROOT_URL,
   SPARKLEVERSE_REDIRECT_URL,
@@ -19,6 +28,7 @@ import {
 } from "settings";
 
 import { tracePromise } from "utils/performance";
+import { generateAttendeeInsideUrl } from "utils/url";
 
 import { useSettings } from "hooks/useSettings";
 import { useUser } from "hooks/useUser";
@@ -103,13 +113,29 @@ export const AppRouter: React.FC = () => {
   const { user } = useUser();
 
   if (!isLoaded) return <LoadingPage />;
-
   const { enableAdmin1 } = settings;
+
+  // @debt custom redirects that are to be removed in the future
+  // done as per: https://github.com/sparkletown/internal-sparkle-issues/issues/1547
+  const googleCloudWestWorldUrl = generateAttendeeInsideUrl({
+    worldSlug: googleCloudWestName,
+    spaceSlug: googleCloudWestName,
+  });
+  const iterableWorldUrl = generateAttendeeInsideUrl({
+    worldSlug: iterableName,
+    spaceSlug: iterableName,
+  });
 
   return (
     <Router basename="/">
       <Suspense fallback={<LoadingPage />}>
         <Switch>
+          <Route path={iterableRootUrl}>
+            <Redirect to={iterableWorldUrl} />
+          </Route>
+          <Route path={googleCloudWestRootUrl}>
+            <Redirect to={googleCloudWestWorldUrl} />
+          </Route>
           <Route path={ENTER_ROOT_URL} component={EnterSubrouter} />
 
           <Route path={ACCOUNT_ROOT_URL}>

--- a/src/settings/urlSettings.ts
+++ b/src/settings/urlSettings.ts
@@ -72,6 +72,13 @@ export const ADMIN_IA_SPACE_EDIT_PARAM_URL = `${ADMIN_IA_SPACE_BASE_PARAM_URL}/:
 export const ADMIN_IA_SPACE_CREATE_PARAM_URL = `${ADMIN_IA_WORLD_PARAM_URL}/create-space`; // e.g. /admin/w/world123/create-space
 export const ADMIN_IA_SPACE_SETTINGS_PARAM_URL = `${ADMIN_IA_WORLD_PARAM_URL}/tweak-space/:spaceSlug/:selectedTab?`; // e.g. /admin/w/world123/tweak-space/space456
 
+// @debt custom urls with AppRouter redirects that are to be removed in the future
+// done as per: https://github.com/sparkletown/internal-sparkle-issues/issues/1547
+export const googleCloudWestName = "googlecloudwest";
+export const iterableName = "iterable";
+export const googleCloudWestRootUrl = `/v/${googleCloudWestName}`;
+export const iterableRootUrl = `/v/${iterableName}`;
+
 // @debt remove v1 URLs
 // Admin v1 URLs
 export const ADMIN_V1_CREATE_URL = `${ADMIN_OLD_ROOT_URL}/venue/creation`;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -82,8 +82,11 @@ export const adminWorldSpacesUrl = (worldSlug?: string) =>
   generatePath(ADMIN_IA_WORLD_PARAM_URL, { worldSlug });
 
 type generateAttendeeInsideUrlParams = {
-  worldSlug?: WorldSlug;
-  spaceSlug?: SpaceSlug;
+  // @debt changes made due to having hardcoded strings as world/space slugs
+  // (| string;) to be removed in the future
+  // done as per: https://github.com/sparkletown/internal-sparkle-issues/issues/1547
+  worldSlug?: WorldSlug | string;
+  spaceSlug?: SpaceSlug | string;
   absoluteUrl?: boolean;
 };
 


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1547

Adds a custom redirect for `googlecloudwest` and `iterable` spaces.

To be removed in the future as per https://github.com/sparkletown/internal-sparkle-issues/issues/1550