### PR TITLE
Tighten up entrance steps routing

### DIFF
--- a/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
+++ b/src/components/molecules/AdminSpaceCard/AdminSpaceCard.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 
 import {
-  ATTENDEE_SPACE_INSIDE_URL,
+  ATTENDEE_INSIDE_URL,
   DEFAULT_VENUE_BANNER_COLOR,
   DEFAULT_VENUE_LOGO,
   PORTAL_INFO_ICON_MAPPING,
@@ -68,7 +68,7 @@ export const AdminSpaceCard: React.FC<AdminSpaceCardProps> = ({
           <Link
             className="AdminSpaceCard__link"
             to={generateUrl({
-              route: ATTENDEE_SPACE_INSIDE_URL,
+              route: ATTENDEE_INSIDE_URL,
               required: ["worldSlug", "spaceSlug"],
               params: { worldSlug, spaceSlug: venue.slug },
             })}

--- a/src/components/molecules/NavBar/components/NavBarLogin/NavBarLogin.tsx
+++ b/src/components/molecules/NavBar/components/NavBarLogin/NavBarLogin.tsx
@@ -1,9 +1,14 @@
 import React, { FC, useCallback } from "react";
 import { useHistory } from "react-router-dom";
 
-import { DEFAULT_SPACE_SLUG, DEFAULT_WORLD_SLUG } from "settings";
+import {
+  ATTENDEE_STEPPING_PARAM_URL,
+  DEFAULT_ENTER_STEP,
+  DEFAULT_SPACE_SLUG,
+  DEFAULT_WORLD_SLUG,
+} from "settings";
 
-import { venueEntranceUrl } from "utils/url";
+import { generateUrl } from "utils/url";
 
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
 
@@ -16,10 +21,15 @@ export const NavBarLogin: FC = () => {
   const navigateToDefault = useCallback(
     () =>
       history.push(
-        venueEntranceUrl(
-          worldSlug ?? DEFAULT_WORLD_SLUG,
-          spaceSlug ?? DEFAULT_SPACE_SLUG
-        )
+        generateUrl({
+          route: ATTENDEE_STEPPING_PARAM_URL,
+          required: ["worldSlug", "spaceSlug", "step"],
+          params: {
+            worldSlug: worldSlug ?? DEFAULT_WORLD_SLUG,
+            spaceSlug: spaceSlug ?? DEFAULT_SPACE_SLUG,
+            step: DEFAULT_ENTER_STEP,
+          },
+        })
       ),
     [history, worldSlug, spaceSlug]
   );

--- a/src/components/molecules/SecretPasswordForm/SecretPasswordForm.tsx
+++ b/src/components/molecules/SecretPasswordForm/SecretPasswordForm.tsx
@@ -1,11 +1,13 @@
 import React, { ChangeEventHandler, useCallback, useState } from "react";
 import { useHistory } from "react-router-dom";
 
+import { ATTENDEE_STEPPING_PARAM_URL, DEFAULT_ENTER_STEP } from "settings";
+
 import { checkAccess } from "api/auth";
 
 import { setLocalStorageToken } from "utils/localStorage";
 import { isDefined, isTruthy } from "utils/types";
-import { venueEntranceUrl } from "utils/url";
+import { generateUrl } from "utils/url";
 
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
 import { useWorldAndSpaceBySlug } from "hooks/spaces/useWorldAndSpaceBySlug";
@@ -59,7 +61,13 @@ const SecretPasswordForm = ({ buttonText = "Join the party" }) => {
         .then((result) => {
           if (isTruthy(result?.data?.token)) {
             setLocalStorageToken(spaceId, result.data.token);
-            history.push(venueEntranceUrl(worldSlug, spaceSlug));
+            history.push(
+              generateUrl({
+                route: ATTENDEE_STEPPING_PARAM_URL,
+                required: ["worldSlug", "spaceSlug", "step"],
+                params: { worldSlug, spaceSlug, step: DEFAULT_ENTER_STEP },
+              })
+            );
           } else {
             setMessage(`Wrong password!`);
             setError(true);

--- a/src/components/organisms/AppRouter/AppRouter.tsx
+++ b/src/components/organisms/AppRouter/AppRouter.tsx
@@ -9,11 +9,11 @@ import {
 import {
   ACCOUNT_ROOT_URL,
   ADMIN_ROOT_URL,
-  ATTENDEE_SPACE_EMERGENCY_PARAM_URL,
-  ATTENDEE_SPACE_INSIDE_URL,
-  ATTENDEE_SPACE_LANDING_URL,
+  ATTENDEE_EMERGENCY_PARAM_URL,
+  ATTENDEE_INSIDE_URL,
+  ATTENDEE_LANDING_URL,
+  ATTENDEE_STEPPING_PARAM_URL,
   ENTER_ROOT_URL,
-  ENTRANCE_STEP_VENUE_PARAM_URL,
   EXTERNAL_SPARKLE_HOMEPAGE_URL,
   EXTERNAL_SPARKLEVERSE_HOMEPAGE_URL,
   LOGIN_CUSTOM_TOKEN_PARAM_URL,
@@ -165,22 +165,22 @@ export const AppRouter: React.FC = () => {
             path={LOGIN_CUSTOM_TOKEN_PARAM_URL}
             component={LoginWithCustomToken}
           />
-          <Route path={ATTENDEE_SPACE_LANDING_URL}>
+          <Route path={ATTENDEE_LANDING_URL}>
             <Provided withRelatedVenues>
               <VenueLandingPage />
             </Provided>
           </Route>
-          <Route path={ENTRANCE_STEP_VENUE_PARAM_URL}>
+          <Route path={ATTENDEE_STEPPING_PARAM_URL}>
             <Provided withRelatedVenues>
               <VenueEntrancePage />
             </Provided>
           </Route>
-          <Route path={ATTENDEE_SPACE_INSIDE_URL}>
+          <Route path={ATTENDEE_INSIDE_URL}>
             <Provided withRelatedVenues>
               <VenuePage />
             </Provided>
           </Route>
-          <Route path={ATTENDEE_SPACE_EMERGENCY_PARAM_URL}>
+          <Route path={ATTENDEE_EMERGENCY_PARAM_URL}>
             <Provided withRelatedVenues>
               <EmergencyViewPage />
             </Provided>

--- a/src/hooks/useAdminContextCheck.tsx
+++ b/src/hooks/useAdminContextCheck.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from "react";
 import { matchPath, useLocation } from "react-router-dom";
 
-import { ADMIN_OLD_ROOT_URL, ADMIN_ROOT_URL } from "settings";
+import { ADMIN_ROOT_URL } from "settings";
 
 export const useAdminContextCheck = () => {
   const location = useLocation();
-  return useMemo(
-    () => matchPath(location.pathname, [ADMIN_ROOT_URL, ADMIN_OLD_ROOT_URL]),
-    [location]
-  );
+  return useMemo(() => matchPath(location.pathname, [ADMIN_ROOT_URL]), [
+    location,
+  ]);
 };

--- a/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
+++ b/src/pages/VenueEntrancePage/VenueEntrancePage.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback } from "react";
 import { Redirect, useHistory, useParams } from "react-router-dom";
 
-import { ACCOUNT_PROFILE_VENUE_PARAM_URL } from "settings";
+import {
+  ACCOUNT_PROFILE_VENUE_PARAM_URL,
+  ATTENDEE_STEPPING_PARAM_URL,
+} from "settings";
 
 import {
   EntranceStepTemplate,
@@ -9,11 +12,7 @@ import {
 } from "types/EntranceStep";
 
 import { isCompleteProfile } from "utils/profile";
-import {
-  generateAttendeeInsideUrl,
-  generateUrl,
-  venueEntranceUrl,
-} from "utils/url";
+import { generateAttendeeInsideUrl, generateUrl } from "utils/url";
 
 import { useSpaceParams } from "hooks/spaces/useSpaceParams";
 import { useWorldAndSpaceBySlug } from "hooks/spaces/useWorldAndSpaceBySlug";
@@ -48,8 +47,13 @@ export const VenueEntrancePage: React.FC = () => {
 
   const proceed = useCallback(
     () =>
-      spaceSlug &&
-      history.push(venueEntranceUrl(worldSlug, spaceSlug, step + 1)),
+      history.push(
+        generateUrl({
+          route: ATTENDEE_STEPPING_PARAM_URL,
+          required: ["worldSlug", "spaceSlug", "step"],
+          params: { worldSlug, spaceSlug, step: `${step + 1}` },
+        })
+      ),
     [worldSlug, spaceSlug, step, history]
   );
 
@@ -62,14 +66,9 @@ export const VenueEntrancePage: React.FC = () => {
   }
 
   const stepConfig = world.entrance?.[step - 1];
-  if (!stepConfig) {
+  if (Number.isNaN(step) || !stepConfig) {
     return (
-      <Redirect
-        to={generateAttendeeInsideUrl({
-          worldSlug: world.slug,
-          spaceSlug: spaceSlug,
-        })}
-      />
+      <Redirect to={generateAttendeeInsideUrl({ worldSlug, spaceSlug })} />
     );
   }
 

--- a/src/pages/VenueLandingPage/VenueLandingPageContent.tsx
+++ b/src/pages/VenueLandingPage/VenueLandingPageContent.tsx
@@ -8,6 +8,8 @@ import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 
 import {
+  ATTENDEE_STEPPING_PARAM_URL,
+  DEFAULT_ENTER_STEP,
   DEFAULT_LANDING_BANNER,
   DEFAULT_VENUE_LOGO,
   IFRAME_ALLOW,
@@ -22,7 +24,7 @@ import { eventEndTime, eventStartTime, hasEventFinished } from "utils/event";
 import { WithId } from "utils/id";
 import { venueEventsSelector } from "utils/selectors";
 import { formatTimeLocalised, getTimeBeforeParty } from "utils/time";
-import { generateAttendeeInsideUrl, venueEntranceUrl } from "utils/url";
+import { generateAttendeeInsideUrl, generateUrl } from "utils/url";
 
 import { useValidImage } from "hooks/useCheckImage";
 import { useSelector } from "hooks/useSelector";
@@ -60,15 +62,21 @@ const VenueLandingPageContent: React.FC<VenueLandingPageContentProps> = ({
   );
   const nextVenueEventId = futureOrOngoingVenueEvents?.[0]?.id;
 
+  // @debt use callback hook and history push
   const onJoinClick = () => {
     if (!spaceSlug) return;
 
     const hasEntrance = world?.entrance?.length;
+    const worldSlug = world?.slug;
 
     window.location.href =
       user && !hasEntrance
-        ? generateAttendeeInsideUrl({ worldSlug: world?.slug, spaceSlug })
-        : venueEntranceUrl(world?.slug, spaceSlug);
+        ? generateAttendeeInsideUrl({ worldSlug, spaceSlug })
+        : generateUrl({
+            route: ATTENDEE_STEPPING_PARAM_URL,
+            required: ["worldSlug", "spaceSlug", "step"],
+            params: { worldSlug, spaceSlug, step: DEFAULT_ENTER_STEP },
+          });
   };
 
   const isPasswordRequired = space.access === VenueAccessMode.Password;
@@ -87,7 +95,7 @@ const VenueLandingPageContent: React.FC<VenueLandingPageContentProps> = ({
   const containerClasses = classNames("header", containerVars);
 
   return (
-    <div className="container venue-entrance-experience-container">
+    <div className="VenueLandingPageContent container venue-entrance-experience-container">
       <div className={containerClasses}>
         <div className="venue-host">
           <div className="host-icon-container">

--- a/src/pages/VenuePage/VenuePage.tsx
+++ b/src/pages/VenuePage/VenuePage.tsx
@@ -4,6 +4,8 @@ import { useTitle } from "react-use";
 
 import {
   ACCOUNT_PROFILE_VENUE_PARAM_URL,
+  ATTENDEE_STEPPING_PARAM_URL,
+  DEFAULT_ENTER_STEP,
   LOC_UPDATE_FREQ_MS,
   PLATFORM_BRAND_NAME,
 } from "settings";
@@ -23,7 +25,7 @@ import {
 } from "utils/selectors";
 import { wrapIntoSlashes } from "utils/string";
 import { isDefined } from "utils/types";
-import { generateUrl, venueEntranceUrl } from "utils/url";
+import { generateUrl } from "utils/url";
 import { isCompleteUserInfo } from "utils/user";
 import {
   clearLocationData,
@@ -253,7 +255,15 @@ export const VenuePage: React.FC = () => {
   const hasEntered = world?.id && enteredWorldIds?.includes(world.id);
 
   if (hasEntrance && !hasEntered) {
-    return <Redirect to={venueEntranceUrl(worldSlug, spaceSlug)} />;
+    return (
+      <Redirect
+        to={generateUrl({
+          route: ATTENDEE_STEPPING_PARAM_URL,
+          required: ["worldSlug", "spaceSlug", "step"],
+          params: { worldSlug, spaceSlug, step: DEFAULT_ENTER_STEP },
+        })}
+      />
+    );
   }
 
   if (checkSupportsPaidEvents(template) && hasPaidEvents && !isUserVenueOwner) {

--- a/src/pages/entrance/WelcomeVideo/WelcomeVideo.tsx
+++ b/src/pages/entrance/WelcomeVideo/WelcomeVideo.tsx
@@ -23,11 +23,13 @@ export const WelcomeVideo: React.FunctionComponent<EntranceStepTemplateProps> = 
   const defaultWelcomeText = `Welcome to ${venueName}! Please watch this video to get started.`;
 
   return (
-    <div className="splash-page-container">
-      <div className="step-container">
-        <h2>{welcomeText ?? defaultWelcomeText}</h2>
+    <div className="WelcomeVideo splash-page-container">
+      <div className="WelcomeVideo__step-container step-container">
+        <h2 className="WelcomeVideo__header">
+          {welcomeText ?? defaultWelcomeText}
+        </h2>
         <iframe
-          className="video"
+          className="WelcomeVideo__video video"
           title="art-piece-video"
           src={convertToEmbeddableUrl({ url, autoPlay })}
           frameBorder="0"

--- a/src/settings/urlSettings.ts
+++ b/src/settings/urlSettings.ts
@@ -1,6 +1,12 @@
 import { SpaceSlug } from "types/venues";
 import { WorldSlug } from "types/world";
 
+export const DEFAULT_SPACE_SLUG = "bootstrap" as SpaceSlug;
+export const DEFAULT_WORLD_SLUG = "bootstrap" as WorldSlug;
+export const DEFAULT_ENTER_STEP = "1";
+
+export const DEFAULT_MISSING_PARAM_URL = "#";
+
 export const VALID_URL_PROTOCOLS = Object.freeze(["https:"]);
 
 // External Sparkle URLs
@@ -19,32 +25,29 @@ export const EXTERNAL_SPARKLEVERSE_COMMUNITY_URL =
 
 // NOTE: URLs ending with _PARAM_URL aren't meant for direct browser consumption but React router
 // NOTE: URLs ending with _ROOT_URL are the bases for sub-routers and URLs used inside them
-// NOTE: URLs ending with _BASE_URL are the bases for other (often parametrized) URLs, but not at subrouter level
+// NOTE: URLs ending with _BASE_URL are the bases for other (often parametrized) URLs, but not at sub-router level
 
-// Top level and attendee URLs
+// Top level URLs
 export const ROOT_URL = "/";
 
 export const ACCOUNT_ROOT_URL = "/account";
-export const ADMIN_OLD_ROOT_URL = "/a1";
 export const ADMIN_ROOT_URL = "/admin";
 export const ENTER_ROOT_URL = "/enter";
-const ENTRANCE_BASE_URL = "/e";
-const LOGIN_BASE_URL = `/login`;
 export const SPARKLEVERSE_REDIRECT_URL = "/sparkleverse";
 export const VERSION_URL = "/version";
-const SPACE_EMERGENCY_BASE_URL = "/m";
-const SPACE_INSIDE_BASE_URL = "/in";
-const SPACE_LANDING_BASE_URL = "/v";
-export const WORLD_ROOT_URL = "/w";
 
-export const DEFAULT_SPACE_SLUG = "bootstrap" as SpaceSlug;
-export const DEFAULT_WORLD_SLUG = "bootstrap" as WorldSlug;
+// Attendee URLs
+const EMERGENCY_BASE_URL = "/m";
+const INSIDE_BASE_URL = "/in";
+const LANDING_BASE_URL = "/v";
+const ENTRANCE_BASE_URL = "/e";
+const LOGIN_BASE_URL = `/login`;
 
-export const ATTENDEE_SPACE_EMERGENCY_PARAM_URL = `${SPACE_EMERGENCY_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
-export const ATTENDEE_SPACE_INSIDE_URL = `${SPACE_INSIDE_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
-export const ATTENDEE_SPACE_LANDING_URL = `${SPACE_LANDING_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
+export const ATTENDEE_EMERGENCY_PARAM_URL = `${EMERGENCY_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
+export const ATTENDEE_INSIDE_URL = `${INSIDE_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
+export const ATTENDEE_LANDING_URL = `${LANDING_BASE_URL}/w/:worldSlug/s/:spaceSlug`;
+export const ATTENDEE_STEPPING_PARAM_URL = `${ENTRANCE_BASE_URL}/w/:worldSlug/s/:spaceSlug/:step`;
 
-export const ENTRANCE_STEP_VENUE_PARAM_URL = `${ENTRANCE_BASE_URL}/:worldSlug/:step/:spaceSlug`;
 // @debt I don't think we support custom tokens right now. Probably remove this.
 export const LOGIN_CUSTOM_TOKEN_PARAM_URL = `${LOGIN_BASE_URL}/:spaceSlug/:customToken`;
 
@@ -56,7 +59,7 @@ export const ACCOUNT_PROFILE_QUESTIONS_URL = `${ACCOUNT_ROOT_URL}/questions/:wor
 
 // Admin IA URLs
 export const ADMIN_IA_WORLD_BASE_URL = `${ADMIN_ROOT_URL}/w`; // e.g. /admin/w
-export const ADMIN_IA_WORLD_CREATE_URL = `${ADMIN_ROOT_URL}/create-world`; // e.g. /admin/w/world123/entrance
+export const ADMIN_IA_WORLD_CREATE_URL = `${ADMIN_ROOT_URL}/create-world`; // e.g. /admin/create-world
 export const ADMIN_IA_WORLD_PARAM_URL = `${ADMIN_IA_WORLD_BASE_URL}/:worldSlug`; // e.g. /admin/w/world123
 export const ADMIN_IA_WORLD_EDIT_PARAM_URL = `${ADMIN_IA_WORLD_PARAM_URL}/settings/:selectedTab?`; // e.g. /admin/w/world123/entrance
 export const ADMIN_IA_SPACE_BASE_PARAM_URL = `${ADMIN_IA_WORLD_PARAM_URL}/s`; // e.g. /admin/w/world123/s

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -4,9 +4,9 @@ import Bugsnag from "@bugsnag/js";
 import {
   ADMIN_IA_SPACE_EDIT_PARAM_URL,
   ADMIN_IA_WORLD_PARAM_URL,
-  ATTENDEE_SPACE_INSIDE_URL,
-  ATTENDEE_SPACE_LANDING_URL,
-  ENTRANCE_STEP_VENUE_PARAM_URL,
+  ATTENDEE_INSIDE_URL,
+  ATTENDEE_LANDING_URL,
+  DEFAULT_MISSING_PARAM_URL,
   VALID_URL_PROTOCOLS,
 } from "settings";
 
@@ -14,18 +14,20 @@ import { Room } from "types/rooms";
 import { SpaceSlug } from "types/venues";
 import { WorldSlug } from "types/world";
 
-// @debt most of these (a,b,c)=>generatePath(PATH,{}) function should be just inlined where called
-// like to={generatePath(params)} or actually have logic inside them that deals with missing params
+// @debt most of these (a,b,c)=>generatePath(PATH,{}) functions should be replaced with inlined  generateUrl
 
-const DEFAULT_MISSING_PARAM_URL = "#";
-
-export const generateUrl: (options: {
+type GenerateUrlParams = Record<string, string | undefined> | undefined;
+type GenerateUrlOptions<T = GenerateUrlParams> = {
   route: string;
   fallback?: string;
   required?: string[];
   absolute?: boolean;
-  params: Record<string, string | undefined>;
-}) => string = ({
+  params: T;
+};
+
+export const generateUrl: <T = GenerateUrlParams>(
+  options: GenerateUrlOptions<T>
+) => string = ({
   route,
   fallback = DEFAULT_MISSING_PARAM_URL,
   required = [],
@@ -44,7 +46,10 @@ export const generateUrl: (options: {
     return fallback;
   }
 
-  const relativePath = generatePath(route, params);
+  // NOTE: ?? {} stops TS from crying and the check makes the shorter generatePath is used
+  const relativePath = params
+    ? generatePath(route, params ?? {})
+    : generatePath(route);
 
   // also be helpful with generating external links
   return absolute
@@ -84,7 +89,7 @@ export const generateAttendeeInsideUrl = ({
   spaceSlug,
   absoluteUrl = false,
 }: generateAttendeeInsideUrlOptions) => {
-  const relativePath = generatePath(ATTENDEE_SPACE_INSIDE_URL, {
+  const relativePath = generatePath(ATTENDEE_INSIDE_URL, {
     worldSlug,
     spaceSlug,
   });
@@ -101,20 +106,7 @@ export const generateAttendeeInsideUrl = ({
 export const generateAttendeeSpaceLandingUrl = (
   worldSlug?: WorldSlug,
   spaceSlug?: SpaceSlug
-) => generatePath(ATTENDEE_SPACE_LANDING_URL, { worldSlug, spaceSlug });
-
-/** @deprecated use generateUrl instead */
-export const venueEntranceUrl = (
-  worldSlug?: WorldSlug,
-  spaceSlug?: SpaceSlug,
-  step?: number
-) => {
-  return generatePath(ENTRANCE_STEP_VENUE_PARAM_URL, {
-    worldSlug,
-    spaceSlug,
-    step: step ?? 1,
-  });
-};
+) => generatePath(ATTENDEE_LANDING_URL, { worldSlug, spaceSlug });
 
 export const isExternalUrl = (url: string) => {
   try {


### PR DESCRIPTION
Couldn't reproduce what is described in
- https://github.com/sparkletown/internal-sparkle-issues/issues/1613

Instead tightened up the routing connected to entrance steps:
- URLs more in line with general strategy `/e/w/mysharkyworld/s/myconversationspace/1`
- use of `generateUrl` for more explicit and robust route generation
- removed ` spaceSlug &&` check since it is legacy and not needed
- added not-a-number check for the entrance step
- a bit more consolidation work in the URL constants