### PR TITLE
replace space name with world name in admin nav bar

### DIFF
--- a/src/components/molecules/NavBar/NavBar.scss
+++ b/src/components/molecules/NavBar/NavBar.scss
@@ -3,6 +3,7 @@
 $photobooth-button-margin: 140px 0px 0px;
 $photobooth-button-text-margin: 38px 0px 0px;
 $photobooth-button-background-size: 35px;
+$nav-bar-title-width: 120px;
 
 .navbar-links-user-avatar {
   cursor: pointer;
@@ -91,6 +92,18 @@ $photobooth-button-background-size: 35px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  height: 100%;
+}
+
+.nav-location-title {
+  display: flex;
+  width: $nav-bar-title-width;
+  border-left: $border-width--slim solid $lighter-intermediate-grey;
+  border-right: $border-width--slim solid $lighter-intermediate-grey;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  margin-right: $spacing--sm;
 }
 
 .nav-sparkle-logo,

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -171,7 +171,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
   const showSoundCloudRadio = withRadio
     ? (world?.showRadio && isSoundCloud) ?? false
     : false;
-  console.log(isAdminContext);
+
   return (
     <>
       <header>

--- a/src/components/molecules/NavBar/NavBar.tsx
+++ b/src/components/molecules/NavBar/NavBar.tsx
@@ -171,7 +171,7 @@ export const NavBar: React.FC<NavBarPropsType> = ({
   const showSoundCloudRadio = withRadio
     ? (world?.showRadio && isSoundCloud) ?? false
     : false;
-
+  console.log(isAdminContext);
   return (
     <>
       <header>
@@ -200,7 +200,10 @@ export const NavBar: React.FC<NavBarPropsType> = ({
                   <span className="schedule-text">Schedule</span>
                 </button>
               ) : (
-                <div>{navbarTitle}</div>
+                <>
+                  <div className="nav-location-title">Sparkle Admin</div>
+                  <div>{navbarTitle}</div>
+                </>
               )}
 
               {spaceId && !isAdminContext && (

--- a/src/components/organisms/AdminVenueView/AdminVenueView.tsx
+++ b/src/components/organisms/AdminVenueView/AdminVenueView.tsx
@@ -109,7 +109,7 @@ export const AdminVenueView: React.FC = () => {
     return <LoadingPage />;
   }
 
-  const navBarTitle = `Sparkle Admin ${world?.name ?? ""}`;
+  const navBarTitle = `${world?.name ?? ""}`;
 
   if (!space) {
     return (

--- a/src/components/organisms/AdminVenueView/AdminVenueView.tsx
+++ b/src/components/organisms/AdminVenueView/AdminVenueView.tsx
@@ -76,7 +76,7 @@ export const AdminVenueView: React.FC = () => {
     hide: closeDeleteModal,
   } = useShowHide();
 
-  const { space, spaceId, isLoaded } = useWorldAndSpaceBySlug(
+  const { space, spaceId, isLoaded, world } = useWorldAndSpaceBySlug(
     worldSlug,
     spaceSlug
   );
@@ -109,9 +109,11 @@ export const AdminVenueView: React.FC = () => {
     return <LoadingPage />;
   }
 
+  const navBarTitle = `Sparkle Admin ${world?.name ?? ""}`;
+
   if (!space) {
     return (
-      <WithNavigationBar withSchedule withHiddenLoginButton>
+      <WithNavigationBar withSchedule withHiddenLoginButton title={navBarTitle}>
         <AdminRestricted>
           <NotFound />
         </AdminRestricted>
@@ -120,7 +122,11 @@ export const AdminVenueView: React.FC = () => {
   }
 
   return (
-    <WithNavigationBar withSchedule variant="internal-scroll">
+    <WithNavigationBar
+      withSchedule
+      variant="internal-scroll"
+      title={navBarTitle}
+    >
       <AdminRestricted>
         <div className="AdminVenueView">
           <AdminTitleBar variant="grid-with-tools">

--- a/src/pages/SpacesDashboard/SpacesDashboard.tsx
+++ b/src/pages/SpacesDashboard/SpacesDashboard.tsx
@@ -85,7 +85,7 @@ export const SpacesDashboard: React.FC = () => {
     <div className="SpacesDashboard">
       <WithNavigationBar
         variant="internal-scroll"
-        title={`Sparkle Admin ${world?.name ?? ""}`}
+        title={`${world?.name ?? ""}`}
       >
         <AdminRestricted>
           <AdminTitleBar variant="grid-with-tools">

--- a/src/pages/SpacesDashboard/SpacesDashboard.tsx
+++ b/src/pages/SpacesDashboard/SpacesDashboard.tsx
@@ -83,7 +83,10 @@ export const SpacesDashboard: React.FC = () => {
 
   return (
     <div className="SpacesDashboard">
-      <WithNavigationBar variant="internal-scroll">
+      <WithNavigationBar
+        variant="internal-scroll"
+        title={`Sparkle Admin ${world?.name ?? ""}`}
+      >
         <AdminRestricted>
           <AdminTitleBar variant="grid-with-tools">
             <ButtonNG

--- a/src/pages/WorldEditor/WorldEditor.tsx
+++ b/src/pages/WorldEditor/WorldEditor.tsx
@@ -40,7 +40,7 @@ export const WorldEditor: React.FC = () => {
 
   const adminTitle = world ? `${world.name} settings` : "Create a new world";
 
-  const navBarTitle = `Sparkle Admin ${world?.name ?? ""}`;
+  const navBarTitle = `${world?.name ?? ""}`;
 
   const WorldEditorPanel = PANEL_MAP[selectedTab] ?? <></>;
 

--- a/src/pages/WorldEditor/WorldEditor.tsx
+++ b/src/pages/WorldEditor/WorldEditor.tsx
@@ -40,11 +40,13 @@ export const WorldEditor: React.FC = () => {
 
   const adminTitle = world ? `${world.name} settings` : "Create a new world";
 
+  const navBarTitle = `Sparkle Admin ${world?.name ?? ""}`;
+
   const WorldEditorPanel = PANEL_MAP[selectedTab] ?? <></>;
 
   return (
     <div className="WorldEditor">
-      <WithNavigationBar>
+      <WithNavigationBar title={navBarTitle}>
         <AdminRestricted>
           <AdminTitleBar variant="two-rows">
             {world && (

--- a/src/pages/WorldsDashboard/WorldsDashboard.tsx
+++ b/src/pages/WorldsDashboard/WorldsDashboard.tsx
@@ -51,7 +51,7 @@ export const WorldsDashboard: React.FC = () => {
 
   return (
     <div className="WorldsDashboard">
-      <WithNavigationBar title="Sparkle Admin">
+      <WithNavigationBar>
         <AdminRestricted>
           <AdminPanel variant="unbound">
             {hasWorlds ? (


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1560

Admin dashboard will always show `Sparkle Admin` as the title + world that's currently being edited ( if any )

![image](https://user-images.githubusercontent.com/56254806/145058507-116316b0-3e50-42dc-b6d9-f1f0c97e278b.png)
