### PR TITLE
Remove inline styles from <Select> in <Dropdown>

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.scss
+++ b/src/components/atoms/Dropdown/Dropdown.scss
@@ -6,26 +6,9 @@
   border-radius: 50px;
   box-shadow: none;
   outline: none;
+  width: 100%;
 
-  &__button__control {
-    cursor: pointer;
-    padding: 8px;
-  }
-
-  &__button__input-container {
-    height: 0px;
-    border: none;
-    outline: none;
-    padding: 0px;
-    margin: 0px;
-    opacity: 0px;
-
-    & .Dropdown__button__input {
-      opacity: 0 !important;
-    }
-  }
-
-  &__button {
+  .Select {
     display: flex;
     align-items: center;
     padding: $spacing--md $spacing--xl;
@@ -37,28 +20,75 @@
     &:focus,
     &:hover {
       background: opaque-white(0.2);
-      box-shadow: 0px 2px 4px opaque-black(0.25);
+      box-shadow: 0 2px 4px opaque-black(0.25);
       border-radius: $border-radius--xl;
     }
-  }
 
-  &__button__menu {
-    background: var(--content--under-lighter-20pp);
-    box-shadow: 0px 10px 20px opaque-black(0.25);
-    border-radius: $border-radius--lg;
-    z-index: 1;
-  }
+    &__control {
+      cursor: pointer;
+      padding: 8px;
+      background: transparent;
+      border: none;
+      border-radius: $border-radius--xl;
+      box-shadow: none;
+      outline: none;
+      display: flex;
+    }
 
-  &__button__option {
-    cursor: pointer;
+    &__menu {
+      background: var(--content--under-lighter-20pp);
+      box-shadow: 0 10px 20px opaque-black(0.25);
+      border-radius: $border-radius--xl;
+      z-index: 1;
+      max-height: 240px;
+      position: absolute;
+      top: 45px;
+      overflow: auto;
+      cursor: default;
+      width: 100%;
+    }
 
-    &:hover {
-      background: opaque-white(0.2);
+    &__menu-list {
+      max-height: 240px;
+    }
+
+    &__option {
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+      font-size: 14px;
+      line-height: 17px;
+      padding: 0;
+      cursor: pointer;
+
+      &:hover {
+        background: opaque-white(0.2);
+      }
+    }
+
+    &__input-container {
+      height: 0;
+      border: none;
+      outline: none;
+      padding: 0;
+      margin: 0;
+      opacity: 0;
+    }
+
+    &__input-container &__input {
+      opacity: 0 !important;
+    }
+
+    &__single-value {
+      color: white;
+    }
+
+    &__indicator-separator {
+      display: none;
     }
   }
 
-  .Dropdown__button__input-container {
-    margin: 0px;
-    padding: 0px;
+  &--arrowless .Select__dropdown-indicator {
+    display: none;
   }
 }

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -1,11 +1,16 @@
-import React, { ReactNode } from "react";
+import React, { ReactElement, ReactNode } from "react";
 import Select, { MenuPlacement } from "react-select";
 import classNames from "classnames";
 
-import { ALWAYS_NO_STYLE_FUNCTION } from "settings";
+import {
+  ALWAYS_EMPTY_ARRAY,
+  ALWAYS_EMPTY_SELECT_OPTION,
+  ALWAYS_NO_STYLE_FUNCTION,
+} from "settings";
 
 import "./Dropdown.scss";
 
+// if these are undefined, the 3rd party library will provide own defaults
 const NO_INLINE_STYLES_PLEASE = {
   menu: ALWAYS_NO_STYLE_FUNCTION,
   option: ALWAYS_NO_STYLE_FUNCTION,
@@ -17,9 +22,31 @@ const NO_INLINE_STYLES_PLEASE = {
 };
 Object.freeze(NO_INLINE_STYLES_PLEASE);
 
+const DROPDOWN_VALUE_PROP = "data-dropdown-value";
+type DropdownItemProps = { [DROPDOWN_VALUE_PROP]?: string };
+
+const remap: (label: ReactNode) => { label: ReactNode; value: string } = (
+  reactNode
+) => {
+  if (null === reactNode || undefined === reactNode || "" === reactNode) {
+    return ALWAYS_EMPTY_SELECT_OPTION;
+  }
+
+  const type = typeof reactNode;
+
+  return type === "string" || type === "number" || type === "boolean"
+    ? { label: reactNode, value: String(reactNode) }
+    : {
+        label: reactNode,
+        value:
+          (reactNode as ReactElement<DropdownItemProps>).props[
+            DROPDOWN_VALUE_PROP
+          ] ?? "",
+      };
+};
+
 interface DropdownProps {
-  title: { value: string; label: ReactNode };
-  options: { value: string; label: ReactNode }[];
+  title?: ReactNode;
   className?: string;
   placement?: MenuPlacement;
   noArrow?: boolean;
@@ -27,22 +54,29 @@ interface DropdownProps {
 
 export const Dropdown: React.FC<DropdownProps> = ({
   title,
-  options,
   className,
   placement,
   noArrow,
-}) => (
-  <Select
-    className={classNames(
-      className,
-      "Dropdown",
-      noArrow ? "Dropdown--arrowless" : "Dropdown--arrowful"
-    )}
-    classNamePrefix="Select"
-    value={title}
-    options={options}
-    placeholder={title}
-    menuPlacement={placement}
-    styles={NO_INLINE_STYLES_PLEASE}
-  />
-);
+  children,
+}) => {
+  const value = remap(title);
+  const options = React.Children.map(children, remap) ?? ALWAYS_EMPTY_ARRAY;
+
+  const containerClasses = classNames(
+    className,
+    "Dropdown",
+    noArrow ? "Dropdown--arrowless" : "Dropdown--arrowful"
+  );
+
+  return (
+    <Select
+      className={containerClasses}
+      classNamePrefix="Select"
+      value={value}
+      placeholder={value}
+      options={options}
+      menuPlacement={placement}
+      styles={NO_INLINE_STYLES_PLEASE}
+    />
+  );
+};

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -1,9 +1,23 @@
 import React, { ReactNode } from "react";
-import Select, { MenuPlacement, MenuPosition } from "react-select";
+import Select, { MenuPlacement } from "react-select";
+import classNames from "classnames";
+
+import { NO_STYLE_FUNCTION } from "settings";
 
 import "./Dropdown.scss";
 
-export interface DropdownProps {
+const NO_INLINE_STYLES_PLEASE = {
+  menu: NO_STYLE_FUNCTION,
+  option: NO_STYLE_FUNCTION,
+  control: NO_STYLE_FUNCTION,
+  menuList: NO_STYLE_FUNCTION,
+  singleValue: NO_STYLE_FUNCTION,
+  dropdownIndicator: NO_STYLE_FUNCTION,
+  indicatorSeparator: NO_STYLE_FUNCTION,
+};
+Object.freeze(NO_INLINE_STYLES_PLEASE);
+
+interface DropdownProps {
   title: { value: string; label: ReactNode };
   options: { value: string; label: ReactNode }[];
   className?: string;
@@ -17,48 +31,18 @@ export const Dropdown: React.FC<DropdownProps> = ({
   className,
   placement,
   noArrow,
-}) => {
-  const styles = {
-    indicatorSeparator: () => ({ display: "none" }),
-    control: () => ({
-      background: "transparent",
-      border: "none",
-      borderRadius: "20px",
-      boxShadow: "none",
-      outline: "none",
-      display: "flex",
-    }),
-    singleValue: () => ({ color: "white" }),
-    option: () => ({
-      display: "flex",
-      alignitems: "center",
-      textDecoration: "none",
-      fontSize: "14px",
-      lineHeight: "17px",
-      padding: "0px",
-      cursor: "pointer",
-    }),
-    menu: () => ({
-      borderRadius: "20px",
-      maxHeight: "240px",
-      position: "absolute" as MenuPosition,
-      top: "45px",
-      overflow: "auto",
-      cursor: "default",
-    }),
-    menuList: () => ({ maxHeight: "240px" }),
-    dropdownIndicator: () => ({ ...(noArrow && { display: "none" }) }),
-  };
-
-  return (
-    <Select
-      value={title}
-      className={className || "Dropdown"}
-      classNamePrefix="Dropdown__button"
-      options={options}
-      placeholder={title}
-      styles={styles}
-      menuPlacement={placement}
-    />
-  );
-};
+}) => (
+  <Select
+    className={classNames(
+      className,
+      "Dropdown",
+      noArrow ? "Dropdown--arrowless" : "Dropdown--arrowful"
+    )}
+    classNamePrefix="Select"
+    value={title}
+    options={options}
+    placeholder={title}
+    menuPlacement={placement}
+    styles={NO_INLINE_STYLES_PLEASE}
+  />
+);

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -2,18 +2,18 @@ import React, { ReactNode } from "react";
 import Select, { MenuPlacement } from "react-select";
 import classNames from "classnames";
 
-import { NO_STYLE_FUNCTION } from "settings";
+import { ALWAYS_NO_STYLE_FUNCTION } from "settings";
 
 import "./Dropdown.scss";
 
 const NO_INLINE_STYLES_PLEASE = {
-  menu: NO_STYLE_FUNCTION,
-  option: NO_STYLE_FUNCTION,
-  control: NO_STYLE_FUNCTION,
-  menuList: NO_STYLE_FUNCTION,
-  singleValue: NO_STYLE_FUNCTION,
-  dropdownIndicator: NO_STYLE_FUNCTION,
-  indicatorSeparator: NO_STYLE_FUNCTION,
+  menu: ALWAYS_NO_STYLE_FUNCTION,
+  option: ALWAYS_NO_STYLE_FUNCTION,
+  control: ALWAYS_NO_STYLE_FUNCTION,
+  menuList: ALWAYS_NO_STYLE_FUNCTION,
+  singleValue: ALWAYS_NO_STYLE_FUNCTION,
+  dropdownIndicator: ALWAYS_NO_STYLE_FUNCTION,
+  indicatorSeparator: ALWAYS_NO_STYLE_FUNCTION,
 };
 Object.freeze(NO_INLINE_STYLES_PLEASE);
 

--- a/src/components/atoms/SortDropDown/SortDropDown.scss
+++ b/src/components/atoms/SortDropDown/SortDropDown.scss
@@ -1,10 +1,6 @@
 @import "scss/constants";
 
 .SortDropDown {
-  // NOTE: this dropdown mimics the appearance of the ButtonNG default style
-  // NOTE: it is needed to mitigate the effects of the global SCSS file and Bootstrap
-
-  display: inline-block;
   margin: $spacing--xs;
   width: $button-width--normal;
   max-width: $button-width--max;
@@ -26,13 +22,7 @@
     width: 100%;
   }
 
-  .Dropdown__button__menu {
-    position: absolute;
-    left: -65px;
-  }
-
-  .Dropdown__button__option {
-    padding: 8px 12px;
-    text-decoration: underline;
+  .Dropdown .Select__option {
+    padding: $spacing--sm font-size--parent(2);
   }
 }

--- a/src/components/atoms/SortDropDown/SortDropDown.tsx
+++ b/src/components/atoms/SortDropDown/SortDropDown.tsx
@@ -14,24 +14,19 @@ interface SortDropDownProps {
 export const SortDropDown: React.FC<SortDropDownProps> = ({
   onClick,
   title,
-}) => {
-  const name = { value: title, label: title };
-  const options = Object.values(SortingOptions).map((sortingOption) => ({
-    value: sortingOption,
-    label: (
-      <div
-        key={sortingOption}
-        onClick={() => onClick(sortingOption)}
-        className="SortDropDown__option"
-      >
-        {sortingOption}
-      </div>
-    ),
-  }));
-
-  return (
-    <div className="SortDropDown">
-      <Dropdown title={name} options={options} />
-    </div>
-  );
-};
+}) => (
+  <div className="SortDropDown">
+    <Dropdown title={title}>
+      {Object.values(SortingOptions).map((key) => (
+        <div
+          key={key}
+          className="SortDropDown__option"
+          onClick={() => onClick(key)}
+          data-dropdown-value={key}
+        >
+          {key}
+        </div>
+      ))}
+    </Dropdown>
+  </div>
+);

--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.scss
@@ -45,31 +45,31 @@ $dropddown-list-max-height: 250px;
 
     &:hover {
       background: opaque-white(0.2);
-      box-shadow: 0px 2px 4px opaque-black(0.25);
+      box-shadow: 0 2px 4px opaque-black(0.25);
       border-radius: $border-radius--xl;
     }
-  }
 
-  .Dropdown__button__menu {
-    background: var(--content--under-lighter-20pp);
-    box-shadow: 0px 10px 20px opaque-black(0.25);
-    border-radius: $border-radius--lg;
-  }
+    .Select {
+      display: flex;
+      align-items: center;
+      padding: $spacing--md $spacing--xl;
 
-  .Dropdown__button {
-    display: flex;
-    align-items: center;
-    padding: $spacing--md $spacing--xl;
+      font-size: $font-size--lg;
+      font-weight: $font-weight--500;
+      line-height: 19px;
 
-    font-size: $font-size--lg;
-    font-weight: $font-weight--500;
-    line-height: 19px;
+      &:focus,
+      &:hover {
+        background: opaque-white(0.2);
+        box-shadow: 0 2px 4px opaque-black(0.25);
+        border-radius: $border-radius--xl;
+      }
 
-    &:focus,
-    &:hover {
-      background: opaque-white(0.2);
-      box-shadow: 0px 2px 4px opaque-black(0.25);
-      border-radius: $border-radius--xl;
+      &__menu {
+        background: var(--content--under-lighter-20pp);
+        box-shadow: 0 10px 20px opaque-black(0.25);
+        border-radius: $border-radius--lg;
+      }
     }
   }
 }

--- a/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
+++ b/src/components/atoms/SpacesDropdown/SpacesDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { FieldError, useForm } from "react-hook-form";
 import { omit, omitBy } from "lodash";
 
-import { PORTAL_INFO_ICON_MAPPING } from "settings";
+import { ALWAYS_EMPTY_ARRAY, PORTAL_INFO_ICON_MAPPING } from "settings";
 
 import { AnyVenue, PortalTemplate } from "types/venues";
 import { VenueTemplate } from "types/VenueTemplate";
@@ -80,29 +80,27 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
       spaceOptions.map(({ id, name, template }) => {
         const spaceIcon = PORTAL_INFO_ICON_MAPPING[template ?? ""];
 
-        return {
-          value: name,
-          label: (
-            <div
-              key={id}
-              onClick={() => {
-                setSelected({ name, template, id });
-                setValue(fieldName, id, true);
-              }}
-              className="SpacesDropdown__item"
-            >
-              {name !== spaceNoneOption.name ? (
-                <img
-                  alt={`space-icon-${spaceIcon}`}
-                  src={spaceIcon}
-                  className="SpacesDropdown__item-icon"
-                />
-              ) : null}
-              {name || noneOptionName}
-            </div>
-          ),
-        };
-      }) ?? [],
+        return (
+          <div
+            key={id}
+            onClick={() => {
+              setSelected({ name, template, id });
+              setValue(fieldName, id, true);
+            }}
+            className="SpacesDropdown__item"
+            data-dropdown-value={name}
+          >
+            {name !== spaceNoneOption.name ? (
+              <img
+                alt={`space-icon-${spaceIcon}`}
+                src={spaceIcon}
+                className="SpacesDropdown__item-icon"
+              />
+            ) : null}
+            {name || noneOptionName}
+          </div>
+        );
+      }) ?? ALWAYS_EMPTY_ARRAY,
     [spaceOptions, setValue, fieldName]
   );
 
