### PR TITLE
Replaces prototypal flat with lodash flatten

### DIFF
--- a/functions/analytics.js
+++ b/functions/analytics.js
@@ -15,6 +15,7 @@ const { chunk, flatten } = lodash;
 const functionsConfig = functions.config();
 
 const getUsersWithVisits = async (venueIdsArray) => {
+  // @debt see if JS built in .flatMap is good fit for this logic (maybe would require polyfill to be set)
   const dto = flatten(
     await chunk(venueIdsArray, 10)
       .map(async (idsArray) => {


### PR DESCRIPTION
The node version on staging doesn't have .flat() in its prototype.
That's why it worked locally, but didn't work in staging

closes https://github.com/sparkletown/internal-sparkle-issues/issues/1641