### PR TITLE
add consistent loading buttons around the platform

### DIFF
--- a/src/components/admin/Button/Button.tailwind.ts
+++ b/src/components/admin/Button/Button.tailwind.ts
@@ -6,6 +6,8 @@ export const secondary =
   "border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:ring-indigo-500";
 export const danger =
   "border-transparent text-white bg-warning-red focus:ring-indigo-500";
+export const loading =
+  "bg-sparkle-lighter cursor-not-allowed hover:bg-sparkle-lighter disabled:bg-sparkle-lighter";
 
 export const rounded = "h-10 text-center px-3.5 text-sm leading-4 rounded-full";
 export const regular = "rounded-md";

--- a/src/components/admin/Button/Button.tsx
+++ b/src/components/admin/Button/Button.tsx
@@ -28,10 +28,12 @@ export const Button: React.FC<ButtonProps> = ({
     data-bem="Button"
     {...extraParams}
     type={type}
-    className={cn(TW.general, TW[variant], TW[borders])}
+    className={cn(TW.general, TW[variant], TW[borders], {
+      [TW.loading]: loading,
+    })}
     ref={forwardRef}
   >
-    {loading && <Loading />}
+    {loading && <Loading containerClassName="pr-4" />}
     {children}
   </button>
 );

--- a/src/components/admin/Button/Button.tsx
+++ b/src/components/admin/Button/Button.tsx
@@ -33,7 +33,11 @@ export const Button: React.FC<ButtonProps> = ({
     })}
     ref={forwardRef}
   >
-    {loading && <Loading containerClassName="pr-4" />}
+    {loading && (
+      <div className="pr-4">
+        <Loading />
+      </div>
+    )}
     {children}
   </button>
 );

