### PR TITLE
remove whitespace-nowrap from WorldCard to display long text properly

### DIFF
--- a/src/components/molecules/WorldCard/WorldCard.tsx
+++ b/src/components/molecules/WorldCard/WorldCard.tsx
@@ -27,7 +27,7 @@ export const WorldCard: React.FC<WorldCardProps> = ({ world }) => {
 
   return (
     <tr>
-      <td className="px-6 py-4 whitespace-nowrap">
+      <td className="px-6 py-4">
         <div className="flex items-center">
           <TableRowAvatar src={world.host?.icon || DEFAULT_VENUE_LOGO} />
           <div className="ml-4">


### PR DESCRIPTION
Removes the `nowrap` style to fix the long world names and descriptions that extend outside of the screen and force the browser to show horizontal scrollbar and hide the `Go to world` button.

**Old:**
![nowordbreak](https://user-images.githubusercontent.com/18435853/157253250-6d6000b6-f2b9-4fdb-913c-0bea88d6d4a8.jpg)

**New:**
![wordbreak](https://user-images.githubusercontent.com/18435853/157253293-792ce3c1-a58c-4be1-a60f-a7e23c46b92f.jpg)

