### PR TITLE
remove boothTemplateSpaceId null value from the functions

### DIFF
--- a/functions/src/venue.ts
+++ b/functions/src/venue.ts
@@ -847,10 +847,7 @@ export const updateVenueNG = functions.https.onCall(async (data, context) => {
     updated.maxBooths = data.maxBooths;
   }
 
-  if (
-    typeof data.boothTemplateSpaceId === "string" ||
-    data.boothTemplateSpaceId === null
-  ) {
+  if (typeof data.boothTemplateSpaceId === "string") {
     updated.boothTemplateSpaceId = data.boothTemplateSpaceId;
   }
 

--- a/src/forms/spaceEditSchema.ts
+++ b/src/forms/spaceEditSchema.ts
@@ -48,5 +48,6 @@ export const spaceEditSchema = Yup.object().shape({
         : schema.notRequired()
   ),
   maxBooths: Yup.number().required(),
-  boothTemplateSpaceId: Yup.string().notRequired(),
+  // .nullable() is added for backwards compatibility after 'null' value was wrongly stored in some documents
+  boothTemplateSpaceId: Yup.string().notRequired().nullable(),
 });

--- a/src/forms/spaceEditSchema.ts
+++ b/src/forms/spaceEditSchema.ts
@@ -48,6 +48,5 @@ export const spaceEditSchema = Yup.object().shape({
         : schema.notRequired()
   ),
   maxBooths: Yup.number().required(),
-  // .nullable() is added for backwards compatibility after 'null' value was wrongly stored in some documents
-  boothTemplateSpaceId: Yup.string().notRequired().nullable(),
+  boothTemplateSpaceId: Yup.string().notRequired(),
 });


### PR DESCRIPTION
- Remove unnecessary `null` check from the functions to prevent `null` being stored as a value for a field that's exclusively `string`.
- `.nullable()` has been added to the form for backwards compatibility to ignore the null value for documents that have it already stored in the database.

Fixes: https://github.com/sparkletown/internal-sparkle-issues/issues/1857