### PR TITLE
fix prettier to the specific version of 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "pixi-virtual-joystick": "^0.4.1",
         "pixi.js": "^5.3.10",
         "popper.js": "^1.16.1",
-        "prettier": "^2.2.1",
+        "prettier": "2.2.1",
         "qs": "^6.10.3",
         "re-resizable": "^6.9.1",
         "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "pixi-virtual-joystick": "^0.4.1",
     "pixi.js": "^5.3.10",
     "popper.js": "^1.16.1",
-    "prettier": "^2.2.1",
+    "prettier": "2.2.1",
     "qs": "^6.10.3",
     "re-resizable": "^6.9.1",
     "react": "^17.0.2",


### PR DESCRIPTION
Just because `Prettier` makes code uglier, even more so if you upgrade the `2.2.1` to `2.2.5`