### PR TITLE
add scroll to space dropdown list

### DIFF
--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
@@ -1,11 +1,17 @@
 @import "scss/constants";
 
 $dropdown-item-icon-size: 20px;
+$dropddown-list-max-height: 250px;
 
 .SpacesDropdown {
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  .dropdown-menu {
+    max-height: $dropddown-list-max-height;
+    overflow-y: scroll;
+  }
 
   &__value {
     display: flex;

--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
@@ -10,7 +10,7 @@ $dropddown-list-max-height: 250px;
 
   .dropdown-menu {
     max-height: $dropddown-list-max-height;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   &__value {


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1575

Add `max-height` and `overflow-y: auto` to have a scrollable dropdown