### PR TITLE
Show world events on entrance pages

### DIFF
--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -16,10 +16,7 @@ export interface VenueEventsData {
   events: WorldEvent[];
 }
 
-export const useSpaceEvents = ({
-  worldId,
-  spaceIds,
-}: VenueEventsProps): VenueEventsData => {
+export const useWorldEvents = (worldId?: string): VenueEventsData => {
   const firestore = useFirestore();
 
   const eventsRef = firestore
@@ -31,7 +28,26 @@ export const useSpaceEvents = ({
     eventsRef
   );
 
-  if (!spaceIds || !worldId) {
+  if (!worldId) {
+    return {
+      isLoaded: true,
+      events: [],
+    };
+  }
+
+  return {
+    isLoaded: status !== "loading",
+    events: events,
+  };
+};
+
+export const useSpaceEvents = ({
+  worldId,
+  spaceIds,
+}: VenueEventsProps): VenueEventsData => {
+  const { isLoaded, events } = useWorldEvents(worldId);
+
+  if (!spaceIds) {
     return {
       isLoaded: true,
       events: [],
@@ -46,7 +62,7 @@ export const useSpaceEvents = ({
   spaceEvents.sort((a, b) => a.startUtcSeconds - b.startUtcSeconds);
 
   return {
-    isLoaded: status !== "loading",
+    isLoaded,
     events: spaceEvents,
   };
 };

--- a/src/pages/VenueLandingPage/VenueLandingPageContent.tsx
+++ b/src/pages/VenueLandingPage/VenueLandingPageContent.tsx
@@ -22,12 +22,11 @@ import { AnyVenue } from "types/venues";
 
 import { eventEndTime, eventStartTime, hasEventFinished } from "utils/event";
 import { WithId } from "utils/id";
-import { venueEventsSelector } from "utils/selectors";
 import { formatTimeLocalised, getTimeBeforeParty } from "utils/time";
 import { generateAttendeeInsideUrl, generateUrl } from "utils/url";
 
+import { useWorldEvents } from "hooks/events";
 import { useValidImage } from "hooks/useCheckImage";
-import { useSelector } from "hooks/useSelector";
 import { useUser } from "hooks/useUser";
 
 import { RenderMarkdown } from "components/organisms/RenderMarkdown";
@@ -47,7 +46,7 @@ const VenueLandingPageContent: React.FC<VenueLandingPageContentProps> = ({
   world,
   withJoinEvent = true,
 }) => {
-  const venueEvents = useSelector(venueEventsSelector);
+  const { events: venueEvents } = useWorldEvents(world.id);
 
   const spaceSlug = space.slug;
 


### PR DESCRIPTION
This had not been updated after the world event
refactor.

Resolves https://github.com/sparkletown/internal-sparkle-issues/issues/1691