@@ -115,27 +113,27 @@ export const SpacesDropdown: React.FC<SpacesDropdownProps> = ({
 
     const spaceIcon = PORTAL_INFO_ICON_MAPPING[space?.template ?? ""];
 
-    return {
-      value: selected.name,
-      label: (
-        <span className="SpacesDropdown__value">
-          {selected.name !== spaceNoneOption.name ? (
-            <img
-              alt={`space-icon-${spaceIcon}`}
-              src={spaceIcon}
-              className="SpacesDropdown__item-icon"
-            />
-          ) : null}
-          {selected.name || noneOptionName}
-        </span>
-      ),
-    };
+    return (
+      <span
+        className="SpacesDropdown__value"
+        data-dropdown-value={selected.name}
+      >
+        {selected.name !== spaceNoneOption.name ? (
+          <img
+            alt={`space-icon-${spaceIcon}`}
+            src={spaceIcon}
+            className="SpacesDropdown__item-icon"
+          />
+        ) : null}
+        {selected.name || noneOptionName}
+      </span>
+    );
   }, [spaces, selected, parentSpace]);
 
   return (
     <>
       <div className="SpacesDropdown">
-        <Dropdown title={renderedTitle} options={renderedOptions} />
+        <Dropdown title={renderedTitle}>{renderedOptions}</Dropdown>
         <input type="hidden" ref={register} name={fieldName} />
       </div>
       {error && <span className="input-error">{error.message}</span>}

--- a/src/components/atoms/UserStatusDropdown/UserStatusDropdown.scss
+++ b/src/components/atoms/UserStatusDropdown/UserStatusDropdown.scss
@@ -8,45 +8,39 @@
     font-weight: $font-weight--500;
   }
 
