### PR TITLE
Add informative error in `testWorldBySlugExists()` validation

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -21,6 +21,15 @@ export class SparkleHookError extends SparkleError {
   }
 }
 
+export class SparkleFetchError extends SparkleError {
+  readonly args: unknown;
+
+  constructor(options?: { message?: string; args: unknown }) {
+    super("SparkleFetchError", options?.message);
+    this.args = options?.args;
+  }
+}
+
 type AssertUnreachable = (_: never) => void;
 export const assertUnreachable: AssertUnreachable = () => {
   throw new Error("Didn't expect to get here");

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -5,6 +5,8 @@ import { createSlug } from "api/admin";
 
 import { WorldId } from "types/id";
 
+import { SparkleFetchError } from "utils/error";
+
 export const messageMustBeMinimum = (fieldName: string, min: number) =>
   `${fieldName} must be at least ${min} characters`;
 
@@ -30,6 +32,20 @@ export const testVenueByNameExists = async (value: unknown) => {
 export const testWorldBySlugExists = (worldId: WorldId) => async (
   value: unknown
 ) => {
+  // @debt unsure how test logic at the bottom should work for creating new world
+  // but keep this check and throw of error, TS just declares worldId defined, doesn't make it so
+  if (!worldId) {
+    throw new SparkleFetchError({
+      message: `Invalid worldId: ${String(worldId)} for value: ${String(
+        value
+      )}`,
+      args: {
+        worldId,
+        value,
+      },
+    });
+  }
+
   const slug = createSlug(value);
   if (!slug) return false;
 


### PR DESCRIPTION
I don't know the correct test that should be performed ATM, but this addition will at least not put the blame at Firebase due to hard to understand error.