### PR TITLE
create useLiveSpace for live updates of the banner

### DIFF
--- a/src/components/attendee/AttendeeLayout/AttendeeLayout.tsx
+++ b/src/components/attendee/AttendeeLayout/AttendeeLayout.tsx
@@ -78,9 +78,9 @@ export const AttendeeLayout: React.FC<AttendeeLayoutProps> = ({ space }) => {
         <AttendeeFooter forwardRef={footerRef} />
         {/* Used by popovers to ensure z-index is handled properly */}
         <div id={POPOVER_CONTAINER_ID} className={styles.popoverContainer} />
-        {banner && (
+        {space.id && (
           <Banner
-            banner={banner}
+            spaceId={space.id}
             turnOnBlur={turnOnBlur}
             turnOffBlur={turnOffBlur}
           />

--- a/src/components/attendee/Banner/Banner.tsx
+++ b/src/components/attendee/Banner/Banner.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Button } from "components/attendee/Button";
 
 import { Banner as TBanner } from "types/banner";
+import { SpaceId } from "types/id";
 
 import { openUrl } from "utils/url";
 
+import { useLiveBanner } from "hooks/spaces/useLiveBanner";
 import { useShowHide } from "hooks/useShowHide";
 
 import { RenderMarkdown } from "components/organisms/RenderMarkdown";
@@ -13,21 +15,41 @@ import { RenderMarkdown } from "components/organisms/RenderMarkdown";
 import CN from "./Banner.module.scss";
 
 export type BannerProps = {
-  banner: TBanner;
+  spaceId: SpaceId;
   turnOnBlur: () => void;
   turnOffBlur: () => void;
 };
 
 export const Banner: React.FC<BannerProps> = ({
-  banner,
+  spaceId,
   turnOnBlur,
   turnOffBlur,
 }) => {
-  const { isShown: isBannerShown, hide: closeBanner } = useShowHide(true);
+  const {
+    isShown: isBannerShown,
+    hide: closeBanner,
+    show: showBanner,
+  } = useShowHide(true);
 
-  const isBannerFullScreen = banner.isFullScreen;
+  const [bannerState, setBannerState] = useState<TBanner>();
+
+  const space = useLiveBanner(spaceId);
+
+  const banner = space?.banner;
+
+  const isBannerFullScreen = banner?.isFullScreen;
   const isWithButton = banner?.buttonDisplayText && banner?.isActionButton;
   const isBannerCloaseable = !banner?.isForceFunnel;
+
+  useEffect(() => {
+    setBannerState(banner);
+  }, [banner]);
+
+  useEffect(() => {
+    if (bannerState !== banner) {
+      showBanner();
+    }
+  }, [banner, bannerState, showBanner]);
 
   useEffect(() => {
     if (!isBannerFullScreen) return;
@@ -45,10 +67,10 @@ export const Banner: React.FC<BannerProps> = ({
   }, [turnOffBlur, closeBanner]);
 
   const navigateToBannerDestination = useCallback(() => {
-    if (!banner.buttonUrl) return;
+    if (!banner?.buttonUrl) return;
 
-    openUrl(banner.buttonUrl, { customOpenRelativeUrl: openUrlUsingRouter });
-  }, [openUrlUsingRouter, banner.buttonUrl]);
+    openUrl(banner?.buttonUrl, { customOpenRelativeUrl: openUrlUsingRouter });
+  }, [openUrlUsingRouter, banner?.buttonUrl]);
 
   if (!isBannerFullScreen || !isBannerShown) return null;
 

--- a/src/components/attendee/Banner/Banner.tsx
+++ b/src/components/attendee/Banner/Banner.tsx
@@ -7,7 +7,7 @@ import { SpaceId } from "types/id";
 
 import { openUrl } from "utils/url";
 
-import { useLiveBanner } from "hooks/spaces/useLiveBanner";
+import { useLiveSpace } from "hooks/spaces/useLiveSpace";
 import { useShowHide } from "hooks/useShowHide";
 
 import { RenderMarkdown } from "components/organisms/RenderMarkdown";
@@ -33,7 +33,7 @@ export const Banner: React.FC<BannerProps> = ({
 
   const [bannerState, setBannerState] = useState<TBanner>();
 
-  const space = useLiveBanner(spaceId);
+  const space = useLiveSpace(spaceId);
 
   const banner = space?.banner;
 

--- a/src/hooks/spaces/useLiveBanner.ts
+++ b/src/hooks/spaces/useLiveBanner.ts
@@ -1,0 +1,13 @@
+import { COLLECTION_SPACES, DEFERRED } from "settings";
+
+import { SpaceId, SpaceWithId } from "types/id";
+
+import { useLiveDocument } from "hooks/fire/useLiveDocument";
+
+export const useLiveBanner = (spaceId: SpaceId) => {
+  const { data } = useLiveDocument<SpaceWithId>(
+    spaceId ? [COLLECTION_SPACES, spaceId] : DEFERRED
+  );
+
+  return data;
+};

--- a/src/hooks/spaces/useLiveSpace.ts
+++ b/src/hooks/spaces/useLiveSpace.ts
@@ -4,10 +4,10 @@ import { SpaceId, SpaceWithId } from "types/id";
 
 import { useLiveDocument } from "hooks/fire/useLiveDocument";
 
-export const useLiveBanner = (spaceId: SpaceId) => {
-  const { data } = useLiveDocument<SpaceWithId>(
+export const useLiveSpace = (spaceId: SpaceId) => {
+  const { data: space } = useLiveDocument<SpaceWithId>(
     spaceId ? [COLLECTION_SPACES, spaceId] : DEFERRED
   );
 
-  return data;
+  return space;
 };


### PR DESCRIPTION
Introduces a new `useLiveSpace` hook that's used for the `Banner.tsx` component and shows the banner dynamically when it's changed in the admin.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1812