### PR TITLE
add edit space admins modal to user dashboard

### DIFF
--- a/functions/src/venue.ts
+++ b/functions/src/venue.ts
@@ -435,9 +435,7 @@ export const addSpaceOwnerBulk = functions.https.onCall(
 
     await throwErrorIfNotWorldOwner({
       worldId: worldId,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      userId: context.auth.token.user_id,
+      userId: context.auth?.token.user_id,
     });
 
     const addRequests = addedSpacesIds.map(async (spaceId: string) => {

--- a/functions/src/venue.ts
+++ b/functions/src/venue.ts
@@ -5,7 +5,10 @@ import { HttpsError } from "firebase-functions/v1/https";
 import { addAdmin, removeAdmin } from "./api/roles";
 import { LandingPageConfig } from "./types/venue";
 import { assertValidAuth } from "./utils/assert";
-import { throwErrorIfNeitherWorldNorSpaceOwner } from "./utils/permissions";
+import {
+  throwErrorIfNeitherWorldNorSpaceOwner,
+  throwErrorIfNotWorldOwner,
+} from "./utils/permissions";
 import { checkIfValidVenueId, getSpaceById } from "./utils/venue";
 import { ROOM_TAXON } from "./taxonomy";
 
@@ -421,6 +424,43 @@ export const setAuditoriumSections = functions.https.onCall(
     }
 
     await batch.commit();
+  }
+);
+
+export const addSpaceOwnerBulk = functions.https.onCall(
+  async (data, context) => {
+    assertValidAuth(context);
+
+    const { addedSpacesIds, removedSpacesIds, newOwnerId, worldId } = data;
+
+    await throwErrorIfNotWorldOwner({
+      worldId: worldId,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      userId: context.auth.token.user_id,
+    });
+
+    const addRequests = addedSpacesIds.map(async (spaceId: string) => {
+      return await admin
+        .firestore()
+        .collection("venues")
+        .doc(spaceId)
+        .update({
+          owners: admin.firestore.FieldValue.arrayUnion(newOwnerId),
+        });
+    });
+
+    const removeRequests = removedSpacesIds.map(async (spaceId: string) => {
+      return await admin
+        .firestore()
+        .collection("venues")
+        .doc(spaceId)
+        .update({
+          owners: admin.firestore.FieldValue.arrayRemove(newOwnerId),
+        });
+    });
+
+    await Promise.all([...addRequests, ...removeRequests]);
   }
 );
 

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -518,6 +518,22 @@ export const removeVenueOwner = async (venueId: string, ownerId: string) =>
     ownerId,
   });
 