-  .Dropdown {
-    &__button__menu {
-      top: 30px;
-      width: 150px;
-    }
+  &__item {
+    text-decoration: none;
+    display: flex;
+    justify-content: space-between;
+    margin: auto;
+    opacity: 0.8;
+    width: 100%;
+    padding: $spacing--sm;
   }
 
-  .Dropdown__button {
+  .Dropdown .Select {
     text-decoration: underline;
     font-weight: $font-weight--400;
 
     &::after {
       display: none;
     }
-  }
 
-  &__item {
-    text-decoration: none;
-    display: flex;
-    justify-content: space-between;
-    padding: 0 $spacing--md;
-    margin: auto;
-    opacity: 0.8;
-    width: 100%;
-  }
+    &__menu {
+      top: 30px;
+      width: 150px;
+    }
 
-  .Dropdown__button__value-container {
-    padding: 0px;
-  }
+    &__value-container {
+      padding: 0;
+    }
 
-  .Dropdown__button__single-value {
-    text-decoration: underline;
-  }
+    &__single-value {
+      text-decoration: underline;
+    }
 
-  .Dropdown__button__control {
-    padding: 0px;
-  }
-
-  &__item {
-    padding: 8px;
+    &__control {
+      padding: 0;
+    }
   }
 }

--- a/src/components/atoms/UserStatusDropdown/UserStatusDropdown.tsx
+++ b/src/components/atoms/UserStatusDropdown/UserStatusDropdown.tsx
@@ -35,18 +35,16 @@ export const UserStatusDropdown: React.FC<UserStatusDropdownProps> = ({
 
   const userStatusDropdownOptions = useMemo(
     () =>
-      userStatuses.map((userStatus) => ({
-        value: userStatus.status,
-        label: (
-          <div
-            className="UserStatusDropdown__item"
-            key={userStatus.status}
-            onClick={() => changeUserStatus(userStatus.status)}
-          >
-            {userStatus.status}
-          </div>
-        ),
-      })),
+      userStatuses.map((userStatus) => (
+        <div
+          className="UserStatusDropdown__item"
+          key={userStatus.status}
+          onClick={() => changeUserStatus(userStatus.status)}
+          data-dropdown-value={userStatus.status}
+        >
+          {userStatus.status}
+        </div>
+      )),
     [userStatuses, changeUserStatus]
   );
 
@@ -56,11 +54,9 @@ export const UserStatusDropdown: React.FC<UserStatusDropdownProps> = ({
         {userStatus.status}&nbsp;
       </div>
       {showDropdown && (
-        <Dropdown
-          title={{ label: "change status", value: "change status" }}
-          options={userStatusDropdownOptions}
-          noArrow
-        />
+        <Dropdown title="change status" noArrow>
+          {userStatusDropdownOptions}
+        </Dropdown>
       )}
     </div>
   );

--- a/src/components/molecules/Chatbox/components/ChatboxOptionsControls/ChatboxOptionsControls.tsx
+++ b/src/components/molecules/Chatbox/components/ChatboxOptionsControls/ChatboxOptionsControls.tsx
@@ -23,19 +23,17 @@ export const ChatboxOptionsControls: React.FC<ChatboxOptionsControlsProps> = ({
 
   const dropdownOptions = useMemo(
     () =>
-      ChatMessageOptions.map((option) => ({
-        value: option.name,
-        label: (
-          <div
-            key={option.name}
-            onClick={() => setActiveOption(option.type)}
-            className="ChatboxOptionsControls__option"
-          >
-            <span>{option.name}</span>
-            <FontAwesomeIcon icon={option.icon} />
-          </div>
-        ),
-      })),
+      ChatMessageOptions.map((option) => (
+        <div
+          key={option.name}
+          onClick={() => setActiveOption(option.type)}
+          className="ChatboxOptionsControls__option"
+          data-dropdown-value={option.name}
+        >
+          <span>{option.name}</span>
+          <FontAwesomeIcon icon={option.icon} />
+        </div>
+      )),
     [setActiveOption]
   );
 
@@ -49,12 +47,13 @@ export const ChatboxOptionsControls: React.FC<ChatboxOptionsControlsProps> = ({
         <TextButton label="Cancel Poll" onClick={unselectOption} />
       ) : (
         <Dropdown
-          title={{ value: "Options", label: "Options" }}
+          title="Options"
           className="ChatboxOptionsControls__dropdown"
-          options={dropdownOptions}
           placement="top"
           noArrow
-        />
+        >
+          {dropdownOptions}
+        </Dropdown>
       )}
     </div>
   );

--- a/src/settings/placeholderSettings.ts
+++ b/src/settings/placeholderSettings.ts
@@ -9,5 +9,5 @@ Object.freeze(ALWAYS_EMPTY_ARRAY);
 export const ALWAYS_NOOP_FUNCTION = () => {};
 Object.freeze(ALWAYS_NOOP_FUNCTION);
 
-export const NO_STYLE_FUNCTION = () => ALWAYS_EMPTY_OBJECT;
-Object.freeze(NO_STYLE_FUNCTION);
+export const ALWAYS_NO_STYLE_FUNCTION = () => ALWAYS_EMPTY_OBJECT;
+Object.freeze(ALWAYS_NO_STYLE_FUNCTION);

--- a/src/settings/placeholderSettings.ts
+++ b/src/settings/placeholderSettings.ts
@@ -11,3 +11,6 @@ Object.freeze(ALWAYS_NOOP_FUNCTION);
 
 export const ALWAYS_NO_STYLE_FUNCTION = () => ALWAYS_EMPTY_OBJECT;
 Object.freeze(ALWAYS_NO_STYLE_FUNCTION);
+
+export const ALWAYS_EMPTY_SELECT_OPTION = { label: "", value: "" };
+Object.freeze(ALWAYS_EMPTY_SELECT_OPTION);

--- a/src/settings/placeholderSettings.ts
+++ b/src/settings/placeholderSettings.ts
@@ -8,3 +8,6 @@ Object.freeze(ALWAYS_EMPTY_ARRAY);
 
 export const ALWAYS_NOOP_FUNCTION = () => {};
 Object.freeze(ALWAYS_NOOP_FUNCTION);
+
+export const NO_STYLE_FUNCTION = () => ALWAYS_EMPTY_OBJECT;
+Object.freeze(NO_STYLE_FUNCTION);


### PR DESCRIPTION
A first update to of `Dropdown` component that removes inline `stlyle`s from the `Select` component and fixes the prefix to not contain double dunder, thus not breaking BEM naming convention.