### PR TITLE
Fix for wiping images when editing portals

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -295,34 +295,23 @@ const createFirestoreRoomInput = async (
   const urlPortalName = createSlug(
     input.title + Math.random().toString() //room titles are not necessarily unique
   );
-  type ImageNaming = {
-    fileKey: RoomImageFileKeys;
-    urlKey: RoomImageUrlKeys;
-  };
-  const imageKeys: Array<ImageNaming> = [
-    {
-      fileKey: "image_file",
-      urlKey: "image_url",
-    },
-  ];
 
   let imageInputData = {};
 
   // upload the files
-  for (const entry of imageKeys) {
-    const fileArr = input[entry.fileKey];
+  if (input["image_file"]) {
+    const fileArr = input["image_file"];
     const downloadUrl = await uploadFile(
       `users/${user.uid}/venues/${venueId}/${urlPortalName}`,
       fileArr
     );
-    imageInputData = { ...imageInputData, [entry.urlKey]: downloadUrl };
+    imageInputData = { image_url: downloadUrl };
+  } else {
+    imageInputData = { image_url: input.image_url };
   }
 
   const firestoreRoomInput: FirestoreRoomInput = {
-    ...omit(
-      input,
-      imageKeys.map((entry) => entry.fileKey)
-    ),
+    ...omit(input, "image_file"),
     ...imageInputData,
   };
   return firestoreRoomInput;

--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
@@ -50,6 +50,9 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
   // @debt: Probably need to omit returning playa from the useOwnedVenues as it's deprecated and
   // doesn't exist on SPACE_PORTALS_ICONS_MAPPING
   const spacesWithoutPlaya = omit(spaces, VenueTemplate.playa);
+  // @debt Filter out all the poster pages as poster hall currently uses (abuses?)
+  // spaces by creating a space for every single poster page. They aren't
+  // proper spaces though. We should make a better way of handling this.
   const filteredSpaces = omitBy(
     spacesWithoutPlaya,
     (s) => s.template === VenueTemplate.posterpage

--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Dropdown as ReactBootstrapDropdown } from "react-bootstrap";
 import { FieldError, useForm } from "react-hook-form";
-import { omit } from "lodash";
+import { omit, omitBy } from "lodash";
 
 import { PORTAL_INFO_ICON_MAPPING } from "settings";
 
@@ -49,7 +49,11 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
 
   // @debt: Probably need to omit returning playa from the useOwnedVenues as it's deprecated and
   // doesn't exist on SPACE_PORTALS_ICONS_MAPPING
-  const filteredSpaces = omit(spaces, VenueTemplate.playa);
+  const spacesWithoutPlaya = omit(spaces, VenueTemplate.playa);
+  const filteredSpaces = omitBy(
+    spacesWithoutPlaya,
+    (s) => s.template === VenueTemplate.posterpage
+  );
   const sortedSpaces = useMemo(
     () =>
       Object.values(filteredSpaces).sort((a, b) =>


### PR DESCRIPTION
# Prior to this change
When editing a portal (without changing the image), the `image_url` would be set to undefined in the payload for the upsertRoom cloud function. This resulted in the cloud function wiping that field in the database and no images appearing in the attendee side. 

# This change
Simplifies the logic that deals with image uploads and doesn't wipe that field if a new image is not provided.