### PR TITLE
Fix <Toggle> double click in <PortalStripForm>

### DIFF
--- a/src/components/admin/PortalStripForm.tsx
+++ b/src/components/admin/PortalStripForm.tsx
@@ -29,6 +29,10 @@ import { PortalIcon } from "components/atoms/PortalIcon";
 
 import { TablePanel } from "./TablePanel";
 import { Toggle } from "./Toggle";
+
+const FIELD_ENABLED = "isEnabled";
+const FIELD_CLICKABLE = "isClickable";
+
 interface PortalStripFormProps {
   portal: Room;
   index: number;
@@ -75,13 +79,13 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
   const values = getValues();
 
   const [{ loading, error: submitError }, submit] = useAsyncFn(
-    async (field: string, _) => {
+    async (field: typeof FIELD_ENABLED | typeof FIELD_CLICKABLE) => {
       if (!user) return;
 
       const isEnabled =
-        field === "isEnabled" ? !values.isEnabled : values.isEnabled;
+        field === FIELD_ENABLED ? !values.isEnabled : values.isEnabled;
       const isClickable =
-        field === "isClickable" ? !values.isClickable : values.isClickable;
+        field === FIELD_CLICKABLE ? !values.isClickable : values.isClickable;
 
       const type = convertClickabilityToPortalType(isClickable);
 
@@ -103,7 +107,7 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
   const handleClickable = useCallback(
     (event) => {
       setUpdatingClickable(true);
-      const handler = handleSubmit((data) => submit("isClickable", data));
+      const handler = handleSubmit(() => submit(FIELD_CLICKABLE));
       return handler(event);
     },
     [setUpdatingClickable, handleSubmit, submit]
@@ -112,7 +116,7 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
   const handleEnabled = useCallback(
     (event) => {
       setUpdatingEnabled(true);
-      const handler = handleSubmit((data) => submit("isEnabled", data));
+      const handler = handleSubmit(() => submit(FIELD_ENABLED));
       return handler(event);
     },
     [setUpdatingEnabled, handleSubmit, submit]
@@ -168,8 +172,6 @@ export const PortalStripForm: React.FC<PortalStripFormProps> = ({
         </div>
         <div className="flex items-center -mb-5 flex-row">
           <div className="flex items-center mb-5">
-            {/* @debt For some reason this requires being double clicked.
-               Investigate when first pass is done. */}
             <Toggle
               name="isClickable"
               label={renderedClickableLabel}

--- a/src/components/admin/Toggle/Toggle.tailwind.ts
+++ b/src/components/admin/Toggle/Toggle.tailwind.ts
@@ -1,7 +1,11 @@
-export const checkedButtonClass = "block bg-indigo-600 w-14 h-8 rounded-full";
-export const uncheckedButtonClass = "block bg-gray-200 w-14 h-8 rounded-full";
+// noinspection JSUnusedGlobalSymbols
+export const trueTrack = "block bg-indigo-600 w-14 h-8 rounded-full";
 
-export const checkedLabelClass =
+// noinspection JSUnusedGlobalSymbols
+export const falseTrack = "block bg-gray-200 w-14 h-8 rounded-full";
+
+export const trueThumb =
   "dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition translate-x-full";
-export const uncheckedLabelClass =
+
+export const falseThumb =
   "dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition";

--- a/src/components/admin/Toggle/Toggle.tsx
+++ b/src/components/admin/Toggle/Toggle.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, SyntheticEvent, useCallback } from "react";
 
 import * as TW from "./Toggle.tailwind";
 
 export interface ToggleProps {
   label: ReactNode;
   checked?: boolean;
-  onChange?: (ev: React.FormEvent<HTMLInputElement>) => void;
+  onChange?: React.ReactEventHandler<SyntheticEvent>;
   name?: string;
 }
 
@@ -15,25 +15,20 @@ export const Toggle: React.FC<ToggleProps> = ({
   onChange,
   name,
 }) => {
-  const toggleClassName = checked
-    ? TW.checkedButtonClass
-    : TW.uncheckedButtonClass;
-  const dotClassName = checked ? TW.checkedLabelClass : TW.uncheckedLabelClass;
+  // NOTE: the click handlers needs to be on the label to capture all its children clicks and there must always be a <label>
+  const handleClick = useCallback((event) => onChange?.(event), [onChange]);
+
+  // NOTE: the thumb is a little circle sliding left-right inside a horizontal track
+  const thumbClasses = TW[`${!!checked}Thumb`];
+  const trackClasses = TW[`${!!checked}Track`];
+
   return (
     <div className="flex justify-end w-full">
-      <label
-        htmlFor={`toggle${name}`}
-        className="flex items-center cursor-pointer"
-      >
+      <label className="flex items-center cursor-pointer" onClick={handleClick}>
         <div className="relative">
-          <input
-            type="checkbox"
-            id={`toggle${name}`}
-            onChange={onChange}
-            className="sr-only "
-          />
-          <div className={toggleClassName}></div>
-          <div className={dotClassName}></div>
+          <input className="sr-only " name={name} type="checkbox" />
+          <div className={trackClasses} />
+          <div className={thumbClasses} />
         </div>
         <div className="ml-3 text-gray-700 font-medium">{label}</div>
       </label>


### PR DESCRIPTION
Resolves:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1759

The previous version of the `<Toggle >` component used `register` to handle data. The new version switched the handling to `onChange()` handler on the `<input>` element which doesn't always capture the clicks (without `register` even more so).

This update moves the handler to `onClick()` for the `<label>` component and adds a bit of cleanup and comments to explain the logic behind it.