### PR TITLE
Some tidy up of code related to UserAvatar

### DIFF
--- a/src/components/atoms/UserAvatar/UserAvatar.tsx
+++ b/src/components/atoms/UserAvatar/UserAvatar.tsx
@@ -51,8 +51,8 @@ const AVATAR_SIZE_MAP: { [key in UserAvatarSize]: number | null } = {
 // @debt the UserProfilePicture component serves a very similar purpose to this, we should unify them as much as possible
 export const _UserAvatar: React.FC<UserAvatarProps> = ({
   user,
-  containerClassName,
-  imageClassName,
+  containerClassName, // @debt remove injected classes in favor of variance props
+  imageClassName, // @debt remove injected classes in favor of variance props
   clickable = true,
   showStatus,
   size,

--- a/src/components/atoms/UserAvatar/UserStatus.tsx
+++ b/src/components/atoms/UserAvatar/UserStatus.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames";
 
 import { useVenueUserStatuses } from "hooks/useVenueUserStatuses";
@@ -10,6 +10,7 @@ interface UserAvatarStatusProps {
   showStatus?: boolean;
   size?: UserAvatarSize;
 }
+
 export const UserAvatarStatus: React.FC<UserAvatarStatusProps> = ({
   user,
   showStatus,

--- a/src/components/attendee/BasicInfo/ProfileModalAvatar/ProfileModalAvatar.module.scss
+++ b/src/components/attendee/BasicInfo/ProfileModalAvatar/ProfileModalAvatar.module.scss
@@ -2,7 +2,6 @@
 @use "scss/attendee/theme";
 @use "scss/attendee/font";
 @use "scss/attendee/border";
-@use "scss/attendee/icon";
 
 $-avatar-size: 84px;
 

--- a/src/components/attendee/BasicInfo/ProfileModalAvatar/ProfileModalAvatar.module.scss
+++ b/src/components/attendee/BasicInfo/ProfileModalAvatar/ProfileModalAvatar.module.scss
@@ -4,9 +4,11 @@
 @use "scss/attendee/border";
 @use "scss/attendee/icon";
 
+$-avatar-size: 84px;
+
 .profileModalAvatar {
-  width: icon.$size--profile-overlay-avatar;
-  height: icon.$size--profile-overlay-avatar;
+  width: $-avatar-size;
+  height: $-avatar-size;
 }
 
 .input {
@@ -14,9 +16,9 @@
 }
 
 .image {
-  width: icon.$size--profile-overlay-avatar;
-  height: icon.$size--profile-overlay-avatar;
-  border-radius: 50%;
+  width: $-avatar-size;
+  height: $-avatar-size;
+  border-radius: border.$radius--mx;
   cursor: pointer;
 }
 

--- a/src/components/attendee/Input/Input.module.scss
+++ b/src/components/attendee/Input/Input.module.scss
@@ -1,7 +1,7 @@
 @use "scss/attendee/space";
 @use "scss/attendee/border";
 @use "scss/attendee/font";
-@use "scss/attendee/icon";
+@use "scss/attendee/layout";
 @use "scss/attendee/theme";
 @use "scss/attendee/effects/error";
 
@@ -43,8 +43,8 @@
 
 .errorIcon {
   background-image: url(/assets/icons/input-error-icon.svg);
-  height: icon.$size--input-error-icon;
-  width: icon.$size--input-error-icon;
+  height: layout.$sz-input-error-icon;
+  width: layout.$sz-input-error-icon;
   // pull icon inside input field
   margin-left: space.empty(-2);
 }

--- a/src/components/attendee/InputSelect/InputSelect.module.scss
+++ b/src/components/attendee/InputSelect/InputSelect.module.scss
@@ -2,7 +2,7 @@
 @use "scss/attendee/space";
 @use "scss/attendee/font";
 @use "scss/attendee/border";
-@use "scss/attendee/icon";
+@use "scss/attendee/layout";
 @use "scss/attendee/effects/error";
 
 .wrapper {
@@ -36,8 +36,9 @@
 
 .errorIcon {
   background-image: url(/assets/icons/input-error-icon.svg);
-  height: icon.$size--input-error-icon;
-  width: icon.$size--input-error-icon;
+
+  height: layout.$sz-input-error-icon;
+  width: layout.$sz-input-error-icon;
   // pull icon inside input field
   margin-left: space.empty(-2);
 }

--- a/src/components/attendee/SpaceInfo/SpaceInfo.module.scss
+++ b/src/components/attendee/SpaceInfo/SpaceInfo.module.scss
@@ -3,7 +3,6 @@
 @use "scss/attendee/space";
 @use "scss/attendee/layout";
 @use "scss/attendee/breakpoint";
-@use "scss/attendee/icon";
 
 $-info-image-size: 188px;
 

--- a/src/components/attendee/SpaceInfo/SpaceInfo.module.scss
+++ b/src/components/attendee/SpaceInfo/SpaceInfo.module.scss
@@ -5,6 +5,8 @@
 @use "scss/attendee/breakpoint";
 @use "scss/attendee/icon";
 
+$-info-image-size: 188px;
+
 .spaceWrapper {
   height: 100%;
   width: 100%;
@@ -20,8 +22,8 @@
 }
 
 .spaceImage {
-  min-width: icon.$size--space-info-image;
-  min-height: icon.$size--space-info-image;
+  min-width: $-info-image-size;
+  min-height: $-info-image-size;
   background-size: contain;
   background-repeat: no-repeat;
   margin-bottom: space.empty(1);

--- a/src/scss/attendee/icon.scss
+++ b/src/scss/attendee/icon.scss
@@ -1,1 +1,0 @@
-$size--input-error-icon: 18px;

--- a/src/scss/attendee/icon.scss
+++ b/src/scss/attendee/icon.scss
@@ -1,3 +1,1 @@
-$size--space-info-image: 188px;
-$size--profile-overlay-avatar: 84px;
 $size--input-error-icon: 18px;

--- a/src/scss/attendee/layout.scss
+++ b/src/scss/attendee/layout.scss
@@ -15,13 +15,13 @@ $h-mobile-chat-bar: 180px;
 // Button height plus padding
 $h-top-nav: 42px + space.empty(2);
 
-// TODO Only medium has had its size set. The other sizes need configuring
-// which is why they're odd values.
+// NOTE: these values reflect AVATAR_SIZE_MAP from UserAvatar.tsx
+// @debt they shouldn't be used outside their respective component
 $avatar-sizes: (
-  small: 1px,
+  small: 25px,
   medium: 42px,
-  large: 504px,
-  xlarge: 1000px,
+  large: 54px,
+  xlarge: 100px,
 );
 
 // TODO: at the moment we have only one usage of card.

--- a/src/scss/attendee/layout.scss
+++ b/src/scss/attendee/layout.scss
@@ -12,6 +12,8 @@ $h-chat-controls: 42px;
 
 $h-mobile-chat-bar: 180px;
 
+$sz-input-error-icon: 18px;
+
 // Button height plus padding
 $h-top-nav: 42px + space.empty(2);
 

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -16,8 +16,7 @@ export type Position = {
 // @debt remove this, components shouldn't have containerClassName prop, and
 // in a rare need of injecting classes, className?: string is more close to how React deals with it
 /**
- * @deprecated Do not add this to interfaces.
- * Prefer variance props over injected classes
+ * @deprecated Do not add this to interfaces. Prefer variance props over injected classes
  * */
 export type ContainerClassName = { containerClassName?: string };
 

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -15,6 +15,10 @@ export type Position = {
 
 // @debt remove this, components shouldn't have containerClassName prop, and
 // in a rare need of injecting classes, className?: string is more close to how React deals with it
+/**
+ * @deprecated Do not add this to interfaces.
+ * Prefer variance props over injected classes
+ * */
 export type ContainerClassName = { containerClassName?: string };
 
 // NOTE: use the following only in case of forms register type, define another like this one for other workarounds


### PR DESCRIPTION
Tried to resolve:
- https://github.com/sparkletown/internal-sparkle-issues/issues/1806

but couldn't reproduce.

Instead, opted out to do some tidying up in the code of some easy and quick to refactor places like isolating non-shared constants and adding `@debt` comments.

There is still a lot of debt to be repaid by the `UserAvatar` component, especially in terms of removing the injected classes to achieve robustness and uniformity.