### PR TITLE
Fix StartTable layer

### DIFF
--- a/src/components/molecules/StartTable/StartTable.scss
+++ b/src/components/molecules/StartTable/StartTable.scss
@@ -24,6 +24,8 @@ $start-table-internal-indent: 25px;
     $start-table-button-indent;
   cursor: pointer;
 
+  z-index: z(start-table);
+
   &:hover {
     background-color: lighten($secondary--live, 10%);
     transform: scale(1.05);

--- a/src/scss/constants.scss
+++ b/src/scss/constants.scss
@@ -213,6 +213,7 @@ $z-layer-embed-iframe: $z-layer-on-top-bg;
 $z-layer-external-message: $z-layer-on-top-bg;
 $z-layer-auditorium-iframe: $z-layer-on-top-bg;
 $z-layer-jukebox: $z-layer-on-top-bg;
+$z-layer-start-table: 0;
 
 // @debt hack-fix to hide dropdown under navbar (reason: navbar stacking context)
 //       a better solution discussed here https://github.com/sparkletown/sparkle/pull/1350#discussion_r622895298
@@ -299,7 +300,8 @@ $z-layers: (
   loading-page-sparkle: 10,
   private-recipient-search-input-dropdown: 1,
   venuepage-preview-indication: 1,
-  map-preview-header: 5
+  map-preview-header: 5,
+  start-table: $z-layer-start-table
 );
 
 @function z($layer) {


### PR DESCRIPTION
a bit hacky solution that fixes https://github.com/sparkletown/internal-sparkle-issues/issues/1606
not sure why only `StartTable` component needs `z-index`, and existing tables don't.. 😕 