### PR TITLE
redesign jazzbar and conversation space tables

### DIFF
--- a/src/components/molecules/TableComponent/TableComponent.scss
+++ b/src/components/molecules/TableComponent/TableComponent.scss
@@ -1,0 +1,99 @@
+@use "scss/attendee/mixins.scss"as *;
+@use "scss/attendee/variables.scss"as *;
+
+.TableComponent {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: $whitespace * 2 $whitespace * 3.5 $button-height * 2;
+  flex-wrap: wrap;
+
+  &__delete-button {
+    align-self: flex-start;
+  }
+
+  &__table-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  &__table-users {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__video-well {
+    margin: $whitespace * 0.5 $whitespace * 0.5;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    flex-direction: column;
+    @include sparkle-panel-glass;
+    @include rounded;
+    border: 1px solid $sparkle-border;
+    padding: $whitespace;
+    width: 100%;
+
+    h2 {
+      flex-grow: 1;
+      width: 100%;
+      padding: $whitespace * 0.5 $whitespace;
+
+      span {
+        float: right;
+        opacity: $opacity;
+      }
+    }
+
+    hr {
+      width: 100%;
+      border: none;
+      margin: $whitespace 0 0;
+      flex-grow: 1;
+    }
+  }
+
+  &__user-avatar {
+    @include atom-avatar;
+    margin: $whitespace * 0.5;
+    width: $whitespace * 4;
+    height: $whitespace * 4;
+    border-radius: 100%;
+
+    @media (min-width: 768px) {
+      width: $whitespace * 5;
+      height: $whitespace * 5;
+    }
+  }
+
+  &__join-button {
+    border-radius: 50%;
+    @include sparkle-panel;
+    margin: $whitespace * 0.5;
+    border: 1px solid $sparkle-border;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: $whitespace * 4;
+    height: $whitespace * 4;
+    cursor: pointer;
+
+    @media (min-width: 768px) {
+      width: $whitespace * 5;
+      height: $whitespace * 5;
+    }
+
+    &.hidden {
+      display: none;
+    }
+  }
+
+  &__table {
+    @media (min-width: 768px) {
+      max-width: $whitespace * 33;
+    }
+  }
+}

--- a/src/components/molecules/TableComponent/TableComponent.tsx
+++ b/src/components/molecules/TableComponent/TableComponent.tsx
@@ -5,7 +5,6 @@ import {
   CONVERSATION_TABLES,
   DEFAULT_PARTY_NAME,
   JAZZBAR_TABLES,
-  STRING_PLUS,
   STRING_SPACE,
 } from "settings";
 
@@ -82,7 +81,7 @@ export const TableComponent: React.FunctionComponent<TableComponentPropsType> = 
           <img
             onClick={() => openUserProfileModal(user.id)}
             key={user.id}
-            className="TableComponent__profile-icon"
+            className="TableComponent__user-avatar"
             src={profilePic}
             onError={onLoadError}
             title={user.partyName || DEFAULT_PARTY_NAME}
@@ -96,69 +95,63 @@ export const TableComponent: React.FunctionComponent<TableComponentPropsType> = 
   );
 
   return (
-    <div className="TableComponent">
-      <div>
+    <div className="TableComponent TableComponent__table TableComponent__video-well">
+      <div className="TableComponent__table-header">
+        {isRemoveButtonShown && (
+          <img
+            className="TableComponent__delete-button"
+            src={PortalCloseIcon}
+            alt="remove table"
+            onClick={toggleModal}
+          />
+        )}
         <div className="TableComponent__occupancy-warning">
           {locked && "locked"}
           {!locked && full && "full"}
         </div>
-        <div className="TableComponent__item-wrapper">
-          <span className="TableComponent__title">{table.title}</span>
-
-          {isRemoveButtonShown && (
-            <img
-              className="TableComponent__delete-icon"
-              src={PortalCloseIcon}
-              alt="remove table"
-              onClick={toggleModal}
-            />
-          )}
-        </div>
-        <div className="TableComponent__users">
-          {renderedUserPictures}
-
-          {users &&
-            table.capacity &&
-            table.capacity - users.length >= 0 &&
-            [...Array(table.capacity - users.length)].map((e, i) => (
-              <span
-                key={i}
-                onClick={() => onJoinClicked(table.reference, locked)}
-                id={`join-table-${venue?.name}-${table.reference}`}
-                className="TableComponent__add-user"
-              >
-                {STRING_PLUS}
-              </span>
-            ))}
-        </div>
+        <span className="TableComponent__title">{table.title}</span>
       </div>
-      <Modal show={isModalShown} onHide={hideModal} centered bgVariant="dark">
-        <div className="TableComponent__modal-container">
-          <h2>Delete table</h2>
-          <p>
-            WARNING: This action cannot be undone and will permanently remove
-            {STRING_SPACE}
-            {table.title}
-          </p>
-          <div className="TableComponent__modal-buttons">
-            <ButtonNG
-              variant="secondary"
-              onClick={hideModal}
-              disabled={isDeletingTable}
-            >
-              Cancel
-            </ButtonNG>
+      <div className="TableComponent__table-users">
+        {renderedUserPictures}
 
-            <ButtonNG
-              disabled={isDeletingTable}
-              variant="danger"
-              onClick={removeTable}
-            >
-              Delete
-            </ButtonNG>
+        {users && table.capacity && table.capacity - users.length >= 0 && (
+          <span
+            key={"join-button"}
+            onClick={() => onJoinClicked(table.reference, locked)}
+            id={`join-table-${venue?.name}-${table.reference}`}
+            className="TableComponent__video-well TableComponent__join-button"
+          >
+            Join
+          </span>
+        )}
+        <Modal show={isModalShown} onHide={hideModal} centered bgVariant="dark">
+          <div className="TableComponent__modal-container">
+            <h2>Delete table</h2>
+            <p>
+              WARNING: This action cannot be undone and will permanently remove
+              {STRING_SPACE}
+              {table.title}
+            </p>
+            <div className="TableComponent__modal-buttons">
+              <ButtonNG
+                variant="secondary"
+                onClick={hideModal}
+                disabled={isDeletingTable}
+              >
+                Cancel
+              </ButtonNG>
+
+              <ButtonNG
+                disabled={isDeletingTable}
+                variant="danger"
+                onClick={removeTable}
+              >
+                Delete
+              </ButtonNG>
+            </div>
           </div>
-        </div>
-      </Modal>
+        </Modal>
+      </div>
     </div>
   );
 };

