### PR TITLE
Unclip user reactions

### DIFF
--- a/src/components/attendee/VideoComms/VideoCommsParticipant.tsx
+++ b/src/components/attendee/VideoComms/VideoCommsParticipant.tsx
@@ -58,58 +58,58 @@ export const VideoCommsParticipant: React.FC<VideoCommsParticipantProps> = ({
   const { isMuted, mute, unmute } = useMute();
 
   return (
-    <div className={styles.videoCommsParticipant}>
-      {hasActiveVideoStream &&
-        participant.videoTracks.map((track) => (
-          <div key={track.id} className={styles.trackContainer}>
-            <VideoTrackDisplay
-              key={track.id}
-              track={track}
-              isMirrored={isLocal && track.sourceType === VideoSource.Webcam}
-            />
-            <div className={styles.videoCommsControlsContainer}>
-              {videoTrackControls && videoTrackControls(track)}
+    <div className={styles.container}>
+      <div className={styles.videoCommsParticipant}>
+        {hasActiveVideoStream &&
+          participant.videoTracks.map((track) => (
+            <div key={track.id} className={styles.trackContainer}>
+              <VideoTrackDisplay
+                key={track.id}
+                track={track}
+                isMirrored={isLocal && track.sourceType === VideoSource.Webcam}
+              />
+              <div className={styles.videoCommsControlsContainer}>
+                {videoTrackControls && videoTrackControls(track)}
+              </div>
             </div>
-          </div>
-        ))}
-      {!isLocal &&
-        participant.audioTracks.map((track) => (
-          <AudioTrackPlayer key={track.id} track={track} isMuted={isMuted} />
-        ))}
+          ))}
+        {!isLocal &&
+          participant.audioTracks.map((track) => (
+            <AudioTrackPlayer key={track.id} track={track} isMuted={isMuted} />
+          ))}
 
-      {!isLoading && (
-        <>
+        {!isLoading && (
           <UserAvatar
             containerClassName={styles.avatarContainer}
             user={profile}
           />
-          {userId && (
-            <UserReactions
-              userId={userId}
-              isMuted={isAudioEffectDisabled}
-              reactionPosition={reactionPosition}
+        )}
+        <div className={styles.videoCommsControlsContainer}>
+          {isLocal ? (
+            <VideoCommsControls
+              startAudio={startAudio}
+              stopAudio={stopAudio}
+              startVideo={startVideo}
+              stopVideo={stopVideo}
+              audioEnabled={isTransmittingAudio}
+              videoEnabled={isTransmittingVideo}
+            />
+          ) : (
+            <VideoCommsControls
+              startAudio={unmute}
+              stopAudio={mute}
+              audioEnabled={!isMuted}
             />
           )}
-        </>
-      )}
-      <div className={styles.videoCommsControlsContainer}>
-        {isLocal ? (
-          <VideoCommsControls
-            startAudio={startAudio}
-            stopAudio={stopAudio}
-            startVideo={startVideo}
-            stopVideo={stopVideo}
-            audioEnabled={isTransmittingAudio}
-            videoEnabled={isTransmittingVideo}
-          />
-        ) : (
-          <VideoCommsControls
-            startAudio={unmute}
-            stopAudio={mute}
-            audioEnabled={!isMuted}
-          />
-        )}
+        </div>
       </div>
+      {!isLoading && userId && (
+        <UserReactions
+          userId={userId}
+          isMuted={isAudioEffectDisabled}
+          reactionPosition={reactionPosition}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/attendee/VideoComms/scss/VideoCommsParticipant.module.scss
+++ b/src/components/attendee/VideoComms/scss/VideoCommsParticipant.module.scss
@@ -1,14 +1,17 @@
 @use "scss/constants";
 
-.videoCommsParticipant {
-  display: flex;
-  flex-direction: row;
+.container, .videoCommsParticipant {
   position: relative;
   height: 100%;
   max-width: constants.$video-participant-optimal-width;
   min-width: constants.$video-participant-optimal-width;
   max-height: constants.$video-participant-optimal-height;
   width: 100%;
+}
+
+.videoCommsParticipant {
+  display: flex;
+  flex-direction: row;
   background: #3d3a3f;
   border-radius: constants.$border-radius--xl;
   overflow: hidden;
@@ -18,6 +21,7 @@
   display: flex;
   position: relative;
   width: 100%;
+
   video {
     object-fit: cover;
     width: 100%;
@@ -34,6 +38,7 @@
   color: #f1f1f1;
   background: rgba(0, 0, 0, 0.5);
   border-top-left-radius: 4px;
+
   span {
     margin: 2px 7px;
     cursor: pointer;
@@ -47,6 +52,7 @@
   position: absolute;
   left: 8px;
   bottom: 8px;
+
   img {
     max-width: 64px;
     max-height: 64px;

--- a/src/components/attendee/VideoComms/scss/VideoCommsParticipant.module.scss
+++ b/src/components/attendee/VideoComms/scss/VideoCommsParticipant.module.scss
@@ -1,6 +1,7 @@
 @use "scss/constants";
 
-.container, .videoCommsParticipant {
+.container,
+.videoCommsParticipant {
   position: relative;
   height: 100%;
   max-width: constants.$video-participant-optimal-width;

--- a/src/components/molecules/ReactionsBar/ReactionsBar.tsx
+++ b/src/components/molecules/ReactionsBar/ReactionsBar.tsx
@@ -115,10 +115,10 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     }
   }, [isShoutSent]);
 
-  const isTextTooLogn = errors?.text?.type === "maxLength";
+  const isTextTooLong = errors?.text?.type === "maxLength";
   const inputClasses = classNames({
     text: true,
-    "input-error": isTextTooLogn,
+    "input-error": isTextTooLong,
   });
 
   return (
@@ -162,7 +162,7 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
               type="submit"
               id={`send-shout-out`}
               value={isShoutSent ? "Sent!" : "Send"}
-              disabled={isShoutSent || isTextTooLogn}
+              disabled={isShoutSent || isTextTooLong}
             />
           </form>
         </div>

--- a/src/components/molecules/ReactionsBar/ReactionsBar.tsx
+++ b/src/components/molecules/ReactionsBar/ReactionsBar.tsx
@@ -23,6 +23,9 @@ import { Reaction } from "components/atoms/Reaction";
 
 import "./ReactionsBar.scss";
 
+// @see https://github.com/sparkletown/internal-sparkle-issues/issues/1627
+const MAX_SHOUTOUT_LENGTH = 30;
+
 interface ChatOutDataType {
   text: string;
 }
@@ -82,8 +85,8 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     [reactions, sendReaction]
   );
 
-  const { register, handleSubmit, reset } = useForm<ChatOutDataType>({
-    mode: "onSubmit",
+  const { register, handleSubmit, reset, errors } = useForm<ChatOutDataType>({
+    mode: "onChange",
   });
 
   // @debt This should probably be all rolled up into a single canonical component.
@@ -112,6 +115,12 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
     }
   }, [isShoutSent]);
 
+  const isTextTooLogn = errors?.text?.type === "maxLength";
+  const inputClasses = classNames({
+    text: true,
+    "input-error": isTextTooLogn,
+  });
+
   return (
     <div className="ReactionsBar">
       <div className="ReactionsBar__reactions-container">
@@ -139,9 +148,12 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
           <form onSubmit={handleSubmit(onSubmit)} className="shout-form">
             <input
               name="text"
-              className="text"
+              className={inputClasses}
               placeholder="Shout out to the crowd"
-              ref={register({ required: true })}
+              ref={register({
+                required: true,
+                maxLength: MAX_SHOUTOUT_LENGTH,
+              })}
               disabled={isShoutSent}
               autoComplete="off"
             />
@@ -150,7 +162,7 @@ export const ReactionsBar: React.FC<ReactionsBarProps> = ({
               type="submit"
               id={`send-shout-out`}
               value={isShoutSent ? "Sent!" : "Send"}
-              disabled={isShoutSent}
+              disabled={isShoutSent || isTextTooLogn}
             />
           </form>
         </div>

--- a/src/components/molecules/UserReactions/UserReactions.scss
+++ b/src/components/molecules/UserReactions/UserReactions.scss
@@ -106,7 +106,8 @@ $reactionTimeout: 5s;
   }
 
   25% {
-    transform: scale(1.25) translateX(calc(-1 * #{$shoutBounceTranslateXOffset}));
+    transform: scale(1.25)
+      translateX(calc(-1 * #{$shoutBounceTranslateXOffset}));
   }
 
   40%,

--- a/src/components/molecules/UserReactions/UserReactions.scss
+++ b/src/components/molecules/UserReactions/UserReactions.scss
@@ -62,6 +62,8 @@ $reactionTimeout: 5s;
     color: $content--under;
     font-size: 20px;
     border-radius: 10px;
+
+    word-break: break-all;
   }
 }
 
@@ -104,8 +106,7 @@ $reactionTimeout: 5s;
   }
 
   25% {
-    transform: scale(1.25)
-      translateX(calc(-1 * #{$shoutBounceTranslateXOffset}));
+    transform: scale(1.25) translateX(calc(-1 * #{$shoutBounceTranslateXOffset}));
   }
 
   40%,


### PR DESCRIPTION
Resolves
- https://github.com/sparkletown/internal-sparkle-issues/issues/1627

Break `UserReactions` out of `VideoCommsParticipant` CSS box by adding a container `div` for both and add max characters check on the text input to 30 according to the issue.

![sparkle-long-shoutout-02](https://user-images.githubusercontent.com/79229621/157653873-a607cc5d-7dd0-441d-bbdd-6727f15ea64a.png)
![sparkle-long-shoutout-01](https://user-images.githubusercontent.com/79229621/157653887-c90a9a52-9441-4ab2-9f47-5325f2cc8d60.png)
