### PR TITLE
Refetch events when they are likely to have changed

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -25,9 +25,11 @@ export const fetchVenueEvents = async (
 export const fetchAllVenueEvents = async (
   venueIdOrIds: string | string[]
 ): Promise<WithVenueId<WithId<VenueEvent>>[]> =>
-  Promise.all(asArray(venueIdOrIds).map(fetchVenueEvents)).then((result) =>
-    result.flat()
-  );
+  Promise.all(asArray(venueIdOrIds).map(fetchVenueEvents)).then((result) => {
+    const flattened = result.flat();
+    flattened.sort((a, b) => a.start_utc_seconds - b.start_utc_seconds);
+    return flattened;
+  });
 
 /**
  * Convert VenueEvent objects between the app/firestore formats (@debt:, including validation).

--- a/src/components/organisms/AdminVenueView/components/EventsView/EventsView.tsx
+++ b/src/components/organisms/AdminVenueView/components/EventsView/EventsView.tsx
@@ -26,11 +26,17 @@ export type EventsViewProps = {
 };
 
 export const EventsView: React.FC<EventsViewProps> = ({ venueId, venue }) => {
+  // @debt This refetchIndex is used to force a refetch of the data when events
+  // have been edited. It's horrible and needs a rethink. It also doesn't
+  // help the attendee side at all.
+  const [refetchIndex, setRefetchIndex] = useState(0);
+
   const { relatedVenueIds, isLoading: isVenuesLoading } = useRelatedVenues({
     currentVenueId: venueId,
   });
   const { events, isEventsLoading } = useVenueEvents({
     venueIds: relatedVenueIds,
+    refetchIndex,
   });
 
   const {
@@ -55,7 +61,12 @@ export const EventsView: React.FC<EventsViewProps> = ({ venueId, venue }) => {
   const adminEventModalOnHide = useCallback(() => {
     setHideCreateEventModal();
     setEditedEvent(undefined);
-  }, [setHideCreateEventModal]);
+    setRefetchIndex(refetchIndex + 1);
+  }, [setHideCreateEventModal, refetchIndex]);
+
+  const triggerRefetch = useCallback(() => {
+    setRefetchIndex(refetchIndex + 1);
+  }, [refetchIndex]);
 
   const hasVenueEvents = events?.length !== 0;
 
@@ -154,6 +165,7 @@ export const EventsView: React.FC<EventsViewProps> = ({ venueId, venue }) => {
           onHide={() => {
             setHideDeleteEventModal();
             setEditedEvent && setEditedEvent(undefined);
+            triggerRefetch();
           }}
           venueId={venue.id}
           event={editedEvent}

--- a/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
+++ b/src/components/organisms/NavBarSchedule/NavBarSchedule.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import classNames from "classnames";
 import {
   addDays,
@@ -54,6 +60,17 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
   isVisible,
   venueId,
 }) => {
+  // @debt This refetchIndex is used to force a refetch of the data when events
+  // have been edited. It's horrible and needs a rethink. It also doesn't
+  // help the attendee side at all.
+  const [refetchIndex, setRefetchIndex] = useState(0);
+  const prevIsVisibleRef = useRef<boolean>();
+  useEffect(() => {
+    if (prevIsVisibleRef.current !== isVisible) {
+      setRefetchIndex(refetchIndex + 1);
+      prevIsVisibleRef.current = isVisible;
+    }
+  }, [isVisible, prevIsVisibleRef, refetchIndex]);
   const { currentVenue: venue, findVenueInRelatedVenues } = useRelatedVenues({
     currentVenueId: venueId,
   });
@@ -78,7 +95,7 @@ export const NavBarSchedule: React.FC<NavBarScheduleProps> = ({
     isEventsLoading,
     sovereignVenue,
     relatedVenues,
-  } = useVenueScheduleEvents({ userEventIds });
+  } = useVenueScheduleEvents({ userEventIds, refetchIndex });
 
   const scheduledStartDate = sovereignVenue?.start_utc_seconds;
 

--- a/src/components/organisms/TimingDeleteModal/TimingDeleteModal.tsx
+++ b/src/components/organisms/TimingDeleteModal/TimingDeleteModal.tsx
@@ -31,6 +31,7 @@ export const TimingDeleteModal: React.FC<TimingDeleteModalProps> = ({
     mode: "onSubmit",
     reValidateMode: "onChange",
   });
+  const eventSpaceId = event?.spaceId;
 
   useEffect(() => {
     if (event) {
@@ -52,11 +53,11 @@ export const TimingDeleteModal: React.FC<TimingDeleteModalProps> = ({
     { loading: isDeletingEvent },
     deleteVenueEvent,
   ] = useAsyncFn(async () => {
-    if (event) {
-      await deleteEvent(venueId, event.id);
+    if (event && eventSpaceId) {
+      await deleteEvent(eventSpaceId, event.id);
     }
     onHide();
-  }, [event, onHide, venueId]);
+  }, [event, onHide, eventSpaceId]);
 
   const eventStartTime = event
     ? dayjs(event.start_utc_seconds * 1000).format("ha")

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -12,6 +12,8 @@ const emptyArray: never[] = [];
 
 export interface VenueEventsProps {
   venueIds: string[];
+  // A dummy number that is used to trigger a refetch
+  refetchIndex?: number;
 }
 
 export interface VenueEventsData {
@@ -24,6 +26,7 @@ export interface VenueEventsData {
 
 export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
   venueIds,
+  refetchIndex = 0,
 }) => {
   const {
     loading: isEventsLoading,
@@ -38,13 +41,20 @@ export const useVenueEvents: ReactHook<VenueEventsProps, VenueEventsData> = ({
       {
         metrics: {
           venueIdsLength: venueIds.length,
+          refetchIndex,
         },
       }
     );
-  }, [venueIds]); // TODO: figure out this deps in an efficient way so it doesn't keep re-rendering
+    // @debt This refetchIndex is a hack to force a refetch when we think the
+    // underlying data might have changed. This is because the data structure
+    // makes it hard to subscribe to all events on all venues.
+  }, [refetchIndex, venueIds]); // TODO: figure out this deps in an efficient way so it doesn't keep re-rendering
 
   return {
-    isEventsLoading,
+    // @debt related to the above
+    // To make things seem smoother the loading flag is only set if the
+    // refetchIndex is zero.
+    isEventsLoading: isEventsLoading && refetchIndex === 0,
     isError: eventsError !== undefined,
 
     events,

--- a/src/hooks/useVenueScheduleEvents.ts
+++ b/src/hooks/useVenueScheduleEvents.ts
@@ -29,8 +29,10 @@ const todaysDate = new Date();
 
 const useVenueScheduleEvents = ({
   userEventIds,
+  refetchIndex = 0,
 }: {
   userEventIds: Partial<Record<string, string[]>>;
+  refetchIndex?: number;
 }) => {
   const {
     descendantVenues,
@@ -47,6 +49,7 @@ const useVenueScheduleEvents = ({
     isEventsLoading,
   } = useVenueEvents({
     venueIds: relatedVenueIds,
+    refetchIndex,
   });
   const liveAndFutureEvents = useMemo(
     () =>


### PR DESCRIPTION
Trigger a refetch of events when they are likely to have changed.

This change applies to both attendee and admin side.

The debt in this PR needs to be picked up later.

Resolves https://github.com/sparkletown/internal-sparkle-issues/issues/1551