### PR TITLE
Show Embeddable space template in the list

### DIFF
--- a/src/settings/spacePortalsSettings.ts
+++ b/src/settings/spacePortalsSettings.ts
@@ -153,7 +153,6 @@ export const SPACE_INFO_MAP: Record<VenueTemplate, SpaceInfoItem> = {
     poster: PosterEmbeddable,
     description: "",
     template: VenueTemplate.embeddable,
-    hidden: true,
   },
   [VenueTemplate.screeningroom]: {
     text: "Screening Room",


### PR DESCRIPTION
closes https://github.com/sparkletown/internal-sparkle-issues/issues/1669

decided to show Embeddable template as it's easier.
Finishing work with ViewingWindow template would require more efforts + migration of the existed ArtPiece and Embeddable spaces. 