### PR TITLE
portal form UI fixes

### DIFF
--- a/src/components/organisms/PortalAddEditForm/PortalAddEditForm.scss
+++ b/src/components/organisms/PortalAddEditForm/PortalAddEditForm.scss
@@ -28,7 +28,9 @@ $image-container-height: 200px;
   .InputField {
     margin: font-size--parent(3) 0;
   }
+}
 
+.PortalAddEditForm__form {
   .AdminSection {
     &__label {
       display: flex;
@@ -36,10 +38,16 @@ $image-container-height: 200px;
 
       .ImageInput__container {
         position: relative;
-        width: 60%;
+        width: 50%;
         margin-bottom: -($spacing--lg);
         align-self: center;
         height: $image-container-height;
+
+        &.mod--hidden {
+          height: 0;
+          padding: 0;
+          margin: 0;
+        }
       }
     }
   }

--- a/src/components/organisms/PortalAddEditForm/PortalAddEditForm.scss
+++ b/src/components/organisms/PortalAddEditForm/PortalAddEditForm.scss
@@ -25,30 +25,30 @@ $image-container-height: 200px;
     justify-content: center;
   }
 
-  .InputField {
-    margin: font-size--parent(3) 0;
-  }
-}
+  &__form {
+    .AdminSection {
+      &__label {
+        display: flex;
+        flex-direction: column;
 
-.PortalAddEditForm__form {
-  .AdminSection {
-    &__label {
-      display: flex;
-      flex-direction: column;
+        .ImageInput__container {
+          position: relative;
+          width: 50%;
+          margin-bottom: -($spacing--lg);
+          align-self: center;
+          height: $image-container-height;
 
-      .ImageInput__container {
-        position: relative;
-        width: 50%;
-        margin-bottom: -($spacing--lg);
-        align-self: center;
-        height: $image-container-height;
-
-        &.mod--hidden {
-          height: 0;
-          padding: 0;
-          margin: 0;
+          &.mod--hidden {
+            height: 0;
+            padding: 0;
+            margin: 0;
+          }
         }
       }
     }
+  }
+
+  .InputField {
+    margin: font-size--parent(3) 0;
   }
 }

--- a/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
+++ b/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
@@ -294,6 +294,7 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
       )}
 
       <SubmitError error={submitError || deleteError} />
+
       <div className="PortalAddEditForm__buttons">
         {isEditMode && (
           <ButtonNG

--- a/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
+++ b/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
@@ -294,7 +294,6 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
       )}
 
       <SubmitError error={submitError || deleteError} />
-
       <div className="PortalAddEditForm__buttons">
         {isEditMode && (
           <ButtonNG

--- a/src/components/organisms/PortalStripForm/PortalStripForm.tsx
+++ b/src/components/organisms/PortalStripForm/PortalStripForm.tsx
@@ -21,6 +21,7 @@ import {
 import { generateAttendeeInsideUrl, isExternalPortal } from "utils/url";
 
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
+import { useShowHide } from "hooks/useShowHide";
 import { useUser } from "hooks/useUser";
 
 import { PrettyLink } from "components/organisms/AdminVenueView/components/PrettyLink";
@@ -77,7 +78,11 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
   const { user } = useUser();
   const [updatingClickable, setUpdatingClickable] = useState(false);
   const [updatingEnabled, setUpdatingEnabled] = useState(false);
-  const [showModal, setShowModal] = useState(false);
+  const {
+    isShown: isModalShown,
+    hide: hideModal,
+    show: showModal,
+  } = useShowHide(false);
 
   const portalIcon = isExternalPortal(portal)
     ? PORTAL_INFO_ICON_MAPPING["external"]
@@ -170,14 +175,6 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
     [loading, updatingEnabled, values.isEnabled]
   );
 
-  const openModal = useCallback(() => {
-    setShowModal(true);
-  }, [setShowModal]);
-
-  const hideModal = useCallback(() => {
-    setShowModal(false);
-  }, [setShowModal]);
-
   const targetUrl = !isSpaceLoading
     ? generateTargetUrl({ worldSlug, portal, targetSpace })
     : "";
@@ -219,18 +216,19 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
             tabIndex={0}
           />
         </div>
-        <div className="PortalStripForm__cell PortalStripForm__edit">
+        <div
+          className="PortalStripForm__cell PortalStripForm__edit"
+          onClick={showModal}
+        >
           <PrettyLink>
             <FontAwesomeIcon icon={faPen} />
-            <span className="PortalStripForm__edit-text" onClick={openModal}>
-              Edit
-            </span>
+            <span className="PortalStripForm__edit-text">Edit</span>
           </PrettyLink>
         </div>
         <FormErrors errors={errors} />
         <SubmitError error={submitError} />
       </Form>
-      {showModal && (
+      {isModalShown && (
         <PortalAddEditModal
           portal={portal}
           show={true}


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1600


Error handling is present and existed before the changes:
![image](https://user-images.githubusercontent.com/56254806/145222778-a2bc6dee-0298-491d-b4fb-09b44d93efe7.png)

Fixed: 
 - Portal image display
![image](https://user-images.githubusercontent.com/56254806/145222959-edb37792-e26b-4d4b-b2cc-11ee92cba843.png)

- Edit button `onclick` handler (triggered by click on a div instead of text span)
