### PR TITLE
Fix `Dropdown` having duplicate option keys

### DIFF
--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -107,8 +107,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
         } absolute z-10 w-44 text-base list-none bg-white rounded divide-y divide-gray-100 shadow dark:bg-gray-700`}
       >
         <ul className="py-1">
-          {options.map((option) => (
-            <li key={option.value}>
+          {options.map((option, index) => (
+            <li key={`${index}-${option.value}`}>
               <div
                 className="block py-2 px-4 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 dark:text-gray-200 dark:hover:text-white"
                 onClick={() => selectOption(option)}

--- a/src/hooks/useRelatedVenues.tsx
+++ b/src/hooks/useRelatedVenues.tsx
@@ -8,11 +8,9 @@ import {
 } from "settings";
 
 import {
-  SpaceId,
   SpaceSlug,
   SpaceWithId,
   WorldAndSpaceIdLocation,
-  WorldId,
   WorldIdLocation,
 } from "types/id";
 import { AnyVenue } from "types/venues";
@@ -22,6 +20,7 @@ import { isDefined } from "utils/types";
 import { findSovereignVenue } from "utils/venue";
 
 import { useRefiCollection } from "hooks/fire/useRefiCollection";
+import { useWorldAndSpaceByParams } from "hooks/spaces/useWorldAndSpaceByParams";
 
 export type FindVenueInRelatedVenuesOptions = {
   spaceId?: string;
@@ -222,10 +221,8 @@ const WorldSpacesProvider: React.FC<WorldIdLocation> = ({
   );
 };
 
-export const RelatedVenuesProvider: React.FC<{
-  spaceId?: SpaceId;
-  worldId?: WorldId;
-}> = ({ worldId, spaceId, children }) => {
+export const RelatedVenuesProvider: React.FC = ({ children }) => {
+  const { worldId, spaceId } = useWorldAndSpaceByParams();
   const defaultState: RelatedVenuesContextState = useMemo(
     () => ({
       isLoading: false,
@@ -238,7 +235,6 @@ export const RelatedVenuesProvider: React.FC<{
   );
 
   if (!worldId) {
-    // @debt maybe even provide an error message to user and/or in console and/or to bugsnag
     return (
       <RelatedVenuesContext.Provider value={defaultState}>
         {children}


### PR DESCRIPTION
Mix in the index for `Dropdown` to resolve cases of duplicate values 