### PR TITLE
Fix default space logo icon

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -119,6 +119,7 @@ const createFirestoreVenueInputWithoutId_v2 = async (
     fileKey: ImageFileKeys;
     urlKey: ImageUrlKeys;
   };
+
   const imageKeys: Array<ImageNaming> = [
     {
       fileKey: "logoImageFile",

--- a/src/components/atoms/ImageInput/ImageInput.tsx
+++ b/src/components/atoms/ImageInput/ImageInput.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, useCallback, useRef, useState } from "react";
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { FieldError, useForm } from "react-hook-form";
 import { useCss } from "react-use";
 import classNames from "classnames";
@@ -51,6 +57,12 @@ const ImageInput: React.FC<ImageInputProps> = ({
   const inputFileRef = useRef<HTMLInputElement>(null);
 
   const [imageUrl, setImageUrl] = useState(imgUrl);
+
+  useEffect(() => {
+    if (imgUrl && !imageUrl) {
+      setImageUrl(imgUrl);
+    }
+  }, [imgUrl, imageUrl]);
 
   const fileName = nameWithUnderscore ? `${name}_file` : `${name}File`;
   const fileUrl = nameWithUnderscore ? `${name}_url` : `${name}Url`;

--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -11,12 +11,14 @@ import {
   DEFAULT_SHOW_REACTIONS,
   DEFAULT_SHOW_SHOUTOUTS,
   DEFAULT_VENUE_AUTOPLAY,
+  DEFAULT_VENUE_LOGO,
   DISABLED_DUE_TO_1253,
   HAS_GRID_TEMPLATES,
   HAS_REACTIONS_TEMPLATES,
   IFRAME_TEMPLATES,
   MAX_SECTIONS_AMOUNT,
   MIN_SECTIONS_AMOUNT,
+  PORTAL_INFO_ICON_MAPPING,
   SECTION_DEFAULT_COLUMNS_COUNT,
   SECTION_DEFAULT_ROWS_COUNT,
   SUBVENUE_TEMPLATES,
@@ -74,6 +76,9 @@ export interface SpaceEditFormProps {
 export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
   const { user } = useUser();
 
+  const spaceLogoImage =
+    PORTAL_INFO_ICON_MAPPING[space.template] ?? DEFAULT_VENUE_LOGO;
+
   const defaultValues = useMemo(
     () => ({
       name: space.name ?? "",
@@ -97,7 +102,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
       bannerImage: undefined,
       bannerImageUrl: space?.config?.landingPageConfig?.coverImageUrl ?? "",
       logoImage: undefined,
-      logoImageUrl: space?.host?.icon ?? "",
+      logoImageUrl: space?.host?.icon ?? spaceLogoImage,
     }),
     [
       space.name,
@@ -119,6 +124,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
       space.zoomUrl,
       space?.host?.icon,
       space?.config?.landingPageConfig?.coverImageUrl,
+      spaceLogoImage,
     ]
   );
 
@@ -269,7 +275,11 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
           </AdminSpacesListItem>
 
           <AdminSpacesListItem title="Appearance" isOpened>
-            <AdminSection title="Upload a highlight image" withLabel>
+            <AdminSection
+              title="Upload a highlight image"
+              subtitle="A plain 1920 x 1080px image works best."
+              withLabel
+            >
               <ImageInput
                 onChange={changeBackgroundImageUrl}
                 name="bannerImage"
@@ -280,7 +290,11 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
                 setValue={setValue}
               />
             </AdminSection>
-            <AdminSection title="Upload a logo" withLabel>
+            <AdminSection
+              title="Upload a logo"
+              withLabel
+              subtitle="(A transparent 300 px square image works best)"
+            >
               <ImageInput
                 onChange={changePortalImageUrl}
                 name="logoImage"
@@ -289,7 +303,6 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
                 setValue={setValue}
                 register={register}
                 small
-                subtext="(A transparent 300 px square image works best)"
               />
             </AdminSection>
           </AdminSpacesListItem>

--- a/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
+++ b/src/components/organisms/PortalAddEditForm/PortalAddEditForm.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_PORTAL_IS_CLICKABLE,
   DEFAULT_PORTAL_IS_ENABLED,
   DEFAULT_VENUE_LOGO,
+  PORTAL_INFO_ICON_MAPPING,
   PortalInfoListItem,
   ROOM_TAXON,
   SPACE_TAXON,
@@ -59,20 +60,21 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
 }) => {
   const { user } = useUser();
   const { worldSlug, spaceSlug } = useParams<AdminVenueViewRouteParams>();
-  const { spaceId: currentSpaceId, world } = useWorldAndSpaceBySlug(
+  const { spaceId: currentSpaceId, world, space } = useWorldAndSpaceBySlug(
     worldSlug,
     spaceSlug
   );
 
   const { icon } = item ?? {};
-
+  const spaceLogoImage =
+    PORTAL_INFO_ICON_MAPPING[space?.template ?? ""] ?? DEFAULT_VENUE_LOGO;
   const isEditMode = isTruthy(portal);
   const title = isEditMode ? "Edit the portal" : "Create a portal";
 
   const defaultValues = useMemo(
     () => ({
       title: portal?.title ?? "",
-      image_url: portal?.image_url ?? icon ?? DEFAULT_VENUE_LOGO,
+      image_url: portal?.image_url ?? icon ?? spaceLogoImage,
       visibility: portal?.visibility ?? venueVisibility,
       spaceId: portal?.spaceId ?? undefined,
       isClickable: portal?.type !== RoomType.unclickable,
@@ -87,6 +89,7 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
       portal?.isEnabled,
       icon,
       venueVisibility,
+      spaceLogoImage,
     ]
   );
 

--- a/src/components/organisms/PortalStripForm/PortalStripForm.tsx
+++ b/src/components/organisms/PortalStripForm/PortalStripForm.tsx
@@ -74,6 +74,7 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
     title,
     spaceId: targetSpaceId,
   } = portal;
+
   const { worldSlug } = useSpaceParams();
   const { user } = useUser();
   const [updatingClickable, setUpdatingClickable] = useState(false);

--- a/src/forms/spaceEditSchema.ts
+++ b/src/forms/spaceEditSchema.ts
@@ -4,7 +4,6 @@ import {
   IFRAME_TEMPLATES,
   MAX_SECTIONS_AMOUNT,
   MIN_SECTIONS_AMOUNT,
-  ROOM_TAXON,
 } from "settings";
 
 import { VenueTemplate } from "types/venues";
@@ -20,7 +19,7 @@ export interface RoomSchemaShape {
 }
 
 export const spaceEditSchema = Yup.object().shape({
-  logoImageUrl: Yup.string().required(`${ROOM_TAXON.capital} icon is required`),
+  logoImageUrl: Yup.string().notRequired(),
   bannerImageUrl: Yup.string().notRequired(),
   autoplay: Yup.boolean().notRequired(),
   numberOfSections: Yup.number().when(


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1609

* Added default space logo icon uploaded per creation. 
* Made logo image optional ( since it's uploaded automatically there's no way it's gonna be missing )
* Made default portal icon to be parent space's icon

Before:
![image](https://user-images.githubusercontent.com/56254806/145387609-7ac4f8b6-261e-4389-9d97-d84afb7a3278.png)


After:
![image](https://user-images.githubusercontent.com/56254806/145387543-90710925-2a6b-4899-b3c1-29ffbe052929.png)
![image](https://user-images.githubusercontent.com/56254806/145387577-baa82f1c-bf68-436f-a3ca-3b10d21c7952.png)
