### PR TITLE
fix table avatars appearing outside of the container

### DIFF
--- a/src/components/attendee/TableComponent/TableComponent.module.scss
+++ b/src/components/attendee/TableComponent/TableComponent.module.scss
@@ -42,6 +42,7 @@
 
 .tableUsers {
   display: flex;
+  flex-wrap: wrap;
   flex-direction: row;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Adds flex-wrap to fix the table avatars in the TableComponent for both jazzbar and conversation space.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1741

### P.S. The join button is in a wrong position because I manually added the rest of the html avatars after it's definition.
![new-table](https://user-images.githubusercontent.com/18435853/157432645-4d0d1bf6-dd67-44b7-b0d0-dd57f27c2187.jpg)

