### PR TITLE
Fix make world owner script ts node path

### DIFF
--- a/scripts/make-owner-all-world-spaces.ts
+++ b/scripts/make-owner-all-world-spaces.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env node -r esm -r ts-node/register
 
 import {
   checkFileExists,


### PR DESCRIPTION
Fixes following error when trying to run the `make-owner-all-world-spaces.ts` script

<img width="642" alt="image" src="https://user-images.githubusercontent.com/56254806/161754128-7cbb53a3-f7ab-40ed-a06f-dfabd852f641.png">
