### PR TITLE
Fix create Booth button placement in Safari

### DIFF
--- a/src/components/attendee/BoothGrid/BoothCard.module.scss
+++ b/src/components/attendee/BoothGrid/BoothCard.module.scss
@@ -16,6 +16,7 @@ $booth-height: 255px;
   width: $booth-width;
   height: $booth-height;
   overflow: hidden;
+  position: relative;
 }
 
 .contents {


### PR DESCRIPTION
fixes the position of the create booth button in Safari