### PR TITLE
fix broken external portal icon

### DIFF
--- a/src/components/atoms/ImageInput/ImageInput.scss
+++ b/src/components/atoms/ImageInput/ImageInput.scss
@@ -26,6 +26,11 @@ $upload-button-height: 150px;
     &--small {
       display: inline-block;
       padding: $image-input-padding--small;
+
+      &.mod--hidden {
+        height: 0;
+        padding: 0;
+      }
     }
   }
 

--- a/src/components/organisms/PortalStripForm/PortalStripForm.tsx
+++ b/src/components/organisms/PortalStripForm/PortalStripForm.tsx
@@ -5,7 +5,7 @@ import { useAsync, useAsyncFn } from "react-use";
 import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { DEFAULT_PORTAL_IS_ENABLED } from "settings";
+import { DEFAULT_PORTAL_IS_ENABLED, PORTAL_INFO_ICON_MAPPING } from "settings";
 
 import { upsertRoom } from "api/admin";
 import { fetchVenue } from "api/venue";
@@ -18,7 +18,7 @@ import {
   convertClickabilityToPortalType,
   convertPortalTypeToClickability,
 } from "utils/portal";
-import { generateAttendeeInsideUrl } from "utils/url";
+import { generateAttendeeInsideUrl, isExternalPortal } from "utils/url";
 
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
 import { useUser } from "hooks/useUser";
@@ -78,6 +78,10 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
   const [updatingClickable, setUpdatingClickable] = useState(false);
   const [updatingEnabled, setUpdatingEnabled] = useState(false);
   const [showModal, setShowModal] = useState(false);
+
+  const portalIcon = isExternalPortal(portal)
+    ? PORTAL_INFO_ICON_MAPPING["external"]
+    : iconUrl;
 
   const { value: targetSpace, loading: isSpaceLoading } = useAsync(async () => {
     if (targetSpaceId) {
@@ -182,7 +186,7 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
     <>
       <Form className="PortalStripForm">
         <div className="PortalStripForm__cell PortalStripForm__icon">
-          <PortalIcon src={iconUrl} />
+          <PortalIcon src={portalIcon} />
         </div>
         <div className="PortalStripForm__cell PortalStripForm__info">
           <div className="PortalStripForm__title">{title}</div>

--- a/src/settings/spacePortalsSettings.ts
+++ b/src/settings/spacePortalsSettings.ts
@@ -7,6 +7,7 @@ import IconBurnBarrel from "assets/icons/icon-room-burnbarrel.svg";
 import IconConversation from "assets/icons/icon-room-conversation.svg";
 import IconEmbeddable from "assets/icons/icon-room-embeddable.svg";
 import IconExperience from "assets/icons/icon-room-experience.svg";
+import IconExternalLink from "assets/icons/icon-room-externallink.svg";
 import IconMap from "assets/icons/icon-room-map.svg";
 import IconMusicBar from "assets/icons/icon-room-musicbar.svg";
 import IconScreening from "assets/icons/icon-room-screening.svg";
@@ -16,6 +17,7 @@ import PosterAuditorium from "assets/spaces/add-portal-auditorium.png";
 import PosterConversation from "assets/spaces/add-portal-conversation.png";
 import PosterEmbeddable from "assets/spaces/add-portal-embeddable.png";
 import PosterExperience from "assets/spaces/add-portal-experience.png";
+import PosterExternal from "assets/spaces/add-portal-external.png";
 import PosterMusicBar from "assets/spaces/add-portal-jazzbar.png";
 import PosterMap from "assets/spaces/add-portal-map.png";
 
@@ -122,8 +124,8 @@ export const SPACE_INFO_LIST: SpaceInfoListItem[] = [
 
 export const PORTAL_INFO_LIST: PortalInfoListItem[] = [
   ...SPACE_INFO_LIST,
-  /*
   // @debt external templates need to be implemented properly again
+  // enabled to fix broken icon as per https://github.com/sparkletown/internal-sparkle-issues/issues/1576
   {
     text: "External link",
     icon: IconExternalLink,
@@ -133,7 +135,6 @@ export const PORTAL_INFO_LIST: PortalInfoListItem[] = [
     template: "external",
     hidden: true,
   },
-  */
 ];
 
 export const PORTAL_INFO_ICON_MAPPING: Record<string, string> = Object.freeze(


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1576

Before:
![image](https://user-images.githubusercontent.com/56254806/145194129-e82cacda-a3d7-4d31-8a18-300f676f8a31.png)

After:
![image](https://user-images.githubusercontent.com/56254806/145194064-5efa0456-07b5-4da7-9e73-594ecc8382c6.png)