--- a/src/components/molecules/TablesUserList/TablesUserList.scss
+++ b/src/components/molecules/TablesUserList/TablesUserList.scss
@@ -1,0 +1,10 @@
+@use "scss/attendee/mixins.scss"as *;
+@use "scss/attendee/variables.scss"as *;
+
+.TablesUserList {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: $whitespace * 2 $whitespace * 3.5 $button-height * 2;
+  flex-wrap: wrap;
+}

--- a/src/components/molecules/TablesUserList/TablesUserList.tsx
+++ b/src/components/molecules/TablesUserList/TablesUserList.tsx
@@ -208,7 +208,7 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
 
   return (
     <>
-      {renderedTables}
+      <div className="TablesUserList">{renderedTables}</div>
       {allowCreateEditTable && (
         <StartTable
           defaultTables={defaultTables}

--- a/src/components/templates/ConversationSpace/ConversationSpace.tsx
+++ b/src/components/templates/ConversationSpace/ConversationSpace.tsx
@@ -132,20 +132,18 @@ export const ConversationSpace: React.FC<ConversationSpaceProps> = ({
               )}
             </div>
           </div>
-          <div className="seated-area">
-            <TablesUserList
-              setSeatedAtTable={setSeatedAtTable}
-              seatedAtTable={seatedAtTable}
-              venueId={venue.id}
-              TableComponent={TableComponent}
-              joinMessage={venue.hideVideo === false}
-              customTables={tables}
-              defaultTables={CONVERSATION_TABLES}
-              showOnlyAvailableTables={showOnlyAvailableTables}
-              venue={venue}
-              template={VenueTemplate.conversationspace}
-            />
-          </div>
+          <TablesUserList
+            setSeatedAtTable={setSeatedAtTable}
+            seatedAtTable={seatedAtTable}
+            venueId={venue.id}
+            TableComponent={TableComponent}
+            joinMessage={venue.hideVideo === false}
+            customTables={tables}
+            defaultTables={CONVERSATION_TABLES}
+            showOnlyAvailableTables={showOnlyAvailableTables}
+            venue={venue}
+            template={VenueTemplate.conversationspace}
+          />
           <UserList
             usersSample={venue.recentUsersSample ?? ALWAYS_EMPTY_ARRAY}
             userCount={venue.recentUserCount ?? 0}


### PR DESCRIPTION
Redesigns the jazzbar and conversation space tables. The design looks almost identical to the design mock ups and the styles are the same, however the jazzbar layout is missing and the end result might be slight different.

![tables-redesign](https://user-images.githubusercontent.com/18435853/153459974-947a577f-fce0-440a-94d1-334fa9a9a323.jpg)


Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1717