+export const addSpaceOwnerBulk = async (
+  addedSpacesIds: string[],
+  removedSpacesIds: string[],
+  newOwnerId: string,
+  worldId: string
+) =>
+  await httpsCallable(
+    FIREBASE.functions,
+    "venue-addSpaceOwnerBulk"
+  )({
+    addedSpacesIds,
+    removedSpacesIds,
+    newOwnerId,
+    worldId,
+  });
+
 export const upsertScreeningRoomVideo = async (
   video: ScreeningRoomVideo,
   spaceId: string,

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -18,7 +18,7 @@ import {
 import { getUserRef } from "api/profile";
 import { findSpaceBySlug } from "api/space";
 
-import { SpaceId, SpaceSlug } from "types/id";
+import { SpaceId, SpaceSlug, UserId, WorldId } from "types/id";
 import { PortalInput, Room, RoomInput } from "types/rooms";
 import { ScreeningRoomVideo } from "types/screeningRoom";
 import { SpaceType } from "types/spaces";
@@ -519,10 +519,10 @@ export const removeVenueOwner = async (venueId: string, ownerId: string) =>
   });
 
 export const addSpaceOwnerBulk = async (
-  addedSpacesIds: string[],
-  removedSpacesIds: string[],
-  newOwnerId: string,
-  worldId: string
+  addedSpacesIds: SpaceId[],
+  removedSpacesIds: SpaceId[],
+  newOwnerId: UserId,
+  worldId: WorldId
 ) =>
   await httpsCallable(
     FIREBASE.functions,

--- a/src/components/admin/EditAdminModal/EditAdminModal.tsx
+++ b/src/components/admin/EditAdminModal/EditAdminModal.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { useAsyncFn } from "react-use";
+
+import { addSpaceOwnerBulk } from "api/admin";
+
+import { SpaceWithId, UserWithId } from "types/id";
+
+import { useWorldAndSpaceByParams } from "hooks/spaces/useWorldAndSpaceByParams";
+
+import { Modal } from "components/molecules/Modal";
+
+import { Button } from "../Button";
+
+interface EditAdminModalProps {
+  show: boolean;
+  user: UserWithId;
+  worldSpaces: SpaceWithId[];
+  onHide: () => void;
+}
+
+export const EditAdminModal: React.FC<EditAdminModalProps> = ({
+  show,
+  user,
+  worldSpaces,
+  onHide,
+}) => {
+  const ownedSpaces = worldSpaces.filter((space) =>
+    space.owners?.includes(user.id)
+  );
+
+  const [selectedSpaces, setSelectedSpaces] = useState<SpaceWithId[]>(
+    ownedSpaces
+  );
+  const [addedSpacesIds, setAddedSpacesIds] = useState<string[]>([]);
+  const [removedSpacesIds, setRemovedSpacesIds] = useState<string[]>([]);
+
+  const { worldId } = useWorldAndSpaceByParams();
+
+  const hasSelectedSpaces = !!selectedSpaces.length;
+
+  const remainingSpaces = worldSpaces.filter(
+    (space) => !selectedSpaces.includes(space)
+  );
+
+  const hasRemainingSpaces = !!remainingSpaces.length;
+
+  const [{ loading: isEditing }, editAdminSpaces] = useAsyncFn(async () => {
+    if (!worldId) {
+      return;
+    }
+
+    await addSpaceOwnerBulk(addedSpacesIds, removedSpacesIds, user.id, worldId);
+    onHide();
+  }, [addedSpacesIds, onHide, removedSpacesIds, user.id, worldId]);
+
+  const addOwner = (space: SpaceWithId) => {
+    setAddedSpacesIds((spaceIds) => [...spaceIds, space.id]);
+    setSelectedSpaces((spaces) => [...spaces, space]);
+  };
+
+  const removeOwner = (space: SpaceWithId) => {
+    setRemovedSpacesIds((spaceIds) => [...spaceIds, space.id]);
+    setSelectedSpaces((spaces) =>
+      spaces.filter((selectedSpaces) => selectedSpaces !== space)
+    );
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} autoHide>
+      <div className="text-xl font-medium text-gray-900">
+        Manage user spaces
+      </div>
+      <div>
+        <div className="text-md font-medium text-gray-900">
+          Available spaces
+        </div>
+        <div className="text-sm text-gray-500">
+          Select spaces to add the user as an owner.
+        </div>
+      </div>
+      <div>
+        {hasRemainingSpaces &&
+          remainingSpaces.map((space) => (
+            <div
+              key={space.id}
+              className="px-2 cursor-pointer select-none inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"
+              onClick={() => addOwner(space)}
+            >
+              {space.name}
+            </div>
+          ))}
+        {!hasRemainingSpaces && (
+          <div className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+            None
+          </div>
+        )}
+      </div>
+      <div>
+        <div className="text-md font-medium text-gray-900">Owned spaces</div>
+        <div className="text-sm text-gray-500">
+          Select spaces to remove the user from the owners.
+        </div>
+      </div>
+      <div>
+        {hasSelectedSpaces &&
+          selectedSpaces.map((space) => (
+            <div
+              key={space.id}
+              className="px-2 cursor-pointer select-none inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"
+              onClick={() => removeOwner(space)}
+            >
+              {space.name}
+            </div>
+          ))}
+        {!hasSelectedSpaces && (
+          <div className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+            None
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-row">
+        <Button variant="secondary" onClick={onHide}>
+          Cancel
+        </Button>
+        <Button disabled={isEditing} variant="danger" onClick={editAdminSpaces}>
+          Edit
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/admin/EditAdminModal/EditAdminModal.tsx
+++ b/src/components/admin/EditAdminModal/EditAdminModal.tsx
@@ -3,7 +3,7 @@ import { useAsyncFn } from "react-use";
 
 import { addSpaceOwnerBulk } from "api/admin";
 
-import { SpaceWithId, UserWithId } from "types/id";
+import { SpaceId, SpaceWithId, UserWithId } from "types/id";
 
 import { useWorldAndSpaceByParams } from "hooks/spaces/useWorldAndSpaceByParams";
 
@@ -31,8 +31,8 @@ export const EditAdminModal: React.FC<EditAdminModalProps> = ({
   const [selectedSpaces, setSelectedSpaces] = useState<SpaceWithId[]>(
     ownedSpaces
   );
-  const [addedSpacesIds, setAddedSpacesIds] = useState<string[]>([]);
-  const [removedSpacesIds, setRemovedSpacesIds] = useState<string[]>([]);
+  const [addedSpacesIds, setAddedSpacesIds] = useState<SpaceId[]>([]);
+  const [removedSpacesIds, setRemovedSpacesIds] = useState<SpaceId[]>([]);
 
   const { worldId } = useWorldAndSpaceByParams();
 

--- a/src/components/admin/EditAdminModal/index.ts
+++ b/src/components/admin/EditAdminModal/index.ts
@@ -1,0 +1,1 @@
+export { EditAdminModal } from "./EditAdminModal";

--- a/src/components/admin/WorldUserCard/WorldUserCard.tsx
+++ b/src/components/admin/WorldUserCard/WorldUserCard.tsx
@@ -11,21 +11,17 @@ import { EditAdminModal } from "../EditAdminModal";
 
 export interface WorldUserCardProps {
   user: UserWithId;
-  spaces: SpaceWithId[];
+  ownedSpaces: SpaceWithId[];
   worldSpaces: SpaceWithId[];
   userId?: UserId;
 }
 
 export const WorldUserCard: React.FC<WorldUserCardProps> = ({
   user,
-  spaces,
+  ownedSpaces,
   userId,
   worldSpaces,
 }) => {
-  const ownedSpaces = spaces.filter((space) =>
-    space.owners?.includes(user.id as string)
-  );
-
   const isMyUserCard = user.id === userId;
 
   const {

--- a/src/components/admin/WorldUserCard/WorldUserCard.tsx
+++ b/src/components/admin/WorldUserCard/WorldUserCard.tsx
@@ -1,18 +1,18 @@
 import { faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { DISABLED_DUE_TO_MISSING_DESIGN } from "settings";
-
 import { SpaceWithId, UserId, UserWithId } from "types/id";
 
 import { useShowHide } from "hooks/useShowHide";
 
 import { Button } from "../Button";
 import { DeleteAdminModal } from "../DeleteAdminModal";
+import { EditAdminModal } from "../EditAdminModal";
 
 export interface WorldUserCardProps {
   user: UserWithId;
   spaces: SpaceWithId[];
+  worldSpaces: SpaceWithId[];
   userId?: UserId;
 }
 
@@ -20,6 +20,7 @@ export const WorldUserCard: React.FC<WorldUserCardProps> = ({
   user,
   spaces,
   userId,
+  worldSpaces,
 }) => {
   const ownedSpaces = spaces.filter((space) =>
     space.owners?.includes(user.id as string)
@@ -33,7 +34,11 @@ export const WorldUserCard: React.FC<WorldUserCardProps> = ({
     hide: hideDeleteAdminModal,
   } = useShowHide();
 
-  const { show: showEditAdminModal } = useShowHide();
+  const {
+    isShown: isShownEditAdminModal,
+    show: showEditAdminModal,
+    hide: hideEditAdminModal,
+  } = useShowHide();
 
   const showDeleteModal = () => {
     if (isMyUserCard) {
@@ -72,18 +77,15 @@ export const WorldUserCard: React.FC<WorldUserCardProps> = ({
       </div>
       <div className="flex flex-row w-full justify-end">
         <div className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium flex justify-end items-center gap-x-5">
-          {!DISABLED_DUE_TO_MISSING_DESIGN && (
-            <Button
-              variant="secondary"
-              borders="none"
-              disabled={isMyUserCard}
-              onClick={showEditAdminModal}
-            >
-              <FontAwesomeIcon icon={faPen} className="px-1" size="lg" />
+          <Button
+            variant="secondary"
+            borders="none"
+            onClick={showEditAdminModal}
+          >
+            <FontAwesomeIcon icon={faPen} className="px-1" size="lg" />
 
-              <div>Edit</div>
-            </Button>
-          )}
+            <div>Edit</div>
+          </Button>
         </div>
         <div className="whitespace-nowrap text-right text-sm font-medium flex justify-end items-center gap-x-5">
           <Button
@@ -106,6 +108,14 @@ export const WorldUserCard: React.FC<WorldUserCardProps> = ({
           show={isShownDeleteAdminModal}
           user={user}
           onHide={hideDeleteAdminModal}
+        />
+      )}
+      {isShownEditAdminModal && (
+        <EditAdminModal
+          show={isShownEditAdminModal}
+          user={user}
+          worldSpaces={worldSpaces}
+          onHide={hideEditAdminModal}
         />
       )}
     </div>

--- a/src/hooks/spaces/useWorldSpaces.ts
+++ b/src/hooks/spaces/useWorldSpaces.ts
@@ -1,28 +1,26 @@
 import { useFirestore, useFirestoreCollectionData } from "reactfire";
 import { collection, query, where } from "firebase/firestore";
 
-import { ALWAYS_EMPTY_ARRAY, COLLECTION_SPACES } from "settings";
+import { COLLECTION_SPACES, FIELD_WORLD_ID } from "settings";
 
 import { SpaceId, SpaceWithId, SpaceWithoutId, WorldId } from "types/id";
 
 import { withIdConverter } from "utils/converters";
 
 type UseWorldSpaces = (options: {
-  worldId: WorldId;
+  worldId: WorldId | undefined;
 }) => { spaces: SpaceWithId[] };
 
 export const useWorldSpaces: UseWorldSpaces = ({ worldId }) => {
   const firestore = useFirestore();
+
   const worldSpacesRef = query(
     collection(firestore, COLLECTION_SPACES),
-    where("worldId", "==", worldId)
+    where(FIELD_WORLD_ID, "==", worldId ?? "")
   ).withConverter(withIdConverter<SpaceWithoutId, SpaceId>());
 
   const { data: worldSpaces } = useFirestoreCollectionData<SpaceWithId>(
-    worldSpacesRef,
-    {
-      initialData: ALWAYS_EMPTY_ARRAY,
-    }
+    worldSpacesRef
   );
 
   return { spaces: worldSpaces };

--- a/src/pages/Admin/WorldUsers/WorldUsers.tsx
+++ b/src/pages/Admin/WorldUsers/WorldUsers.tsx
@@ -9,9 +9,9 @@ import { InviteAdminModal } from "components/admin/InviteAdminModal";
 import { WorldUserCard } from "components/admin/WorldUserCard";
 import { AdminLayout } from "components/layouts/AdminLayout";
 import { WithPermission } from "components/shared/WithPermission";
-import { includes } from "lodash";
+import { includes, sortBy } from "lodash";
 
-import { UserId, WorldId } from "types/id";
+import { UserId } from "types/id";
 
 import { useWorldAndSpaceByParams } from "hooks/spaces/useWorldAndSpaceByParams";
 import { useWorldSpaces } from "hooks/spaces/useWorldSpaces";
@@ -55,9 +55,7 @@ export const WorldUsers: React.FC = () => {
 
   const owners = world?.owners;
 
-  const { spaces: worldSpaces } = useWorldSpaces({
-    worldId: worldId ?? ("" as WorldId),
-  });
+  const { spaces: worldSpaces } = useWorldSpaces({ worldId });
 
   const users = useProfileByIds({ userIds: owners as UserId[] });
 
@@ -65,7 +63,10 @@ export const WorldUsers: React.FC = () => {
     user.partyName?.toLowerCase().includes(nameSearchQuery.toLowerCase())
   );
 
-  const userSpaces = filteredUsers?.map((user) => {
+  // Alphabetical sort by field (partyName), first uppercase then lowercase.
+  const sortedUsers = sortBy(filteredUsers, ["partyName"]);
+
+  const userSpaces = sortedUsers?.map((user) => {
     return {
       user: user,
       spaces: worldSpaces.filter((space) =>
@@ -130,7 +131,7 @@ export const WorldUsers: React.FC = () => {
                     key={userSpace.user.id}
                     userId={userId}
                     user={userSpace.user}
-                    spaces={userSpace.spaces}
+                    ownedSpaces={userSpace.spaces}
                     worldSpaces={worldSpaces}
                   />
                 ))}

--- a/src/pages/Admin/WorldUsers/WorldUsers.tsx
+++ b/src/pages/Admin/WorldUsers/WorldUsers.tsx
@@ -55,7 +55,9 @@ export const WorldUsers: React.FC = () => {
 
   const owners = world?.owners;
 
-  const { spaces } = useWorldSpaces({ worldId: worldId ?? ("" as WorldId) });
+  const { spaces: worldSpaces } = useWorldSpaces({
+    worldId: worldId ?? ("" as WorldId),
+  });
 
   const users = useProfileByIds({ userIds: owners as UserId[] });
 
@@ -66,7 +68,7 @@ export const WorldUsers: React.FC = () => {
   const userSpaces = filteredUsers?.map((user) => {
     return {
       user: user,
-      spaces: spaces.filter((space) =>
+      spaces: worldSpaces.filter((space) =>
         space.owners?.includes(user.id as string)
       ),
     };
@@ -129,6 +131,7 @@ export const WorldUsers: React.FC = () => {
                     userId={userId}
                     user={userSpace.user}
                     spaces={userSpace.spaces}
+                    worldSpaces={worldSpaces}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Introduces edit space admins modal to the user dashboard. Allows the world admins to also edit space owners inside of that world.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1703