### PR TITLE
Snagging of StartTable component

### DIFF
--- a/src/components/molecules/StartTable/StartTable.tsx
+++ b/src/components/molecules/StartTable/StartTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useAsyncFn } from "react-use";
+import { Button } from "components/attendee/Button";
 
 import { updateVenueTable } from "api/table";
 
@@ -7,8 +8,6 @@ import { SpaceWithId } from "types/id";
 import { Table } from "types/Table";
 
 import { Loading } from "components/molecules/Loading";
-
-import { ButtonNG } from "components/atoms/ButtonNG";
 
 import styles from "./StartTable.module.scss";
 
@@ -38,13 +37,13 @@ export const StartTable: React.FC<StartTablePropsType> = ({
   return isUpdatingTables ? (
     <Loading />
   ) : (
-    <ButtonNG
+    <Button
       disabled={isUpdatingTables}
       className={styles.startTableButton}
       onClick={updateTables}
       variant="primary"
     >
       Start a table
-    </ButtonNG>
+    </Button>
   );
 };

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -169,6 +169,7 @@ export const MARKDOWN_PRE_CODE_TAGS = ["pre", "code"];
 export const ALLOWED_EMPTY_TABLES_NUMBER = 4;
 export const DEFAULT_JAZZBAR_TABLES_NUMBER = 12;
 export const DEFAULT_CONVERSATION_SPACE_TABLES_NUMBER = 10;
+export const DEFAULT_TABLE_CAPACITY = 6;
 
 export const JAZZBAR_TABLES: Table[] = generateTables({
   num: DEFAULT_JAZZBAR_TABLES_NUMBER,

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,5 +1,7 @@
 import { v4 as uuid } from "uuid";
 
+import { DEFAULT_TABLE_CAPACITY } from "settings";
+
 import { Table } from "types/Table";
 
 const generateUniqueTableReference = (title: string) => `${title}-${uuid()}`;
@@ -10,8 +12,7 @@ export const generateTable: (props: {
   generateTableReference?: (title: string) => string;
 }) => Table = ({
   tableNumber,
-  capacity,
-
+  capacity = DEFAULT_TABLE_CAPACITY,
   generateTableReference = generateUniqueTableReference,
 }) => {
   const title = `Table ${tableNumber}`;


### PR DESCRIPTION
I believe there's no issue for that. The PR fixes a visual issue of StartTable compoent and fixing table creation, cause it was not possible to join newly added tables.

BEFORE
<img width="897" alt="image" src="https://user-images.githubusercontent.com/63313732/167632792-ef46332c-3221-4be1-baa2-6eaab6d741b0.png">

AFTER
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/63313732/167633020-b13ad3c0-2a78-4a22-862b-28a553daf1fb.png">
