### PR TITLE
removed stats dependency from firebase functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -30,7 +30,6 @@ admin.initializeApp({
 
 const access = require("./access");
 const auth = require("./auth");
-const stats = require("./stats");
 const venue = require("./venue");
 const video = require("./video");
 const scheduled = require("./scheduled");


### PR DESCRIPTION
Fix for failed builds due to missing `stats` dependency in firebase functions

![image](https://user-images.githubusercontent.com/56254806/146787070-b6c11b61-7a4b-4045-92a9-2cc7464edc28.png)
![image](https://user-images.githubusercontent.com/56254806/146787096-6940912f-141f-47e9-a0bd-89d603a4af8a.png)
