### PR TITLE
Remove height specification on tables outside jazz bar

### DIFF
--- a/src/components/molecules/TableComponent/TableComponent.tsx
+++ b/src/components/molecules/TableComponent/TableComponent.tsx
@@ -75,7 +75,6 @@ const TableComponent: React.FunctionComponent<TableComponentPropsType> = ({
     isJazzBar
       ? {}
       : {
-          height: `${table.rows && table.rows * 50 + 65}px`,
           width: `${table.columns && (table.columns + 1) * 55}px`,
         }
   );


### PR DESCRIPTION
min-height is already set by the CSS on TableComponent and specifying the
height directly can lead to clipping issues when the component will
resize nicely anyway