### PR TITLE
Fix deleting profile links

### DIFF
--- a/src/components/organisms/NewProfileModal/EditingProfileModalContent/EditingProfileModalContent.tsx
+++ b/src/components/organisms/NewProfileModal/EditingProfileModalContent/EditingProfileModalContent.tsx
@@ -116,8 +116,12 @@ export const EditingProfileModalContent: React.FC<CurrentUserProfileModalContent
   );
 
   const [{ loading: isSubmitting }, onSubmit] = useAsyncFn(
-    async (data: UserProfileModalFormData) => {
+    async (data: Omit<UserProfileModalFormData, "profileLinks">) => {
       if (!firebaseUser) return;
+      const dataWithProfileLinks = {
+        profileLinks: [],
+        ...data,
+      };
 
       const passwordsNotEmpty = Object.values(
         pick(data, profileModalPasswordsFields)
@@ -148,7 +152,10 @@ export const EditingProfileModalContent: React.FC<CurrentUserProfileModalContent
       ) as (keyof UserProfileModalFormData)[];
 
       if (changedFields.length > 0) {
-        await updateUserProfile(firebaseUser.uid, pick(data, changedFields));
+        await updateUserProfile(
+          firebaseUser.uid,
+          pick(dataWithProfileLinks, changedFields)
+        );
       }
 
       onCancelEditing();


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1608

when we remove the last profile link using `remove` function of `useFieldArray`, instead of setting `[]` to the `data`, it disappears, so this hacky solution is just to set an empty list of `profileLinks` if there are no profile links.

related issue: https://github.com/react-hook-form/react-hook-form/issues/871