### PR TITLE
replace new name for manually created tables

### DIFF
--- a/src/components/molecules/TablesUserList/TablesUserList.tsx
+++ b/src/components/molecules/TablesUserList/TablesUserList.tsx
@@ -213,9 +213,7 @@ export const TablesUserList: React.FC<TablesUserListProps> = ({
       {allowCreateEditTable && (
         <StartTable
           defaultTables={defaultTables}
-          newTable={generateTable({
-            tableNumber: tables.length + 1,
-          })}
+          newTable={generateTable({})}
           venue={venue}
         />
       )}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,5 @@
 import { trim } from "lodash";
+import { v4 as uuid } from "uuid";
 
 export const uppercaseFirstChar = (str: string) => {
   return str.charAt(0).toUpperCase() + str.substring(1);
@@ -16,3 +17,5 @@ export const generateId: (prefix: string, tailLength?: number) => string = (
   prefix,
   tailLength = 6
 ) => `${prefix}-${Date.now()}-${Math.trunc(Math.random() * 10 ** tailLength)}`;
+
+export const generateTableReferenceId = (title: string) => `${title}-${uuid()}`;

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,22 +1,22 @@
-import { uuid } from "uuidv4";
-
 import { DEFAULT_TABLE_COLUMNS, DEFAULT_TABLE_ROWS } from "settings";
 
 import { Table } from "types/Table";
 
-const generateUniqueTableReference = (title: string) => `${title}-${uuid()}`;
+import { generateTableReferenceId } from "./string";
 
 export const generateTable: (props: {
-  tableNumber?: number;
+  tableNumber: number;
   columns?: number;
   rows?: number;
+  generateTableReference?: (title: string) => string;
 }) => Table = ({
   tableNumber,
   columns = DEFAULT_TABLE_COLUMNS,
   rows = DEFAULT_TABLE_ROWS,
+  generateTableReference = generateTableReferenceId,
 }) => {
-  const title = tableNumber ? `Table ${tableNumber}` : "New table";
-  const reference = generateUniqueTableReference(title);
+  const title = `Table ${tableNumber}`;
+  const reference = generateTableReference(title);
 
   const capacity = columns * rows;
 
@@ -42,9 +42,21 @@ export const generateTables: (props: {
   rows?: number;
   columns?: number;
   startFrom?: number;
-}) => Table[] = ({ num, rows, columns, startFrom = 1 }) =>
+  generateTableReference?: (title: string) => string;
+}) => Table[] = ({
+  num,
+  rows,
+  columns,
+  generateTableReference = generateTableReferenceId,
+  startFrom = 1,
+}) =>
   Array.from(Array(num)).map((_, idx) => {
     const tableNumber = startFrom + idx;
 
-    return generateTable({ tableNumber, columns, rows });
+    return generateTable({
+      tableNumber,
+      columns,
+      rows,
+      generateTableReference,
+    });
   });

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -5,7 +5,7 @@ import { Table } from "types/Table";
 import { generateTableReferenceId } from "./string";
 
 export const generateTable: (props: {
-  tableNumber: number;
+  tableNumber?: number;
   columns?: number;
   rows?: number;
   generateTableReference?: (title: string) => string;
@@ -15,7 +15,7 @@ export const generateTable: (props: {
   rows = DEFAULT_TABLE_ROWS,
   generateTableReference = generateTableReferenceId,
 }) => {
-  const title = `Table ${tableNumber}`;
+  const title = tableNumber ? `Table ${tableNumber}` : "New table";
   const reference = generateTableReference(title);
 
   const capacity = columns * rows;

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -4,8 +4,10 @@ import { DEFAULT_TABLE_COLUMNS, DEFAULT_TABLE_ROWS } from "settings";
 
 import { Table } from "types/Table";
 
+const generateUniqueTableReference = (title: string) => `${title}-${uuid()}`;
+
 export const generateTable: (props: {
-  tableNumber: number;
+  tableNumber?: number;
   columns?: number;
   rows?: number;
 }) => Table = ({
@@ -13,8 +15,8 @@ export const generateTable: (props: {
   columns = DEFAULT_TABLE_COLUMNS,
   rows = DEFAULT_TABLE_ROWS,
 }) => {
-  const title = `Table ${tableNumber}`;
-  const reference = `${title}-${uuid()}`;
+  const title = tableNumber ? `Table ${tableNumber}` : 'New table';
+  const reference = generateUniqueTableReference(title);
 
   const capacity = columns * rows;
 

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -15,7 +15,7 @@ export const generateTable: (props: {
   columns = DEFAULT_TABLE_COLUMNS,
   rows = DEFAULT_TABLE_ROWS,
 }) => {
-  const title = tableNumber ? `Table ${tableNumber}` : 'New table';
+  const title = tableNumber ? `Table ${tableNumber}` : "New table";
   const reference = generateUniqueTableReference(title);
 
   const capacity = columns * rows;


### PR DESCRIPTION
Closes:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1687

Spaces with tables with have default table names `table1` to `table10`
Manually created tables will be named `New Table`