### PR TITLE
Report error in rare cases secionId is missing

### DIFF
--- a/src/components/templates/Auditorium/components/SeatingBlock/SeatingBlock.tsx
+++ b/src/components/templates/Auditorium/components/SeatingBlock/SeatingBlock.tsx
@@ -1,7 +1,9 @@
+import React from "react";
 import { Route, Switch, useParams, useRouteMatch } from "react-router-dom";
 
 import { AuditoriumVenue } from "types/venues";
 
+import { captureError, SparkleAssertError } from "utils/error";
 import { WithId } from "utils/id";
 
 import { useAllAuditoriumSections } from "hooks/auditorium";
@@ -27,11 +29,20 @@ export const SeatingBlock: React.FC<SeatingBlockProps> = ({ space }) => {
   // same first section. The consistency is important - not the actual order.
   const sortedSections = [...allSections];
   sortedSections.sort(({ id: idA }, { id: idB }) => idA.localeCompare(idB));
-  const sectionId = urlSectionId || sortedSections[0].id;
+  const sectionId = urlSectionId || sortedSections[0]?.id;
+
+  if (!sectionId) {
+    captureError(
+      new SparkleAssertError({
+        message: `Invalid sectionId:${String(sectionId)}`,
+        where: "SeatingBlock",
+      })
+    );
+  }
 
   return (
     <Switch>
-      <Section venue={space} sectionId={sectionId} />
+      {sectionId && <Section venue={space} sectionId={sectionId} />}
       <Route path={`${match.path}`}>
         <AllSectionPreviews venue={space} />
       </Route>

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,32 +1,46 @@
 import { NotifiableError } from "@bugsnag/js";
 import { HttpResponse } from "firebase-admin/lib/utils/api-request";
 
+type SparkleErrorOptions = {
+  message?: string;
+  where?: string;
+};
+
 // NOTE: keep this one private as to only create subclasses for specific uses
 class SparkleError extends Error {
-  constructor(name?: string, message?: string) {
-    super(message);
+  readonly where?: string;
+
+  constructor(name?: string, options?: SparkleErrorOptions) {
+    super(options?.message);
     this.name = name || "SparkleError";
+    this.where = options?.where;
   }
 }
 
 export class SparkleQueryError extends SparkleError {
-  constructor(message?: string) {
-    super("SparkleQueryError", message);
+  constructor(options?: SparkleErrorOptions) {
+    super("SparkleQueryError", options);
   }
 }
 
 export class SparkleHookError extends SparkleError {
-  constructor(message?: string) {
-    super("SparkleHookError", message);
+  constructor(options?: SparkleErrorOptions) {
+    super("SparkleHookError", options);
   }
 }
 
 export class SparkleFetchError extends SparkleError {
   readonly args: unknown;
 
-  constructor(options?: { message?: string; args: unknown }) {
-    super("SparkleFetchError", options?.message);
+  constructor(options?: SparkleErrorOptions & { args: unknown }) {
+    super("SparkleFetchError", options);
     this.args = options?.args;
+  }
+}
+
+export class SparkleAssertError extends SparkleError {
+  constructor(options?: SparkleErrorOptions) {
+    super("SparkleAssertError", options);
   }
 }
 
@@ -70,3 +84,29 @@ export const errorResponse: ErrorResponse = (errorWithResponse) => {
 type ErrorStatus = (errorWithResponse: unknown) => number;
 export const errorStatus: ErrorStatus = (errorWithResponse) =>
   errorResponse(errorWithResponse)?.status ?? 0;
+
+type CaptureError = <T = unknown>(error: T) => T;
+/**
+ * A convenience function to capture errors or promise rejections
+ */
+export const captureError: CaptureError = (error) => {
+  // TODO: add more logic here, distinguish errors by type and extra info in them, write to Bugsnag etc.
+  // NOTE: at least write the error to the console so it is "captured" and not ignored
+  console.warn("Captured", error);
+
+  // just helps with chain-ability, if needed by promises or other function compositions
+  return error;
+};
+
+type CreateErrorCapture = (
+  options: SparkleErrorOptions
+) => (error: unknown) => Error;
+/**
+ * A convenience function to generate error capture function for promise rejections that need extra info
+ */
+export const createErrorCapture: CreateErrorCapture = (
+  options: SparkleErrorOptions
+) => (error: unknown) =>
+  error instanceof Error
+    ? captureError(error)
+    : captureError(new SparkleError("", options));

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -12,17 +12,21 @@ import { SparkleQueryError } from "./error";
 
 type CreatePathError = (path: FirePath) => SparkleQueryError;
 export const createPathError: CreatePathError = (path) =>
-  new SparkleQueryError(`Invalid query path: ${path.map(String).join("/")}`);
+  new SparkleQueryError({
+    message: `Invalid query path: ${path.map(String).join("/")}`,
+    where: "createPathError",
+  });
 
 type CreateConstraintsError = (
   constraints?: FireConstraint[]
 ) => SparkleQueryError;
 export const createConstraintsError: CreateConstraintsError = (constraints) =>
-  new SparkleQueryError(
-    `Invalid query constraints: ${
+  new SparkleQueryError({
+    message: `Invalid query constraints: ${
       constraints ? constraints.map(String).join(" AND ") : constraints
-    }`
-  );
+    }`,
+    where: "createConstraintsError",
+  });
 
 export const dataWithId = <T extends object>(d: QueryDocumentSnapshot<T>) =>
   withId(d.data(), d.id);


### PR DESCRIPTION
Adding an assert error as a type of sparkle error and utilities to capture its info, like the place of it.

This is probably not an isolated issue since types can assume data is there and in certain form, but reading from DB might not produce it as expected. This assertion in `SeatingBlock` component will note it (at least in console for now) and not make the page break.