### PR TITLE
add useMemo to fix infinite request loop in various hooks

### DIFF
--- a/src/components/shared/WithPermission.tsx
+++ b/src/components/shared/WithPermission.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 
 import { useWorldAndSpaceByParams } from "hooks/spaces/useWorldAndSpaceByParams";
-import { usePermission } from "hooks/user/usePermission";
+import { useLivePermission } from "hooks/user/useLivePermission";
 import { useUserId } from "hooks/user/useUserId";
 
 type AdminRestrictedProps = {
@@ -27,7 +27,7 @@ export const WithPermission: React.FC<AdminRestrictedProps> = ({
     isWorldOwner,
     isSpaceOwner,
     isLoading: isLoadingRole,
-  } = usePermission({ userId, worldId, spaceId });
+  } = useLivePermission({ userId, worldId, spaceId });
 
   if (isLoadingUserId || isLoadingRole || isLoadingIds) {
     return <>{loading}</>;

--- a/src/hooks/fire/useLiveCollection.ts
+++ b/src/hooks/fire/useLiveCollection.ts
@@ -35,7 +35,7 @@ export const useLiveCollection = <T extends object, ID extends string = string>(
     hasDeferred,
     constraints,
     filteredConstraints,
-  } = parseCollectionQueryOptions(options);
+  } = useMemo(() => parseCollectionQueryOptions(options), [options]);
 
   // construction of the query is where the Firestore SDK may break if invalid values are given
   const memoizedQuery = useMemo(

--- a/src/hooks/spaces/useSpacesByOwner.tsx
+++ b/src/hooks/spaces/useSpacesByOwner.tsx
@@ -3,10 +3,10 @@ import { where } from "firebase/firestore";
 
 import {
   ALWAYS_EMPTY_ARRAY,
-  COLLECTION_SPACES,
   DEFERRED,
   FIELD_OWNERS,
   FIELD_WORLD_ID,
+  PATH,
 } from "settings";
 
 import { LoadStatus } from "types/fire";
@@ -22,8 +22,6 @@ type UseSpacesByOwner = (options: {
 };
 
 export const useSpacesByOwner: UseSpacesByOwner = ({ worldId, userId }) => {
-  const path = useMemo(() => [COLLECTION_SPACES], []);
-
   const constraints = useMemo(
     () =>
       worldId && userId
@@ -35,7 +33,11 @@ export const useSpacesByOwner: UseSpacesByOwner = ({ worldId, userId }) => {
     [worldId, userId]
   );
 
-  const result = useLiveCollection<SpaceWithId>({ path, constraints });
+  const options = useMemo(() => ({ path: PATH.spaces, constraints }), [
+    constraints,
+  ]);
+
+  const result = useLiveCollection<SpaceWithId>(options);
 
   return useMemo(
     () => ({

--- a/src/hooks/user/useLivePermission.ts
+++ b/src/hooks/user/useLivePermission.ts
@@ -17,7 +17,7 @@ type UsePermissionOptions = {
   worldId?: WorldId;
   spaceId?: SpaceId;
 };
-export const usePermission = (options: UsePermissionOptions) => {
+export const useLivePermission = (options: UsePermissionOptions) => {
   const {
     data: role,
     error: roleError,

--- a/src/hooks/worlds/useWorldsByOwner.ts
+++ b/src/hooks/worlds/useWorldsByOwner.ts
@@ -30,10 +30,17 @@ export const useWorldsByOwner: UseWorldsByOwner = ({ userId }) => {
     [userId]
   );
 
-  const { error, isLoading, isLoaded, data } = useLiveCollection<WorldWithId>({
-    path: PATH.worlds,
-    constraints,
-  });
+  const options = useMemo(
+    () => ({
+      path: PATH.worlds,
+      constraints,
+    }),
+    [constraints]
+  );
+
+  const { error, isLoading, isLoaded, data } = useLiveCollection<WorldWithId>(
+    options
+  );
 
   return useMemo(
     () => ({


### PR DESCRIPTION
The problem was in the `{}` syntax that was passed to `useLiveCollection`. It was creating a new object reference on each re-render and forcing the `useLiveCollection` hook to retrigger. Also the `parseCollectionQueryOptions` was creating a new reference as well, and forcing the `useEffect` to retrigger and subscribe/unsubscribe.