--- a/src/components/admin/DeleteAdminModal/DeleteAdminModal.tsx
+++ b/src/components/admin/DeleteAdminModal/DeleteAdminModal.tsx
@@ -23,18 +23,14 @@ export const DeleteAdminModal: React.FC<DeleteAdminModalProps> = ({
 }) => {
   const { worldId } = useWorldAndSpaceByParams();
 
-  const removeAdminCallback = async () => {
+  const [{ loading: isRemoving }, removeAdmin] = useAsyncFn(async () => {
     if (!worldId) {
       return;
     }
 
     await removeWorldAdmin(worldId, user.id);
     onHide();
-  };
-
-  const [{ loading: isRemoving }, removeAdmin] = useAsyncFn(
-    removeAdminCallback
-  );
+  }, [onHide, user.id, worldId]);
 
   return (
     <Modal show={show} onHide={onHide} autoHide>
@@ -44,8 +40,13 @@ export const DeleteAdminModal: React.FC<DeleteAdminModalProps> = ({
         <Button variant="secondary" onClick={onHide}>
           Cancel
         </Button>
-        <Button disabled={isRemoving} variant="danger" onClick={removeAdmin}>
-          Delete
+        <Button
+          disabled={isRemoving}
+          loading={isRemoving}
+          variant="danger"
+          onClick={removeAdmin}
+        >
+          {isRemoving ? "Deleting..." : "Delete"}
         </Button>
       </div>
     </Modal>

--- a/src/components/admin/EditAdminModal/EditAdminModal.tsx
+++ b/src/components/admin/EditAdminModal/EditAdminModal.tsx
@@ -123,8 +123,13 @@ export const EditAdminModal: React.FC<EditAdminModalProps> = ({
         <Button variant="secondary" onClick={onHide}>
           Cancel
         </Button>
-        <Button disabled={isEditing} variant="danger" onClick={editAdminSpaces}>
-          Edit
+        <Button
+          disabled={isEditing}
+          loading={isEditing}
+          variant="danger"
+          onClick={editAdminSpaces}
+        >
+          {isEditing ? "Editing..." : "Edit"}
         </Button>
       </div>
     </Modal>

--- a/src/components/admin/InviteAdminModal/InviteAdminModal.tsx
+++ b/src/components/admin/InviteAdminModal/InviteAdminModal.tsx
@@ -61,7 +61,7 @@ export const InviteAdminModal: React.FC<InviteAdminModalProps> = ({
 
     await addWorldAdmins(worldId, userIds);
     onHide();
-  });
+  }, [onHide, selectedUsers, worldId]);
 
   const selectUser = (user: User) => {
     setSelectedUsers((selectedUsers) => {
@@ -124,10 +124,11 @@ export const InviteAdminModal: React.FC<InviteAdminModalProps> = ({
         </Button>
         <Button
           disabled={!hasSelectedUsers || isAddingAdmins}
+          loading={isAddingAdmins}
           variant="danger"
           onClick={addNewAdmins}
         >
-          Add
+          {isAddingAdmins ? "Adding..." : "Add"}
         </Button>
       </div>
     </Modal>

--- a/src/components/admin/PortalAddEditForm.tsx
+++ b/src/components/admin/PortalAddEditForm.tsx
@@ -210,6 +210,9 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
     [relatedVenues, portal?.spaceId]
   );
 
+  const createLabel = isLoading ? "Creating..." : "Create";
+  const saveLabel = isLoading ? "Saving..." : "Save";
+
   return (
     <div>
       <form className="bg-white" onSubmit={handleSubmit(addPortal)}>
@@ -297,11 +300,12 @@ export const PortalAddEditForm: React.FC<PortalAddEditFormProps> = ({
           </Button>
           <Button
             variant="primary"
+            loading={isLoading || isDeleting}
             disabled={isLoading || isDeleting}
             title={title}
             type="submit"
           >
-            {portal ? "Save" : "Create"}
+            {portal ? saveLabel : createLabel}
           </Button>
         </div>
       </form>

--- a/src/components/admin/SpaceCreateForm/SpaceCreateForm.tailwind.ts
+++ b/src/components/admin/SpaceCreateForm/SpaceCreateForm.tailwind.ts
@@ -2,4 +2,4 @@ export const saveButton =
   "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-sparkle text-base font-medium text-white disabled:bg-gray-200 disabled:text-gray-50 disabled:shadow-none disabled:cursor-not-allowed hover:bg-sparkle-darker focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm";
 export const cancelButton =
   "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm";
-export const footer = "mt-5 sm:mt-4 sm:flex sm:flex-row-reverse";
+export const footer = "flex mt-5 sm:mt-4 sm:flex sm:flex-row-reverse";

--- a/src/components/admin/SpaceCreateForm/SpaceCreateForm.tsx
+++ b/src/components/admin/SpaceCreateForm/SpaceCreateForm.tsx
@@ -35,7 +35,7 @@ import { PortalList } from "components/molecules/PortalList";
 import { SubmitError } from "components/molecules/SubmitError";
 import { YourUrlDisplay } from "components/molecules/YourUrlDisplay";
 
-import { ButtonNG } from "components/atoms/ButtonNG";
+import { Button } from "../Button";
 
 import * as TW from "./SpaceCreateForm.tailwind";
 
@@ -166,23 +166,21 @@ export const SpaceCreateForm: React.FC<SpaceCreateFormProps> = ({
         <FormErrors errors={errors} omitted={HANDLED_ERRORS} />
         <SubmitError error={submitError} />
         <div className={TW.footer}>
-          <ButtonNG
+          <Button
             type="submit"
             loading={isLoading}
             disabled={isSaveDisabled}
             className={TW.saveButton}
-            title="Save"
           >
-            Save
-          </ButtonNG>
-          <ButtonNG
+            {isLoading ? "Saving..." : "Save"}
+          </Button>
+          <Button
             onClick={navigateToSpaces}
             className={TW.cancelButton}
-            title="Cancel"
-            variant="white"
+            variant="secondary"
           >
             Cancel
-          </ButtonNG>
+          </Button>
         </div>
       </FormCover>
     </form>

--- a/src/components/admin/SpaceEditForm.tsx
+++ b/src/components/admin/SpaceEditForm.tsx
@@ -514,7 +514,7 @@ export const SpaceEditForm: React.FC<SpaceEditFormProps> = ({
             loading={isUpdating}
             disabled={isUpdating}
           >
-            Save changes
+            {isUpdating ? "Saving changes..." : "Save changes"}
           </Button>
         </AdminSidebarButtons>
       </form>

--- a/src/components/admin/WorldAdvancedForm.tsx
+++ b/src/components/admin/WorldAdvancedForm.tsx
@@ -89,7 +89,7 @@ export const WorldAdvancedForm: React.FC<WorldAdvancedFormProps> = ({
   }, [worldId, user, values, reset]);
 
   const isSaveLoading = isSubmitting || isSaving;
-  const isSaveDisabled = !(isDirty || isSaving || isSubmitting);
+  const isSaveDisabled = !isDirty || isSaving || isSubmitting;
 
   const renderedUserStatuses = useMemo(
     () =>
@@ -190,7 +190,7 @@ export const WorldAdvancedForm: React.FC<WorldAdvancedFormProps> = ({
             disabled={isSaveDisabled}
             loading={isSaveLoading}
           >
-            Save
+            {isSaveLoading ? "Saving..." : "Save"}
           </Button>
         </AdminSidebarButtons>
       </form>

--- a/src/components/admin/WorldEntranceForm.tsx
+++ b/src/components/admin/WorldEntranceForm.tsx
@@ -149,7 +149,7 @@ export const WorldEntranceForm: React.FC<WorldEntranceFormProps> = ({
             disabled={isSaveDisabled}
             loading={isSaveLoading}
           >
-            Save
+            {isSaveLoading ? "Saving..." : "Save"}
           </Button>
         </AdminSidebarButtons>
       </form>

--- a/src/components/admin/WorldGeneralForm/WorldGeneralForm.tsx
+++ b/src/components/admin/WorldGeneralForm/WorldGeneralForm.tsx
@@ -219,7 +219,7 @@ export const WorldGeneralForm: React.FC<WorldGeneralFormProps> = ({
             disabled={!isDirty && !isSaving && !isSubmitting}
             loading={isSubmitting || isSaving}
           >
-            Save
+            {isSubmitting || isSaving ? "Saving..." : "Save"}
           </Button>
           <Link to={ADMIN_IA_WORLD_BASE_URL}>
             <Button variant="secondary">Cancel</Button>

--- a/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
+++ b/src/components/organisms/AdminVenueView/components/RunTabView/RunTabView.tsx
@@ -122,8 +122,8 @@ export const RunTabView: React.FC<RunTabViewProps> = ({ space }) => {
             >
               Cancel
             </Button>
-            <Button loading={isUpdating} type="submit">
-              Save
+            <Button disabled={isUpdating} loading={isUpdating} type="submit">
+              {isUpdating ? "Saving..." : "Save"}
             </Button>
           </div>
         </form>

--- a/src/components/organisms/TimingDeleteModal/TimingDeleteModal.tsx
+++ b/src/components/organisms/TimingDeleteModal/TimingDeleteModal.tsx
@@ -27,7 +27,7 @@ export const TimingDeleteModal: React.FC<TimingDeleteModalProps> = ({
   onHide,
   event,
 }) => {
-  const { handleSubmit, formState, reset } = useForm<EventInput>({
+  const { handleSubmit, reset } = useForm<EventInput>({
     mode: "onSubmit",
     reValidateMode: "onChange",
   });
@@ -90,17 +90,20 @@ export const TimingDeleteModal: React.FC<TimingDeleteModalProps> = ({
           <p>Are you sure you wish to delete this event?</p>
         </div>
 
-        <Button onClick={onHide} variant="secondary">
-          Cancel
-        </Button>
+        <div className="flex">
+          <Button onClick={onHide} variant="secondary">
+            Cancel
+          </Button>
 
-        <Button
-          type="submit"
-          variant="primary"
-          disabled={formState.isSubmitting || isDeletingEvent}
-        >
-          Delete
-        </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            loading={isDeletingEvent}
+            disabled={isDeletingEvent}
+          >
+            {isDeletingEvent ? "Deleting..." : "Delete"}
+          </Button>
+        </div>
       </form>
     </Modal>
   );

--- a/src/components/organisms/TimingEventModal/TimingEventModal.tsx
+++ b/src/components/organisms/TimingEventModal/TimingEventModal.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useForm, useFormState } from "react-hook-form";
+import { useAsyncFn } from "react-use";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Button } from "components/admin/Button";
 import { Dropdown } from "components/admin/Dropdown";
@@ -26,8 +27,6 @@ import { useUser } from "hooks/useUser";
 import { LoadingPage } from "components/molecules/LoadingPage";
 import { Modal } from "components/molecules/Modal";
 
-import "./TimingEventModal.scss";
-
 export type TimingEventModalProps = {
   show: boolean;
   onHide: () => void;
@@ -52,13 +51,7 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
 
   const eventSpaceId = event?.spaceId || (venue?.id as SpaceId | undefined);
 
-  const {
-    register,
-    handleSubmit,
-    control,
-    formState,
-    reset,
-  } = useForm<EventInput>({
+  const { register, handleSubmit, control, reset } = useForm<EventInput>({
     mode: "onSubmit",
     reValidateMode: "onChange",
     resolver: yupResolver(eventEditSchema),
@@ -111,7 +104,7 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
     [spacesMap]
   );
 
-  const onUpdateEvent = useCallback(
+  const [{ loading: isLoading }, onUpdateEvent] = useAsyncFn(
     async (data: EventInput) => {
       const start = dayjs(`${data.start_date} ${data.start_time}`);
       const spaceId = eventSpaceId ?? selectedSpace.id ?? "";
@@ -154,6 +147,9 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
   if (isSpacesLoading) {
     return <LoadingPage />;
   }
+
+  const updateLabel = isLoading ? "Updating..." : "Update";
+  const createLabel = isLoading ? "Creating..." : "Create";
 
   return (
     <Modal show={show} onHide={onHide} centered autoHide>
@@ -264,17 +260,18 @@ export const TimingEventModal: React.FC<TimingEventModalProps> = ({
             </div>
           </div>
 
-          <div className="TimingEventModal__container">
+          <div className="flex">
             <Button variant="secondary" onClick={onHide}>
               Cancel
             </Button>
 
             <Button
-              disabled={formState.isSubmitting}
+              disabled={isLoading}
+              loading={isLoading}
               variant="primary"
               type="submit"
             >
-              {event?.id ? "Update" : "Create"}
+              {event?.id ? updateLabel : createLabel}
             </Button>
           </div>
         </form>

--- a/src/pages/Admin/WorldSchedule/WorldSchedule.tsx
+++ b/src/pages/Admin/WorldSchedule/WorldSchedule.tsx
@@ -157,11 +157,18 @@ export const WorldSchedule: React.FC<WorldScheduleProps> = ({ world }) => {
                 </div>
               </section>
 
-              <Button variant="secondary">Cancel</Button>
+              <div className="flex">
+                <Button variant="secondary">Cancel</Button>
 
-              <Button type="submit" disabled={isSaveLoading} variant="primary">
-                {isSaveLoading ? "Saving..." : "Save"}
-              </Button>
+                <Button
+                  type="submit"
+                  disabled={isSaveLoading}
+                  loading={isSaveLoading}
+                  variant="primary"
+                >
+                  {isSaveLoading ? "Saving..." : "Save"}
+                </Button>
+              </div>
             </form>
           </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
       colors: {
         sparkle: "rgb(99, 42, 199)",
         "sparkle-darker": "rgb(84, 35, 169)" /* darker by 15% */,
+        "sparkle-lighter": "rgb(171, 137, 230)" /* lighter by 30% */,
         "warning-red": "rgb(190, 33, 52)",
         "sparkle-gradient-blue": "rgb(0, 246, 213)",
         "sparkle-gradient-purple": "rgb(111, 67, 255)",


### PR DESCRIPTION
Adds the correct loading styles from the mock ups repo and uses that around the platform for consistent UI.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1815