### PR TITLE
fix schedule space id filter

### DIFF
--- a/src/components/attendee/IntersectingButton/IntersectingButton.tsx
+++ b/src/components/attendee/IntersectingButton/IntersectingButton.tsx
@@ -34,5 +34,5 @@ export const IntersectingButton: React.FC<IntersectingButtonProps> = ({
     }
   }, [buttonIntersect, updateIntersected, forwardRef]);
 
-  return <Button {...rest} forwardRef={forwardRef} />;
+  return <Button {...rest} forwardRef={forwardRef} onClick={onClick} />;
 };

--- a/src/components/attendee/ScheduleOverlay/ScheduleOverlay.tsx
+++ b/src/components/attendee/ScheduleOverlay/ScheduleOverlay.tsx
@@ -90,7 +90,7 @@ export const ScheduleOverlay: React.FC = () => {
     isEventsLoading,
     sovereignVenue,
   } = useVenueScheduleEvents({ userEventIds });
-
+  console.log(dayDifference, liveAndFutureEvents);
   const allRefs = useRef<RefObject<HTMLButtonElement>[]>(
     range(dayDifference).map(() => React.createRef())
   );
@@ -202,11 +202,12 @@ export const ScheduleOverlay: React.FC = () => {
 
     const currentVenueBookMarkEvents = eventsFilledWithPriority.filter(
       ({ isSaved, spaceId: eventSpaceId }) =>
-        isSaved && eventSpaceId?.toLowerCase() === space?.id
+        isSaved && eventSpaceId?.toLowerCase() === space?.id.toLowerCase()
     );
 
     const currentVenueEvents = eventsFilledWithPriority.filter(
-      ({ spaceId: eventSpaceId }) => eventSpaceId?.toLowerCase() === space?.id
+      ({ spaceId: eventSpaceId }) =>
+        eventSpaceId?.toLowerCase() === space?.id.toLowerCase()
     );
 
     return {

--- a/src/components/attendee/ScheduleOverlay/ScheduleOverlay.tsx
+++ b/src/components/attendee/ScheduleOverlay/ScheduleOverlay.tsx
@@ -90,7 +90,7 @@ export const ScheduleOverlay: React.FC = () => {
     isEventsLoading,
     sovereignVenue,
   } = useVenueScheduleEvents({ userEventIds });
-  console.log(dayDifference, liveAndFutureEvents);
+
   const allRefs = useRef<RefObject<HTMLButtonElement>[]>(
     range(dayDifference).map(() => React.createRef())
   );


### PR DESCRIPTION
Fixes schedule event filtering. Previously it failed to match the events in the correct spaces due to an incorrect filter value comparison, resulting in errors such as empty schedule list or 
<img width="731" alt="image" src="https://user-images.githubusercontent.com/56254806/157882795-213b7318-7f30-47d4-9d5b-208c1ae4b9cf.png">
