### PR TITLE
remove default jazzbar info

### DIFF
--- a/src/components/molecules/StartTable/StartTable.tsx
+++ b/src/components/molecules/StartTable/StartTable.tsx
@@ -7,11 +7,9 @@ import { DEFAULT_TABLE_CAPACITY } from "settings";
 import { updateVenueTable } from "api/table";
 
 import { Table } from "types/Table";
-import { VenueTemplate } from "types/venues";
+import { AnyVenue, VenueTemplate } from "types/venues";
 
-import { currentVenueSelector } from "utils/selectors";
-
-import { useSelector } from "hooks/useSelector";
+import { WithId } from "utils/id";
 
 import { Loading } from "components/molecules/Loading";
 
@@ -20,14 +18,14 @@ import "./StartTable.scss";
 export interface StartTablePropsType {
   tables: Table[];
   newTable: Table;
+  venue: WithId<AnyVenue>;
 }
 
 export const StartTable: React.FC<StartTablePropsType> = ({
   tables,
   newTable,
+  venue,
 }) => {
-  const venue = useSelector(currentVenueSelector);
-
   const [{ loading: isUpdatingTables }, updateTables] = useAsyncFn(async () => {
     if (!venue?.id) return;
 

--- a/src/components/molecules/TableComponent/TableComponent.tsx
+++ b/src/components/molecules/TableComponent/TableComponent.tsx
@@ -4,10 +4,7 @@ import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
 
 import { TableComponentPropsType } from "types/Table";
 
-import { currentVenueSelector } from "utils/selectors";
-
 import { useProfileModalControls } from "hooks/useProfileModalControls";
-import { useSelector } from "hooks/useSelector";
 
 import "./TableComponent.scss";
 
@@ -17,9 +14,9 @@ const TableComponent: React.FunctionComponent<TableComponentPropsType> = ({
   imageSize = 50,
   table,
   tableLocked,
+  venue,
 }) => {
   const { openUserProfileModal } = useProfileModalControls();
-  const venue = useSelector(currentVenueSelector);
   const locked = tableLocked(table.reference);
   const numberOfSeatsLeft = table.capacity && table.capacity - users.length;
   const full = numberOfSeatsLeft === 0;

--- a/src/components/molecules/TablesUserList/TablesUserList.tsx
+++ b/src/components/molecules/TablesUserList/TablesUserList.tsx
@@ -13,6 +13,7 @@ import { setTableSeat } from "api/venue";
 
 import { Table, TableComponentPropsType } from "types/Table";
 import { TableSeatedUser } from "types/User";
+import { AnyVenue } from "types/venues";
 
 import { WithId } from "utils/id";
 import { experienceSelector } from "utils/selectors";
@@ -55,6 +56,7 @@ export interface TablesUserListProps {
   TableComponent: React.FC<TableComponentPropsType>;
   joinMessage: boolean;
   leaveText?: string;
+  venue: WithId<AnyVenue>;
 }
 
 export const TablesUserList: React.FC<TablesUserListProps> = ({
@@ -65,6 +67,7 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
   showOnlyAvailableTables = false,
   TableComponent,
   joinMessage,
+  venue,
 }) => {
   const {
     isShown: isLockedMessageVisible,
@@ -199,6 +202,7 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
         table={table}
         tableLocked={tableLocked}
         onJoinClicked={onJoinClicked}
+        venue={venue}
       />
     ));
   }, [
@@ -210,6 +214,7 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
     TableComponent,
     usersSeatedAtTables,
     onJoinClicked,
+    venue,
   ]);
 
   if (!isSeatedTableUsersLoaded) return <Loading />;
@@ -218,7 +223,11 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
     <>
       {renderedTables}
       {canStartTable && (
-        <StartTable tables={tables} newTable={createTable(tables.length)} />
+        <StartTable
+          tables={tables}
+          newTable={createTable(tables.length)}
+          venue={venue}
+        />
       )}
       <Modal show={isLockedMessageVisible} onHide={hideLockedMessage}>
         <Modal.Body>

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -138,6 +138,7 @@ export const ConversationSpace: React.FC<ConversationSpaceProps> = ({
               joinMessage={venue.hideVideo === false}
               customTables={tables}
               showOnlyAvailableTables={showOnlyAvailableTables}
+              venue={venue}
             />
           </div>
           <UserList

--- a/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
+++ b/src/components/templates/Jazzbar/JazzBar/JazzBar.tsx
@@ -222,6 +222,7 @@ export const JazzBar: React.FC<JazzProps> = ({ venue }) => {
             joinMessage={!venue.hideVideo ?? true}
             customTables={jazzbarTables}
             showOnlyAvailableTables={showOnlyAvailableTables}
+            venue={venue}
           />
         </div>
       </VenueWithOverlay>

--- a/src/components/templates/Jazzbar/JazzBarPage.tsx
+++ b/src/components/templates/Jazzbar/JazzBarPage.tsx
@@ -15,7 +15,7 @@ export interface JazzbarProps {
 //   you can see it yourself, when you start understanding the way it works
 export const JazzBarPage: React.FC<JazzbarProps> = ({ venue }) => {
   return (
-    <JazzBarSkeletonPage>
+    <JazzBarSkeletonPage venue={venue}>
       <JazzBar venue={venue} />
     </JazzBarSkeletonPage>
   );

--- a/src/components/templates/Jazzbar/JazzBarSkeletonPage/JazzBarSkeletonPage.tsx
+++ b/src/components/templates/Jazzbar/JazzBarSkeletonPage/JazzBarSkeletonPage.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { DEFAULT_VENUE_LOGO, PORTAL_INFO_ICON_MAPPING } from "settings";
 
-import { currentVenueSelector } from "utils/selectors";
+import { JazzbarVenue } from "types/venues";
 
-import { useSelector } from "hooks/useSelector";
+import { WithId } from "utils/id";
 
 import { InformationLeftColumn } from "components/organisms/InformationLeftColumn";
 import { RenderMarkdown } from "components/organisms/RenderMarkdown";
@@ -15,13 +15,13 @@ import "./JazzBarSkeletonPage.scss";
 
 interface PropsType {
   children: React.ReactNode;
+  venue: WithId<JazzbarVenue>;
 }
 
 const JazzBarSkeletonPage: React.FunctionComponent<PropsType> = ({
   children,
+  venue,
 }) => {
-  const venue = useSelector(currentVenueSelector);
-
   const infoIcon =
     venue?.host?.icon ||
     (PORTAL_INFO_ICON_MAPPING[venue?.template ?? ""] ?? DEFAULT_VENUE_LOGO);
@@ -30,58 +30,15 @@ const JazzBarSkeletonPage: React.FunctionComponent<PropsType> = ({
     <div className="jazz-bar-container">
       <InformationLeftColumn iconNameOrPath={infoIcon}>
         <InformationCard title="About the venue">
-          <p>
-            {venue?.name ? (
-              venue.name
-            ) : (
-              <>
-                Kansas Smitty’s
-                <br />
-                It&apos;s a band and it&apos;s a bar.
-              </>
-            )}
-          </p>
+          <p>{venue?.name}</p>
 
-          <p>
-            {venue?.config?.landingPageConfig.subtitle
-              ? venue.config.landingPageConfig.subtitle
-              : "Choose your table, invite your friends to join you and listen to the sounds of our House band."}
-          </p>
-          {venue?.config?.landingPageConfig.description ? (
+          {venue?.config?.landingPageConfig?.subtitle && (
+            <p>{venue?.config?.landingPageConfig?.subtitle}</p>
+          )}
+          {venue?.config?.landingPageConfig.description && (
             <RenderMarkdown
               text={venue.config?.landingPageConfig.description}
             />
-          ) : (
-            <>
-              <p>
-                Saturdays at Kansas Smitty&apos;s have always been about having
-                a great time. The band for this evenings performance features
-                Giacomo Smith on clarinet and alto, Ferg Ireland on double bass,
-                Joe Webb on piano, Alec Harper on tenor sax and Will Cleasby on
-                drums.
-              </p>
-              <p>Performing tonight at Kansas Smitty&apos;s:</p>
-              <ul>
-                <li>Giacomo Smith - alto/clarinet</li>
-                <li>Ferg Ireland - Double Bass</li>
-                <li>Joe Webb - Piano</li>
-                <li>Alec harper - Tenor Sax</li>
-                <li>Will Cleasby - Drums</li>
-              </ul>
-              <p>
-                If you enjoy the music why not join the Patreon community. Our
-                Patreons get access to all sorts of additional musical content
-                and updates on all new shows, performances and events we run.
-                https://www.patreon.com/kansassmittys
-              </p>
-              <p>
-                Kansas Smitty&apos;s have just released their new album
-                &apos;Things Happened Here&apos; available on all good streaming
-                platforms and vinyl/CD
-                https://ever-records.lnk.to/ThingsHappenedHere
-              </p>
-              <p>We&apos;ll see you in the bar...</p>
-            </>
           )}
         </InformationCard>
       </InformationLeftColumn>

--- a/src/components/templates/Jazzbar/components/JazzBarTableComponent/JazzBarTableComponent.tsx
+++ b/src/components/templates/Jazzbar/components/JazzBarTableComponent/JazzBarTableComponent.tsx
@@ -4,10 +4,7 @@ import { DEFAULT_PARTY_NAME, DEFAULT_PROFILE_IMAGE } from "settings";
 
 import { TableComponentPropsType } from "types/Table";
 
-import { currentVenueSelector } from "utils/selectors";
-
 import { useProfileModalControls } from "hooks/useProfileModalControls";
-import { useSelector } from "hooks/useSelector";
 
 import "./JazzBarTableComponent.scss";
 
@@ -21,9 +18,9 @@ export const JazzBarTableComponent: React.FunctionComponent<TableComponentPropsT
   imageSize = 50,
   table,
   tableLocked,
+  venue,
 }) => {
   const { openUserProfileModal } = useProfileModalControls();
-  const venue = useSelector(currentVenueSelector);
   const locked = tableLocked(table.reference);
 
   const numberOfSeatsLeft = table.capacity && table.capacity - users.length;

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -2,6 +2,8 @@ import { DisplayUser } from "types/User";
 
 import { WithId } from "utils/id";
 
+import { AnyVenue } from "./venues";
+
 export interface Table {
   title: string;
   subtitle?: string;
@@ -19,4 +21,5 @@ export interface TableComponentPropsType {
   tableCapacity?: number;
   onJoinClicked: (table: string, locked: boolean) => void;
   imageSize?: number;
+  venue: WithId<AnyVenue>;
 }


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1149

Removing default text placeholder + got rid of the `currentVenueSelector` usages in certain files ( returned undefined ) and replaced with a passed `venue` prop