### PR TITLE
add missing space settings title

### DIFF
--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.scss
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.scss
@@ -17,6 +17,10 @@ $image-container-height: 200px;
     .AdminSection {
       padding: 0px $spacing--xl;
     }
+
+    .AdminSidebarSectionTitle {
+      padding: $spacing--lg;
+    }
   }
 
   &__loading-indicator {
@@ -52,6 +56,10 @@ $image-container-height: 200px;
         align-self: center;
         height: $image-container-height;
       }
+    }
+
+    .AdminSidebarSectionTitle {
+      padding: $spacing--sm $spacing--sm $spacing--xs;
     }
   }
 }

--- a/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
+++ b/src/components/molecules/SpaceEditForm/SpaceEditForm.tsx
@@ -41,6 +41,7 @@ import { useUser } from "hooks/useUser";
 import { BackgroundSelect } from "pages/Admin/BackgroundSelect";
 
 import { AdminSidebarButtons } from "components/organisms/AdminVenueView/components/AdminSidebarButtons";
+import { AdminSidebarSectionTitle } from "components/organisms/AdminVenueView/components/AdminSidebarSectionTitle";
 import { AdminSpacesListItem } from "components/organisms/AdminVenueView/components/AdminSpacesListItem";
 
 import { AdminCheckbox } from "components/molecules/AdminCheckbox";
@@ -223,6 +224,9 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({ space }) => {
     <Form onSubmit={handleSubmit(updateVenue)}>
       <div className="SpaceEditForm">
         <div className="SpaceEditForm__portal">
+          <AdminSidebarSectionTitle>
+            Edit general settings
+          </AdminSidebarSectionTitle>
           <AdminSpacesListItem title="The basics" isOpened>
             <AdminSection title="Rename your space" withLabel>
               <AdminInput

--- a/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
+++ b/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
@@ -1,12 +1,12 @@
 @import "scss/constants.scss";
 
-$no-events-margin-top: 100px;
-
 .EventsView {
   padding: 5vh;
   width: 85%;
 
   &__container {
+    display: flex;
+    flex-direction: column;
     height: 60vh;
     background-color: $content--under;
     border-radius: $border-radius--xl;
@@ -30,6 +30,12 @@ $no-events-margin-top: 100px;
     margin: 0;
     font-weight: $font-weight--700;
     font-size: $font-size--xl;
+  }
+
+  &__content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   &__content > .TimingEvent:nth-of-type(odd) {
@@ -107,7 +113,7 @@ $no-events-margin-top: 100px;
 
   &__no-events {
     text-align: center;
-    margin: $no-events-margin-top auto 0;
+    margin: auto;
   }
 
   &__create {

--- a/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
+++ b/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
@@ -104,12 +104,8 @@
   }
 
   &__no-events {
-    width: 300px;
     text-align: center;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    margin: auto;
   }
 
   &__create {

--- a/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
+++ b/src/components/organisms/AdminVenueView/components/EventsView/EventsView.scss
@@ -1,5 +1,7 @@
 @import "scss/constants.scss";
 
+$no-events-margin-top: 100px;
+
 .EventsView {
   padding: 5vh;
   width: 85%;
@@ -105,7 +107,7 @@
 
   &__no-events {
     text-align: center;
-    margin: auto;
+    margin: $no-events-margin-top auto 0;
   }
 
   &__create {

--- a/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.scss
+++ b/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.scss
@@ -35,4 +35,8 @@
   &--spacing + &--spacing {
     margin-top: $spacing--lg;
   }
+
+  .AdminSidebarSectionTitle {
+    padding: $spacing--lg;
+  }
 }

--- a/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
+++ b/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
@@ -9,11 +9,11 @@ import { WithId } from "utils/id";
 import { AdminPanel } from "components/organisms/AdminVenueView/components/AdminPanel";
 import { AdminShowcase } from "components/organisms/AdminVenueView/components/AdminShowcase";
 import { AdminSidebar } from "components/organisms/AdminVenueView/components/AdminSidebar";
-import { AdminSidebarTitle } from "components/organisms/AdminVenueView/components/AdminSidebarTitle";
 import { RunTabUsers } from "components/organisms/AdminVenueView/components/RunTabUsers/RunTabUsers";
 
 import { LoadingPage } from "components/molecules/LoadingPage";
 
+import { AdminSidebarSectionTitle } from "../AdminSidebarSectionTitle";
 import { MapPreview } from "../MapPreview";
 
 import "./RunTabView.scss";
@@ -32,7 +32,9 @@ export const RunTabView: React.FC<RunTabViewProps> = ({ venue }) => {
   return (
     <AdminPanel variant="unbound" className="RunTabView">
       <AdminSidebar>
-        <AdminSidebarTitle>Run your {SPACE_TAXON.lower}</AdminSidebarTitle>
+        <AdminSidebarSectionTitle>
+          Run your {SPACE_TAXON.lower}
+        </AdminSidebarSectionTitle>
         <div className="RunTabView__content">
           <RunTabUsers venueId={venueId} />
         </div>

--- a/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.scss
+++ b/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.scss
@@ -15,4 +15,8 @@
   .SpaceTimingForm {
     padding: $spacing--md;
   }
+
+  .AdminSidebarSectionTitle {
+    padding: $spacing--lg;
+  }
 }

--- a/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.tsx
+++ b/src/components/organisms/AdminVenueView/components/SpaceTimingPanel/SpaceTimingPanel.tsx
@@ -7,9 +7,9 @@ import { WithId } from "utils/id";
 import { AdminPanel } from "components/organisms/AdminVenueView/components/AdminPanel";
 import { AdminShowcase } from "components/organisms/AdminVenueView/components/AdminShowcase";
 import { AdminSidebar } from "components/organisms/AdminVenueView/components/AdminSidebar";
-import { AdminSidebarTitle } from "components/organisms/AdminVenueView/components/AdminSidebarTitle";
 import { SpaceTimingForm } from "components/organisms/SpaceTimingForm";
 
+import { AdminSidebarSectionTitle } from "../AdminSidebarSectionTitle";
 import { EventsView } from "../EventsView";
 
 import "./SpaceTimingPanel.scss";
@@ -23,7 +23,7 @@ export const SpaceTimingPanel: React.FC<SpaceTimingPanelProps> = ({
 }) => (
   <AdminPanel variant="bound" className="SpaceTimingPanel">
     <AdminSidebar>
-      <AdminSidebarTitle>Plan your event</AdminSidebarTitle>
+      <AdminSidebarSectionTitle>Plan your event</AdminSidebarSectionTitle>
       <SpaceTimingForm venue={venue} />
     </AdminSidebar>
     <AdminShowcase>


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1584

* Add missing title + fixed styles in corresponding places its used 
![image](https://user-images.githubusercontent.com/56254806/145593990-510c411f-dee4-4d3f-96b5-f6bcce93741c.png)
* Fixed no-events message display
Before:
![image](https://user-images.githubusercontent.com/56254806/145594121-4f7f082d-63ba-4ea0-b45b-d7d84bdb39cc.png)
After:
![image](https://user-images.githubusercontent.com/56254806/145594619-6d9b5bbf-ba4e-41bb-bb88-51f8d5b63a3d.png)


After: 
